### PR TITLE
Strengthen TeeOutputStremTest.testTee with an expected result.

### DIFF
--- a/src/test/java/org/apache/commons/io/output/TeeOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/TeeOutputStreamTest.java
@@ -87,24 +87,36 @@ public class TeeOutputStreamTest {
     public void testTee() throws IOException {
         final ByteArrayOutputStream baos1 = new ByteArrayOutputStream();
         final ByteArrayOutputStream baos2 = new ByteArrayOutputStream();
+        final ByteArrayOutputStream expected = new ByteArrayOutputStream();
+
         final TeeOutputStream tos = new TeeOutputStream(baos1, baos2);
         for (int i = 0; i < 20; i++) {
             tos.write(i);
+            expected.write(i);
         }
-        assertByteArrayEquals("TeeOutputStream.write(int)", baos1.toByteArray(), baos2.toByteArray());
+        assertByteArrayEquals("TeeOutputStream.write(int)", expected.toByteArray(), baos1.toByteArray());
+        assertByteArrayEquals("TeeOutputStream.write(int)", expected.toByteArray(), baos2.toByteArray());
 
         final byte[] array = new byte[10];
         for (int i = 20; i < 30; i++) {
             array[i - 20] = (byte) i;
         }
         tos.write(array);
-        assertByteArrayEquals("TeeOutputStream.write(byte[])", baos1.toByteArray(), baos2.toByteArray());
+        expected.write(array);
+        assertByteArrayEquals("TeeOutputStream.write(byte[])", expected.toByteArray(), baos1.toByteArray());
+        assertByteArrayEquals("TeeOutputStream.write(byte[])", expected.toByteArray(), baos2.toByteArray());
 
         for (int i = 25; i < 35; i++) {
             array[i - 25] = (byte) i;
         }
         tos.write(array, 5, 5);
-        assertByteArrayEquals("TeeOutputStream.write(byte[], int, int)", baos1.toByteArray(), baos2.toByteArray());
+        expected.write(array, 5, 5);
+        assertByteArrayEquals("TeeOutputStream.write(byte[], int, int)", expected.toByteArray(), baos1.toByteArray());
+        assertByteArrayEquals("TeeOutputStream.write(byte[], int, int)", expected.toByteArray(), baos2.toByteArray());
+        
+        expected.flush();
+        expected.close();
+        
         tos.flush();
         tos.close();
     }


### PR DESCRIPTION
Tee should not just repeat what's being written to both outputs, the output should also be the same as expected. For example, if the body of any of the `write` methods in TeeOutputStream is removed,
then the values written are the same (nothing) and the assertions don't fail in the test. This is solved by adding an expected value and checking both outputs against it.