### PR TITLE
Add an IfStatement to check the return value of dir.mkdirs().

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -2958,7 +2958,9 @@ public class FileUtils {
             throw new NullPointerException("Destination directory must not be null");
         }
         if (!destDir.exists() && createDestDir) {
-            destDir.mkdirs();
+            if (!destDir.mkdirs()) {
+            	throw new IOException("Can not create temporary directory.");
+            }
         }
         if (!destDir.exists()) {
             throw new FileNotFoundException("Destination directory '" + destDir +


### PR DESCRIPTION
This statement returns a value that is not checked.
The return value should be checked since it can indicate an unusual or unexpected function execution.
The statement returns false if the destination directory could not be successfully created (rather than throwing an Exception).
If you don't check the result, you won't notice if the statement signals an unexpected behavior by returning an atypical return value.
http://findbugs.sourceforge.net/bugDescriptions.html#RV_RETURN_VALUE_IGNORED_BAD_PRACTICE