### PR TITLE
[IO-557] Perform locale independant upper case conversions.

### DIFF
--- a/src/main/java/org/apache/commons/io/ByteOrderMark.java
+++ b/src/main/java/org/apache/commons/io/ByteOrderMark.java
@@ -17,6 +17,7 @@
 package org.apache.commons.io;
 
 import java.io.Serializable;
+import java.util.Locale;
 
 /**
  * Byte Order Mark (BOM) representation - see {@link org.apache.commons.io.input.BOMInputStream}.
@@ -182,7 +183,7 @@ public class ByteOrderMark implements Serializable {
                 builder.append(",");
             }
             builder.append("0x");
-            builder.append(Integer.toHexString(0xFF & bytes[i]).toUpperCase());
+            builder.append(Integer.toHexString(0xFF & bytes[i]).toUpperCase(Locale.ROOT));
         }
         builder.append(']');
         return builder.toString();

--- a/src/main/java/org/apache/commons/io/input/XmlStreamReader.java
+++ b/src/main/java/org/apache/commons/io/input/XmlStreamReader.java
@@ -683,7 +683,7 @@ public class XmlStreamReader extends Reader {
                 final String postMime = httpContentType.substring(i + 1);
                 final Matcher m = CHARSET_PATTERN.matcher(postMime);
                 encoding = m.find() ? m.group(1) : null;
-                encoding = encoding != null ? encoding.toUpperCase(Locale.US) : null;
+                encoding = encoding != null ? encoding.toUpperCase(Locale.ROOT) : null;
             }
         }
         return encoding;
@@ -741,7 +741,7 @@ public class XmlStreamReader extends Reader {
                 }
                 final Matcher m = ENCODING_PATTERN.matcher(prolog);
                 if (m.find()) {
-                    encoding = m.group(1).toUpperCase();
+                    encoding = m.group(1).toUpperCase(Locale.ROOT);
                     encoding = encoding.substring(1, encoding.length() - 1);
                 }
             }

--- a/src/main/java/org/apache/commons/io/output/XmlStreamWriter.java
+++ b/src/main/java/org/apache/commons/io/output/XmlStreamWriter.java
@@ -24,6 +24,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -168,7 +169,7 @@ public class XmlStreamWriter extends Writer {
                     final Matcher m = ENCODING_PATTERN.matcher(xmlProlog.substring(0,
                             xmlPrologEnd));
                     if (m.find()) {
-                        encoding = m.group(1).toUpperCase();
+                        encoding = m.group(1).toUpperCase(Locale.ROOT);
                         encoding = encoding.substring(1, encoding.length() - 1);
                     } else {
                         // no encoding found in XML prolog: using default

--- a/src/test/java/org/apache/commons/io/input/XmlStreamReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/XmlStreamReaderTest.java
@@ -276,6 +276,25 @@ public class XmlStreamReaderTest {
         _testHttpLenient("text/html;charset=UTF-16BE", "no-bom", "US-ASCII", "UTF-8", "UTF-8");
         _testHttpLenient("text/html;charset=UTF-32BE", "no-bom", "US-ASCII", "UTF-8", "UTF-8");
     }
+    
+    /**
+     * Check lower case encoding names are properly handled. Should be successfull
+     * with any system default locale, notably with Turkish language
+     * (-Duser.language=tr JVM parameter), which has specific rules to convert dotted and dottless
+     * i character.
+     */
+    @Test
+    public void testLowerCaseEncoding() throws Exception {
+        final String[] encodings = { "iso8859-1", "us-ascii", "utf-8" };
+        for (final String encoding : encodings) {
+            final String xml = getXML("no-bom", XML3, encoding, encoding);
+            try (final ByteArrayInputStream is = new ByteArrayInputStream(xml.getBytes(encoding));
+                    final XmlStreamReader xmlReader = new XmlStreamReader(is);) {
+                assertTrue("Check encoding : " + encoding, encoding.equalsIgnoreCase(xmlReader.getEncoding()));
+                assertEquals("Check content", xml, IOUtils.toString(xmlReader));
+            }
+        }
+    }
 
     @Test
     public void testRawContent() throws Exception {

--- a/src/test/java/org/apache/commons/io/input/compatibility/XmlStreamReader.java
+++ b/src/test/java/org/apache/commons/io/input/compatibility/XmlStreamReader.java
@@ -29,6 +29,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.text.MessageFormat;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -590,7 +591,7 @@ public class XmlStreamReader extends Reader {
                 final String postMime = httpContentType.substring(i + 1);
                 final Matcher m = CHARSET_PATTERN.matcher(postMime);
                 encoding = m.find() ? m.group(1) : null;
-                encoding = encoding != null ? encoding.toUpperCase() : null;
+                encoding = encoding != null ? encoding.toUpperCase(Locale.ROOT) : null;
             }
         }
         return encoding;
@@ -699,7 +700,7 @@ public class XmlStreamReader extends Reader {
                 }
                 final Matcher m = ENCODING_PATTERN.matcher(prolog);
                 if (m.find()) {
-                    encoding = m.group(1).toUpperCase();
+                    encoding = m.group(1).toUpperCase(Locale.ROOT);
                     encoding = encoding.substring(1, encoding.length() - 1);
                 }
             }

--- a/src/test/java/org/apache/commons/io/output/XmlStreamWriterTest.java
+++ b/src/test/java/org/apache/commons/io/output/XmlStreamWriterTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.io.output;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
@@ -56,7 +55,7 @@ public class XmlStreamWriterTest {
         writer.write(xml);
         writer.close();
         final byte[] xmlContent = out.toByteArray();
-        assertEquals(encoding, writer.getEncoding());
+        assertTrue(encoding.equalsIgnoreCase(writer.getEncoding()));
         assertTrue(Arrays.equals(xml.getBytes(encoding), xmlContent));
 
     }
@@ -101,6 +100,19 @@ public class XmlStreamWriterTest {
         checkXmlWriter(TEXT_UNICODE, null, "UTF-16");
         checkXmlWriter(TEXT_UNICODE, null, "UTF-16BE");
         checkXmlWriter(TEXT_UNICODE, null, "ISO-8859-1");
+    }
+    
+    /**
+     * Check lower case encoding names are properly handled. Should be successfull
+     * with any system default locale, notably with Turkish language
+     * (-Duser.language=tr JVM parameter), which has specific rules to convert
+     * dotted and dottless i character.
+     */
+    @Test
+    public void testLowerCaseEncoding() throws IOException {
+        checkXmlWriter(TEXT_UNICODE, "utf-8");
+        checkXmlWriter(TEXT_LATIN1, "iso-8859-1");
+        checkXmlWriter(TEXT_LATIN7, "iso-8859-7");
     }
 
     @Test


### PR DESCRIPTION
To handle properly lower cased character encoding name in XML prolog
with any default system locale, notably Turkish which has specific rules for case conversion of dotted and dotless i characters.

Fixes issue [IO-557](https://issues.apache.org/jira/browse/IO-557).