### PR TITLE
[IO-528] fix Tailer.run race condition runaway logging

### DIFF
--- a/src/main/java/org/apache/commons/io/input/Tailer.java
+++ b/src/main/java/org/apache/commons/io/input/Tailer.java
@@ -446,6 +446,7 @@ public class Tailer implements Runnable {
                     } catch (final FileNotFoundException e) {
                         // in this case we continue to use the previous reader and position values
                         listener.fileNotFound();
+                        Thread.sleep(delayMillis);
                     }
                     continue;
                 } else {


### PR DESCRIPTION
`Tailer.run` has a race condition that can have serious effects. 

The `run()` method has two while loops. The first waits till the file exists and the second loop reads lines from the file doing some file rotation checking on the way.  If the file is deleted while the second loop is in progress then the loop goes crazy logging warnings that look like this:

```
Dec 06, 2016 1:02:18 AM com.github.davidmoten.logan.LogFile$1 fileRotated
INFO: file rotated
Dec 06, 2016 1:02:18 AM com.github.davidmoten.logan.LogFile$1 fileNotFound
WARNING: file not found
Dec 06, 2016 1:02:18 AM com.github.davidmoten.logan.LogFile$1 fileRotated
INFO: file rotated
Dec 06, 2016 1:02:18 AM com.github.davidmoten.logan.LogFile$1 fileNotFound
WARNING: file not found
Dec 06, 2016 1:02:18 AM com.github.davidmoten.logan.LogFile$1 fileRotated
INFO: file rotated
Dec 06, 2016 1:02:18 AM com.github.davidmoten.logan.LogFile$1 fileNotFound
WARNING: file not found
Dec 06, 2016 1:02:18 AM com.github.davidmoten.logan.LogFile$1 fileRotated
INFO: file rotated
Dec 06, 2016 1:02:18 AM com.github.davidmoten.logan.LogFile$1 fileNotFound
WARNING: file not found
```

In our case this had serious effects. The file being tailed was deleted by another process and all available disk space was rapidly used up by the logging. This crashed a system.

The fix is to put a sleep after the call to `fileNotFound()`.

I haven't made a unit test because reliably triggering this problem would involve a major refactor of the `run` method to make it testable.