### PR TITLE
Added a true iterator for traversing the file trees

### DIFF
--- a/src/main/java/org/apache/commons/io/DepthFirstFileIterator.java
+++ b/src/main/java/org/apache/commons/io/DepthFirstFileIterator.java
@@ -28,9 +28,9 @@ public class DepthFirstFileIterator implements Iterator<File> {
      */
     public DepthFirstFileIterator(File root, FileFilter fileFilter){
         this.stack = new Stack<File>();
+        this.fileFilter = fileFilter;
         this.stack.add(root);
         this.next = getNext();
-        this.fileFilter = fileFilter;
     }
 
 

--- a/src/main/java/org/apache/commons/io/DepthFirstFileIterator.java
+++ b/src/main/java/org/apache/commons/io/DepthFirstFileIterator.java
@@ -1,0 +1,92 @@
+package org.apache.commons.io;
+
+import org.apache.commons.io.filefilter.IOFileFilter;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.Stack;
+
+/**
+ * Depth first traversal based file tree iterator that lists all the regular files in
+ * under the given root directory that matches to file fileter.
+ *
+ * @see FileUtils#iterateFilesDepthFirst(File, IOFileFilter)
+ */
+public class DepthFirstFileIterator implements Iterator<File> {
+
+    private final FileFilter fileFilter;
+    private final Stack<File> stack;
+
+    private File next;
+    private int numFiles;
+    private int numDirs;
+
+    /**
+     * @param root the parent directory
+     */
+    public DepthFirstFileIterator(File root, FileFilter fileFilter){
+        this.stack = new Stack<File>();
+        this.stack.add(root);
+        this.next = getNext();
+        this.fileFilter = fileFilter;
+    }
+
+
+    @Override
+    public boolean hasNext() {
+        return next != null;
+    }
+
+    @Override
+    public File next() {
+        try {
+            return next;
+        } finally {
+            next = getNext();
+        }
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("remove not supported");
+    }
+
+    private File getNext(){
+        File[] files;
+        while (!stack.isEmpty()) {
+            File top = stack.pop();
+            if (top == null || !top.exists() || !top.canRead()) {
+                continue;
+            }
+            if (top.isFile()) {
+                numFiles++;
+                return top;
+            } else {
+                files = fileFilter == null ? top.listFiles() : top.listFiles(fileFilter);
+                if (files != null) {
+                    numDirs++;
+                    Collections.addAll(stack, files);
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Gets number of files visited so far
+     * @return number of files seen
+     */
+    public int getNumFiles() {
+        return numFiles;
+    }
+
+    /**
+     * Gets number of directories visited so far
+     * @return number of directories seen
+     */
+    public int getNumDirs() {
+        return numDirs;
+    }
+}

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -621,6 +621,27 @@ public class FileUtils {
     }
 
     /**
+     * Allows iteration over the files in given directory
+     * <p>
+     * All files found are filtered by an IOFileFilter. This method creates a
+     * true iterator, meaning that the file tree will be traversed as and when the
+     * files are consumed from iterator. Note that the implementation uses a stack
+     * and performs Depth first traversal.
+     * <p>
+     * @param directory  the directory to search in
+     * @param fileFilter filter to apply when finding files.
+     * @return an iterator of java.io.File for the matching files
+     * @see org.apache.commons.io.filefilter.FileFilterUtils
+     * @see org.apache.commons.io.filefilter.NameFileFilter
+     * @since 1.2
+     */
+    public static Iterator<File> iterateFilesDepthFirst(
+            final File directory, final IOFileFilter fileFilter) {
+        IOFileFilter filter = setUpEffectiveFileFilter(fileFilter);
+        return new DepthFirstFileIterator(directory, filter);
+    }
+
+    /**
      * Allows iteration over the files in given directory (and optionally
      * its subdirectories).
      * <p>

--- a/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
@@ -1882,6 +1882,52 @@ public class FileUtilsTestCase extends FileBasedTestCase {
     }
 
     @Test
+    public void testIterateFilesDepthFirst() throws IOException {
+        final File srcDir = getTestDirectory();
+        final File subDir = new File(srcDir, "list_test");
+        subDir.mkdir();
+
+        final String[] fileNames = {"a.txt", "b.txt", "c.txt", "d.txt", "e.txt", "f.txt"};
+        final int[] fileSizes = {123, 234, 345, 456, 678, 789};
+
+        for (int i = 0; i < fileNames.length; ++i) {
+            final File theFile = new File(subDir, fileNames[i]);
+            if (!theFile.getParentFile().exists()) {
+                throw new IOException("Cannot create file " + theFile
+                        + " as the parent directory does not exist");
+            }
+            final BufferedOutputStream output =
+                    new BufferedOutputStream(new FileOutputStream(theFile));
+            try {
+                TestUtils.generateTestData(output, (long) fileSizes[i]);
+            } finally {
+                IOUtils.closeQuietly(output);
+            }
+        }
+
+        final Iterator<File> files = FileUtils.iterateFilesDepthFirst(subDir,
+                new WildcardFileFilter("*.*"));
+
+        final Map<String, String> foundFileNames = new HashMap<String, String>();
+
+        while (files.hasNext()) {
+            boolean found = false;
+            final String fileName = files.next().getName();
+
+            for (int j = 0; !found && j < fileNames.length; ++j) {
+                if (fileNames[j].equals(fileName)) {
+                    foundFileNames.put(fileNames[j], fileNames[j]);
+                    found = true;
+                }
+            }
+        }
+
+        assertEquals(foundFileNames.size(), fileNames.length);
+
+        subDir.delete();
+    }
+
+    @Test
     public void testIterateFilesAndDirs() throws IOException {
         final File srcDir = getTestDirectory();
 


### PR DESCRIPTION
## What is the issue with existing iterator ?
1. The existing `iterateFiles()`  is not really an iterator. It uses an in memory list which is problematic when dealing with millions of child files.
2. The existing one blocks till  it traverses the whole tree to build the list. 
## 
## What is good about the new iterator?
1. This one performs depth first traversal on file tree with the help of a stack as and when the files are consumed,. So no in memory list.
2. It doesnt block till it read all the file descriptors. You are good to consume the moment the first file is read
