### PR TITLE
Correct error message in IOUtils

### DIFF
--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -825,7 +825,7 @@ public class IOUtils {
         }
 
         if (offset != size) {
-            throw new IOException("Unexpected readed size. current: " + offset + ", excepted: " + size);
+            throw new IOException("Unexpected read size. current: " + offset + ", expected: " + size);
         }
 
         return data;

--- a/src/test/java/org/apache/commons/io/IOUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTestCase.java
@@ -926,10 +926,10 @@ public class IOUtilsTestCase extends FileBasedTestCase {
 
         try (FileInputStream fin = new FileInputStream(m_testFile)) {
             IOUtils.toByteArray(fin, m_testFile.length() + 1);
-            fail("IOException excepted");
+            fail("IOException expected");
         } catch (final IOException exc) {
-            assertTrue("Exception message does not start with \"Unexpected readed size\"",
-                    exc.getMessage().startsWith("Unexpected readed size"));
+            assertTrue("Exception message does not start with \"Unexpected read size\"",
+                    exc.getMessage().startsWith("Unexpected read size"));
         }
 
     }
@@ -938,7 +938,7 @@ public class IOUtilsTestCase extends FileBasedTestCase {
 
         try (FileInputStream fin = new FileInputStream(m_testFile)) {
             IOUtils.toByteArray(fin, (long) Integer.MAX_VALUE + 1);
-            fail("IOException excepted");
+            fail("IOException expected");
         } catch (final IllegalArgumentException exc) {
             assertTrue("Exception message does not start with \"Size cannot be greater than Integer max value\"", exc
                     .getMessage().startsWith("Size cannot be greater than Integer max value"));


### PR DESCRIPTION
This corrects the wording of the error message in IOUtils: There's
no such word as "readed", and the author probably meant "expected"
as opposed to "excepted".