### PR TITLE
[IO-483] FilenameUtils.getPrefixLength fix for unix files/folders starting with colon

### DIFF
--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -667,6 +667,8 @@ public class FilenameUtils {
                         return 2;
                     }
                     return 3;
+                } else if (ch0 == UNIX_SEPARATOR) {
+                    return 1;
                 }
                 return NOT_FOUND;
 

--- a/src/test/java/org/apache/commons/io/FilenameUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FilenameUtilsTestCase.java
@@ -583,6 +583,10 @@ public class FilenameUtilsTestCase extends FileBasedTestCase {
         assertEquals(9, FilenameUtils.getPrefixLength("//server/a/b/c.txt"));
         assertEquals(-1, FilenameUtils.getPrefixLength("\\\\\\a\\b\\c.txt"));
         assertEquals(-1, FilenameUtils.getPrefixLength("///a/b/c.txt"));
+
+        assertEquals(1, FilenameUtils.getPrefixLength("/:foo"));
+        assertEquals(1, FilenameUtils.getPrefixLength("/:/"));
+        assertEquals(1, FilenameUtils.getPrefixLength("/:::::::.txt"));
     }
 
     @Test


### PR DESCRIPTION
FilenameUtils.getPrefixLength now works correctly for unix files/folder that are in the root folder and start with colons
