### PR TITLE
[IO-554] fixed: prevent input stream close

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1525,8 +1525,7 @@ public class FileUtils {
      * @since 2.5
      */
     public static void copyToFile(final InputStream source, final File destination) throws IOException {
-        try (InputStream in = source;
-             OutputStream out = openOutputStream(destination)) {
+        try (OutputStream out = openOutputStream(destination)) {
             IOUtils.copy(in, out);
         }
     }

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1526,7 +1526,7 @@ public class FileUtils {
      */
     public static void copyToFile(final InputStream source, final File destination) throws IOException {
         try (OutputStream out = openOutputStream(destination)) {
-            IOUtils.copy(in, out);
+            IOUtils.copy(source, out);
         }
     }
 

--- a/src/test/java/org/apache/commons/io/FileUtilsCopyToFileTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsCopyToFileTestCase.java
@@ -1,0 +1,102 @@
+/* Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License. */
+package org.apache.commons.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.commons.io.testtools.TestUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+
+/**
+ * This is used to test FileUtils for correctness.
+ */
+public class FileUtilsCopyToFileTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    private File getTestDirectory() {
+        return temporaryFolder.getRoot();
+    }
+
+    private File testFile;
+
+    private byte[] testData;
+
+    @Before
+    public void setUp() throws Exception {
+        testFile = new File(getTestDirectory(), "file1-test.txt");
+        if(!testFile.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + testFile + 
+                " as the parent directory does not exist");
+        }
+
+        testData = TestUtils.generateTestData(1024);
+    }
+
+    /**
+     * Tests that <code>copyToFile(InputStream, File)</code> does not close the input stream.
+     * 
+     * @throws IOException
+     * @see FileUtils#copyToFile(InputStream, File)
+     * @see FileUtils#copyInputStreamToFile(InputStream, File)
+     */
+    @Test
+    public void testCopyToFile() throws IOException {
+        try(CheckingInputStream inputStream = new CheckingInputStream(testData)) {
+            FileUtils.copyToFile(inputStream, testFile);
+            Assert.assertFalse("inputStream should NOT be closed", inputStream.isClosed());
+        }
+    }
+
+    /**
+     * Tests that <code>copyInputStreamToFile(InputStream, File)</code> closes the input stream.
+     * 
+     * @throws IOException
+     * @see FileUtils#copyInputStreamToFile(InputStream, File)
+     * @see FileUtils#copyToFile(InputStream, File)
+     */
+    @Test
+    public void testCopyInputStreamToFile() throws IOException {
+        try(CheckingInputStream inputStream = new CheckingInputStream(testData)) {
+            FileUtils.copyInputStreamToFile(inputStream, testFile);
+            Assert.assertTrue("inputStream should be closed", inputStream.isClosed());
+        }
+    }
+
+    private class CheckingInputStream extends ByteArrayInputStream {
+        private boolean closed;
+
+        public CheckingInputStream(byte[] data) {
+            super(data);
+            closed = false;
+        }
+
+        @Override
+        public void close() throws IOException {
+            super.close();
+            closed = true;
+        }
+
+        public boolean isClosed() {
+            return closed;
+        }
+    }
+}


### PR DESCRIPTION
[IO-554] FileUtils.copyToFile(InputStream source, File destination) closes input stream.
Fixed removing 'source' from try-with-resources.