### PR TITLE
fix an exception message issue when call FileUtils.getFile()

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -185,7 +185,7 @@ public class FileUtils {
      */
     public static File getFile(final File directory, final String... names) {
         if (directory == null) {
-            throw new NullPointerException("directorydirectory must not be null");
+            throw new NullPointerException("directory must not be null");
         }
         if (names == null) {
             throw new NullPointerException("names must not be null");


### PR DESCRIPTION
A duplicate word "directory" is in the  exception message "directorydirectory must not be null".