### PR TITLE
FileAlternationMonitor#stop() does not stop the thread

### DIFF
--- a/src/main/java/org/apache/commons/io/monitor/FileAlterationMonitor.java
+++ b/src/main/java/org/apache/commons/io/monitor/FileAlterationMonitor.java
@@ -23,7 +23,7 @@ import java.util.concurrent.ThreadFactory;
 /**
  * A runnable that spawns a monitoring thread triggering any
  * registered {@link FileAlterationObserver} at a specified interval.
- * 
+ *
  * @see FileAlterationObserver
  * @version $Id$
  * @since 2.0
@@ -112,7 +112,7 @@ public final class FileAlterationMonitor implements Runnable {
 
     /**
      * Returns the set of {@link FileAlterationObserver} registered with
-     * this monitor. 
+     * this monitor.
      *
      * @return The set of {@link FileAlterationObserver}
      */
@@ -165,8 +165,8 @@ public final class FileAlterationMonitor implements Runnable {
         running = false;
         try {
             thread.join(stopInterval);
+            thread.interrupt();
         } catch (final InterruptedException e) {
-            Thread.currentThread().interrupt();
         }
         for (final FileAlterationObserver observer : observers) {
             observer.destroy();


### PR DESCRIPTION
The thread if FileAlterationMonitor wasn't stopped by the `stop(int)` method, which forbid application to shutdown unless all `Thread` are exited (if FileAlterationMonitor is part of a DI managed component).

This behavior conflict with the method javadoc `@param stopInterval the amount of time in milliseconds to wait for the thread to finish.`

### Simple example to understand why i changed the code

```java
    Thread t = new Thread(() -> {
        try {
            Thread.sleep(500000);
        } catch (final InterruptedException e) {
        }
    });
    t.start();
    t.join(50);
   // Ok, we reach this point until 500000ms are elapsed, but the thread is still alive.
   //   because Thread#join(int) does not kill the thread. And the thread remains alive.
```

```java
    Thread t = new Thread(() -> {
        try {
            Thread.sleep(500000);
        } catch (final InterruptedException e) {
        }
    });
    t.start();
    t.join(50);
    t.interupt();
   // Thread is exited
```
In this case, we waited the given time BEFORE exiting the `Thread`, as described in the javadoc, and the `Thread` is now finished and killed.