### PR TITLE
[IO-546] ClosedOutputStream#flush should throw

### DIFF
--- a/src/main/java/org/apache/commons/io/output/ClosedOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ClosedOutputStream.java
@@ -47,4 +47,13 @@ public class ClosedOutputStream extends OutputStream {
         throw new IOException("write(" + b + ") failed: stream is closed");
     }
 
+    /**
+     * Throws an {@link IOException} to indicate that the stream is closed.
+     *
+     * @throws IOException always thrown
+     */
+    @Override
+    public void flush() throws IOException {
+        throw new IOException("flush() failed: stream is closed");
+    }
 }

--- a/src/test/java/org/apache/commons/io/output/ClosedOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/ClosedOutputStreamTest.java
@@ -41,4 +41,18 @@ public class ClosedOutputStreamTest {
         }
     }
 
+    /**
+     * Test the <code>flush()</code> method.
+     * @throws Exception
+     */
+    @Test
+    public void testFlush() throws Exception {
+        try (ClosedOutputStream cos = new ClosedOutputStream()) {
+            cos.flush();
+            fail("flush()");
+        } catch (final IOException e) {
+            // expected
+        }
+    }
+
 }


### PR DESCRIPTION
While debugging an issue involving usage of `CloseShieldOutputStream` I discovered that `ClosedOutputStream#flush` is not overridden and will silently succeed. Not sure how much of a breaking change this might be but I think it makes more sense for `ClosedOutputStream#flush` to throw. This is only really meaningful in contexts where multiple streams are being chained together and some of the streams before `CloseShieldOutputStream` perform buffering, but it would make behavior more consistent for these more complex use-cases.

See [IO-546](https://issues.apache.org/jira/browse/IO-546) where @dekobon has attached an example program.
