### PR TITLE
Check the return value of lockFile.delete().

### DIFF
--- a/src/main/java/org/apache/commons/io/output/LockableFileWriter.java
+++ b/src/main/java/org/apache/commons/io/output/LockableFileWriter.java
@@ -288,7 +288,10 @@ public class LockableFileWriter extends Writer {
         try {
             out.close();
         } finally {
-            lockFile.delete();
+            if (!lockFile.delete()) {
+                throw new IOException("Can't delete file, lock " +
+                         lockFile.getPath() + " exists");
+            }
         }
     }
 


### PR DESCRIPTION
This statement returns a value that is not checked.
The return value should be checked since it can indicate an unusual or unexpected function execution.
The statement returns false if the destination file could not be successfully deleted (rather than throwing an Exception).
If you don't check the result, you won't notice if the statement signals an unexpected behavior by returning an atypical return value.
http://findbugs.sourceforge.net/bugDescriptions.html#RV_RETURN_VALUE_IGNORED_BAD_PRACTICE