### PR TITLE
Add another test for ClassLoaderObjectInputStream::resolveProxyClass

### DIFF
--- a/src/test/java/org/apache/commons/io/input/ClassLoaderObjectInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/ClassLoaderObjectInputStreamTest.java
@@ -20,6 +20,7 @@ import java.io.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 /**
  * Tests the CountingInputStream.
@@ -183,4 +184,24 @@ public class ClassLoaderObjectInputStreamTest {
         clois.close();
     }
 
+    @org.junit.Test
+    public void testResolveProxyClassWithMultipleInterfaces() throws Exception {
+
+        final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        final ObjectOutputStream oos = new ObjectOutputStream(baos);
+        oos.writeObject(Boolean.FALSE);
+        final InputStream bais = new ByteArrayInputStream(baos.toByteArray());
+
+        final ClassLoaderObjectInputStream clois =
+                new ClassLoaderObjectInputStream(getClass().getClassLoader(), bais);
+        final String[] interfaces = new String[]{Comparable.class.getName(),
+                                                 Serializable.class.getName(),
+                                                 Runnable.class.getName()};
+        final Class<?> result = clois.resolveProxyClass(interfaces);
+        assertTrue("Assignable", Comparable.class.isAssignableFrom(result));
+        assertTrue("Assignable", Runnable.class.isAssignableFrom(result));
+        assertTrue("Assignable", Serializable.class.isAssignableFrom(result));
+        assertFalse("Not Assignable", Flushable.class.isAssignableFrom(result));
+        clois.close();
+    }
 }


### PR DESCRIPTION
Currently, `ClassLoaderObjectInputStreamTest::testResolveProxyClass` only tests `ClassLoaderObjectInputStream::resolveProxyClass` with single-element array. This PR adds a new test to check for the case where the `Proxy` class is assignable from multiple interfaces, and that the `Proxy` class is only a proxy for the interfaces that it implements.