### PR TITLE
IO-513 - Added convenience methods for loading resources (original PR: #17)

### DIFF
--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -134,7 +134,7 @@ public class IOUtils {
 
     static {
         // avoid security issues
-        try (final StringBuilderWriter buf = new StringBuilderWriter(4); 
+        try (final StringBuilderWriter buf = new StringBuilderWriter(4);
                 final PrintWriter out = new PrintWriter(buf)) {
             out.println();
             LINE_SEPARATOR = buf.toString();
@@ -1248,6 +1248,127 @@ public class IOUtils {
     public static String toString(final byte[] input, final String encoding) throws IOException {
         return new String(input, Charsets.toCharset(encoding));
     }
+
+    // resources
+    //-----------------------------------------------------------------------
+    /**
+     * Gets the contents of a classpath resource as a String using the
+     * specified character encoding.
+     *
+     * <p>
+     * It is expected the given <code>name</code> to be absolute. The
+     * behavior is not well-defined otherwise.
+     * </p>
+     *
+     * @param name     name of the desired resource
+     * @param encoding the encoding to use, null means platform default
+     * @return the requested String
+     * @throws IOException if an I/O error occurs
+     */
+    public static String resourceToString(final String name, final Charset encoding) throws IOException {
+        return resourceToString(name, encoding, null);
+    }
+
+    /**
+     * Gets the contents of a classpath resource as a String using the
+     * specified character encoding.
+     *
+     * <p>
+     * It is expected the given <code>name</code> to be absolute. The
+     * behavior is not well-defined otherwise.
+     * </p>
+     *
+     * @param name     name of the desired resource
+     * @param encoding the encoding to use, null means platform default
+     * @param classLoader the class loader that the resolution of the resource is delegated to
+     * @return the requested String
+     * @throws IOException if an I/O error occurs
+     */
+    public static String resourceToString(final String name, final Charset encoding, ClassLoader classLoader) throws IOException {
+        final URL resource = resourceToURL(name, classLoader);
+
+        try (InputStream content = (InputStream) resource.getContent()) {
+            return toString(content, encoding);
+        }
+    }
+
+    /**
+     * Gets the contents of a classpath resource as a byte array.
+     *
+     * <p>
+     * It is expected the given <code>name</code> to be absolute. The
+     * behavior is not well-defined otherwise.
+     * </p>
+     *
+     * @param name name of the desired resource
+     * @return the requested byte array
+     * @throws IOException if an I/O error occurs
+     */
+    public static byte[] resourceToByteArray(final String name) throws IOException {
+        return resourceToByteArray(name, null);
+    }
+
+    /**
+     * Gets the contents of a classpath resource as a byte array.
+     *
+     * <p>
+     * It is expected the given <code>name</code> to be absolute. The
+     * behavior is not well-defined otherwise.
+     * </p>
+     *
+     * @param name name of the desired resource
+     * @param classLoader the class loader that the resolution of the resource is delegated to
+     * @return the requested byte array
+     * @throws IOException if an I/O error occurs
+     */
+    public static byte[] resourceToByteArray(final String name, final ClassLoader classLoader) throws IOException {
+        final URL resource = resourceToURL(name, classLoader);
+
+        try (InputStream content = (InputStream) resource.getContent()) {
+            return toByteArray(content);
+        }
+    }
+
+    /**
+     * Gets a URL pointing to the given classpath resource.
+     *
+     * <p>
+     * It is expected the given <code>name</code> to be absolute. The
+     * behavior is not well-defined otherwise.
+     * </p>
+     *
+     * @param name name of the desired resource
+     * @return the requested URL
+     * @throws IOException if an I/O error occurs
+     */
+    public static URL resourceToURL(final String name) throws IOException {
+        return resourceToURL(name, null);
+    }
+
+    /**
+     * Gets a URL pointing to the given classpath resource.
+     *
+     * <p>
+     * It is expected the given <code>name</code> to be absolute. The
+     * behavior is not well-defined otherwise.
+     * </p>
+     *
+     * @param name        name of the desired resource
+     * @param classLoader the class loader that the resolution of the resource is delegated to
+     * @return the requested URL
+     * @throws IOException if an I/O error occurs
+     */
+    public static URL resourceToURL(final String name, final ClassLoader classLoader) throws IOException {
+        final URL resource = (classLoader == null) ? IOUtils.class.getResource(name) : classLoader.getResource(name);
+
+        if (resource == null) {
+            throw new IOException("Resource not found: " + name);
+        }
+
+        return resource;
+    }
+
+
 
     // readLines
     //-----------------------------------------------------------------------

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -1251,6 +1251,7 @@ public class IOUtils {
 
     // resources
     //-----------------------------------------------------------------------
+
     /**
      * Gets the contents of a classpath resource as a String using the
      * specified character encoding.
@@ -1367,8 +1368,6 @@ public class IOUtils {
 
         return resource;
     }
-
-
 
     // readLines
     //-----------------------------------------------------------------------

--- a/src/test/java/org/apache/commons/io/IOUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTestCase.java
@@ -1140,6 +1140,218 @@ public class IOUtilsTestCase extends FileBasedTestCase {
         testToString_URL(null);
     }
 
+    @Test public void testResourceToString_ExistingResourceAtRootPackage() throws Exception {
+        final long fileSize = new File(getClass().getResource("/test-file-utf8.bin").getFile()).length();
+        final String content = IOUtils.resourceToString("/test-file-utf8.bin", StandardCharsets.UTF_8);
+
+        assertNotNull(content);
+        assertEquals(fileSize, content.getBytes().length);
+    }
+
+    @Test public void testResourceToString_ExistingResourceAtRootPackage_WithClassLoader() throws Exception {
+        final long fileSize = new File(getClass().getResource("/test-file-utf8.bin").getFile()).length();
+        final String content = IOUtils.resourceToString(
+                "test-file-utf8.bin",
+                StandardCharsets.UTF_8,
+                ClassLoader.getSystemClassLoader()
+        );
+
+        assertNotNull(content);
+        assertEquals(fileSize, content.getBytes().length);
+    }
+
+    @Test public void testResourceToString_ExistingResourceAtSubPackage() throws Exception {
+        final long fileSize = new File(getClass().getResource("/org/apache/commons/io/FileUtilsTestDataCR.dat").getFile()).length();
+        final String content = IOUtils.resourceToString("/org/apache/commons/io/FileUtilsTestDataCR.dat", StandardCharsets.UTF_8);
+
+        assertNotNull(content);
+        assertEquals(fileSize, content.getBytes().length);
+    }
+
+    @Test public void testResourceToString_ExistingResourceAtSubPackage_WithClassLoader() throws Exception {
+        final long fileSize = new File(getClass().getResource("/org/apache/commons/io/FileUtilsTestDataCR.dat").getFile()).length();
+        final String content = IOUtils.resourceToString(
+                "org/apache/commons/io/FileUtilsTestDataCR.dat",
+                StandardCharsets.UTF_8,
+                ClassLoader.getSystemClassLoader()
+        );
+
+        assertNotNull(content);
+        assertEquals(fileSize, content.getBytes().length);
+    }
+
+    @Test(expected = IOException.class) public void testResourceToString_NonExistingResource() throws Exception {
+        IOUtils.resourceToString("/non-existing-file.bin", StandardCharsets.UTF_8);
+    }
+
+    @Test(expected = IOException.class) public void testResourceToString_NonExistingResource_WithClassLoader() throws Exception {
+        IOUtils.resourceToString("non-existing-file.bin", StandardCharsets.UTF_8, ClassLoader.getSystemClassLoader());
+    }
+
+    @Test public void testResourceToString_NullResource() throws Exception {
+        boolean exceptionOccurred = false;
+
+        try {
+            IOUtils.resourceToString(null, StandardCharsets.UTF_8);
+            fail();
+        } catch (NullPointerException npe) {
+            exceptionOccurred = true;
+            assertNotNull(npe);
+        }
+
+        assertTrue(exceptionOccurred);
+    }
+
+    @Test public void testResourceToString_NullResource_WithClassLoader() throws Exception {
+        boolean exceptionOccurred = false;
+
+        try {
+            IOUtils.resourceToString(null, StandardCharsets.UTF_8, ClassLoader.getSystemClassLoader());
+            fail();
+        } catch (NullPointerException npe) {
+            exceptionOccurred = true;
+            assertNotNull(npe);
+        }
+
+        assertTrue(exceptionOccurred);
+    }
+
+    @Test public void testResourceToString_NullCharset() throws Exception {
+        IOUtils.resourceToString("/test-file-utf8.bin", null);
+    }
+
+    @Test public void testResourceToString_NullCharset_WithClassLoader() throws Exception {
+        IOUtils.resourceToString("test-file-utf8.bin", null, ClassLoader.getSystemClassLoader());
+    }
+
+    @Test public void testResourceToByteArray_ExistingResourceAtRootPackage() throws Exception {
+        final long fileSize = new File(getClass().getResource("/test-file-utf8.bin").getFile()).length();
+        final byte[] bytes = IOUtils.resourceToByteArray("/test-file-utf8.bin");
+        assertNotNull(bytes);
+        assertEquals(fileSize, bytes.length);
+    }
+
+    @Test public void testResourceToByteArray_ExistingResourceAtRootPackage_WithClassLoader() throws Exception {
+        final long fileSize = new File(getClass().getResource("/test-file-utf8.bin").getFile()).length();
+        final byte[] bytes = IOUtils.resourceToByteArray("test-file-utf8.bin", ClassLoader.getSystemClassLoader());
+        assertNotNull(bytes);
+        assertEquals(fileSize, bytes.length);
+    }
+
+    @Test public void testResourceToByteArray_ExistingResourceAtSubPackage() throws Exception {
+        final long fileSize = new File(getClass().getResource("/org/apache/commons/io/FileUtilsTestDataCR.dat").getFile()).length();
+        final byte[] bytes = IOUtils.resourceToByteArray("/org/apache/commons/io/FileUtilsTestDataCR.dat");
+        assertNotNull(bytes);
+        assertEquals(fileSize, bytes.length);
+    }
+
+    @Test public void testResourceToByteArray_ExistingResourceAtSubPackage_WithClassLoader() throws Exception {
+        final long fileSize = new File(getClass().getResource("/org/apache/commons/io/FileUtilsTestDataCR.dat").getFile()).length();
+        final byte[] bytes = IOUtils.resourceToByteArray("org/apache/commons/io/FileUtilsTestDataCR.dat", ClassLoader.getSystemClassLoader());
+        assertNotNull(bytes);
+        assertEquals(fileSize, bytes.length);
+    }
+
+    @Test(expected = IOException.class) public void testResourceToByteArray_NonExistingResource() throws Exception {
+        IOUtils.resourceToByteArray("/non-existing-file.bin");
+    }
+
+    @Test(expected = IOException.class) public void testResourceToByteArray_NonExistingResource_WithClassLoader() throws Exception {
+        IOUtils.resourceToByteArray("non-existing-file.bin", ClassLoader.getSystemClassLoader());
+    }
+
+    @Test public void testResourceToByteArray_Null() throws Exception {
+        boolean exceptionOccurred = false;
+
+        try {
+            IOUtils.resourceToByteArray(null);
+            fail();
+        } catch (NullPointerException npe) {
+            exceptionOccurred = true;
+            assertNotNull(npe);
+        }
+
+        assertTrue(exceptionOccurred);
+    }
+
+    @Test public void testResourceToByteArray_Null_WithClassLoader() throws Exception {
+        boolean exceptionOccurred = false;
+
+        try {
+            IOUtils.resourceToByteArray(null, ClassLoader.getSystemClassLoader());
+            fail();
+        } catch (NullPointerException npe) {
+            exceptionOccurred = true;
+            assertNotNull(npe);
+        }
+
+        assertTrue(exceptionOccurred);
+    }
+
+    @Test public void testResourceToURL_ExistingResourceAtRootPackage() throws Exception {
+        final URL url = IOUtils.resourceToURL("/test-file-utf8.bin");
+        assertNotNull(url);
+        assertTrue(url.getFile().endsWith("/test-file-utf8.bin"));
+    }
+
+    @Test public void testResourceToURL_ExistingResourceAtRootPackage_WithClassLoader() throws Exception {
+        final URL url = IOUtils.resourceToURL("test-file-utf8.bin", ClassLoader.getSystemClassLoader());
+        assertNotNull(url);
+        assertTrue(url.getFile().endsWith("/test-file-utf8.bin"));
+    }
+
+    @Test public void testResourceToURL_ExistingResourceAtSubPackage() throws Exception {
+        final URL url = IOUtils.resourceToURL("/org/apache/commons/io/FileUtilsTestDataCR.dat");
+        assertNotNull(url);
+        assertTrue(url.getFile().endsWith("/org/apache/commons/io/FileUtilsTestDataCR.dat"));
+    }
+
+    @Test public void testResourceToURL_ExistingResourceAtSubPackage_WithClassLoader() throws Exception {
+        final URL url = IOUtils.resourceToURL(
+                "org/apache/commons/io/FileUtilsTestDataCR.dat",
+                ClassLoader.getSystemClassLoader()
+        );
+
+        assertNotNull(url);
+        assertTrue(url.getFile().endsWith("/org/apache/commons/io/FileUtilsTestDataCR.dat"));
+    }
+
+    @Test(expected = IOException.class) public void testResourceToURL_NonExistingResource() throws Exception {
+        IOUtils.resourceToURL("/non-existing-file.bin");
+    }
+
+    @Test(expected = IOException.class) public void testResourceToURL_NonExistingResource_WithClassLoader() throws Exception {
+        IOUtils.resourceToURL("non-existing-file.bin", ClassLoader.getSystemClassLoader());
+    }
+
+    @Test public void testResourceToURL_Null() throws Exception {
+        boolean exceptionOccurred = false;
+
+        try {
+            IOUtils.resourceToURL(null);
+            fail();
+        } catch (NullPointerException npe) {
+            exceptionOccurred = true;
+            assertNotNull(npe);
+        }
+
+        assertTrue(exceptionOccurred);
+    }
+
+    @Test public void testResourceToURL_Null_WithClassLoader() throws Exception {
+        boolean exceptionOccurred = false;
+
+        try {
+            IOUtils.resourceToURL(null, ClassLoader.getSystemClassLoader());
+            fail();
+        } catch (NullPointerException npe) {
+            exceptionOccurred = true;
+            assertNotNull(npe);
+        }
+
+        assertTrue(exceptionOccurred);
+    }
+
     @Test public void testAsBufferedNull() {
         try {
             IOUtils.buffer((InputStream) null);


### PR DESCRIPTION
Added convenience methods for loading resources:

* `resourceToString`
* `resourceToByteArray`
* `resourceToURL`

Original PR: https://github.com/apache/commons-io/pull/17

JIRA Issue: https://issues.apache.org/jira/browse/IO-513