### PR TITLE
FileUtils.readFileToByteArray - optimize reading of files with known size

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1849,7 +1849,9 @@ public class FileUtils {
      */
     public static byte[] readFileToByteArray(final File file) throws IOException {
         try (InputStream in = openInputStream(file)) {
-            return IOUtils.toByteArray(in); // Do NOT use file.length() - see IO-453
+            long fileLength = file.length();
+            // file.length() may return 0 for system-dependent entities, treat 0 as unknown length - see IO-453
+            return fileLength > 0 ? IOUtils.toByteArray(in, fileLength) : IOUtils.toByteArray(in);
         }
     }
 


### PR DESCRIPTION
IO-251 added optimization for reading files with known size as byte arrays,  but it was reverted in IO-453 due to regression, because File.length() method may return 0 for path files denoting system-dependent entities such as devices or pipes

More optimal solution is to treat 0 as unknown size and use IOUtils.toByteArray(input), but if size is known (> 0) use more efficient approach and read content into pre-allocated byte array with exact size by calling IOUtils.toByteArray(input, size).