### PR TITLE
Infinite circular input stream

### DIFF
--- a/src/main/java/org/apache/commons/io/input/InfiniteCircularInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/InfiniteCircularInputStream.java
@@ -1,0 +1,34 @@
+package org.apache.commons.io.input;
+
+import java.io.InputStream;
+
+/**
+ * 
+ * An {@link InputStream} that infinitely repeats provided bytes.
+ * <p>
+ * Closing a <tt>InfiniteCircularInputStream</tt> has no effect. The methods in
+ * this class can be called after the stream has been closed without
+ * generating an <tt>IOException</tt>. 
+ * 
+ *
+ */
+public class InfiniteCircularInputStream extends InputStream {
+
+	final private byte[] repeatedContent;
+	private int position = -1;
+	
+	/**
+     * Creates a InfiniteCircularStream from the specified array of chars.
+     * @param repeatedContent       Input buffer to be repeated (not copied)
+     */
+	public InfiniteCircularInputStream(byte[] repeatedContent) {
+		this.repeatedContent = repeatedContent;
+	}
+
+	@Override
+	public int read() {
+		position = (position + 1) % repeatedContent.length;
+		return repeatedContent[position] & 0xff; // copied from java.io.ByteArrayInputStream.read()
+	}
+
+}

--- a/src/test/java/org/apache/commons/io/input/InfiniteCircularInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/InfiniteCircularInputStreamTest.java
@@ -1,0 +1,44 @@
+package org.apache.commons.io.input;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class InfiniteCircularInputStreamTest {
+
+	@Test
+	public void should_cycle_bytes() throws IOException {
+		byte[] input    = new byte[]{1,2};
+		byte[] expected = new byte[]{1,2,1,2,1};
+		
+		assertStreamOutput(input, expected);
+	}
+	
+	@Test
+	public void should_handle_whole_range_of_bytes() throws IOException {
+		int size = Byte.MAX_VALUE - Byte.MIN_VALUE + 1;
+		byte[] contentToCycle = new byte[size];
+		byte value = Byte.MIN_VALUE;
+		for (int i = 0; i < contentToCycle.length; i++) {
+			contentToCycle[i] = value++;
+		}
+		
+		byte[] expectedOutput = Arrays.copyOf(contentToCycle, size);
+		
+		assertStreamOutput(contentToCycle, expectedOutput);
+	}
+	
+	private void assertStreamOutput(byte[] toCycle, byte[] expected) throws IOException {
+		byte[] actual = new byte[expected.length];
+
+		InputStream infStream = new InfiniteCircularInputStream(toCycle);
+		int actualReadBytes = infStream.read(actual);
+		
+		Assert.assertArrayEquals(expected, actual);
+		Assert.assertEquals(expected.length, actualReadBytes);
+	}
+	
+}


### PR DESCRIPTION
provide infinite input stream. it's useful for testing e.g. early exit of stream processors
