### PR TITLE
Performance Enhancement: Call toArray with Zero Array Size

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -454,7 +454,7 @@ public class FileUtils {
      * @return an array of java.io.File
      */
     public static File[] convertFileCollectionToFileArray(final Collection<File> files) {
-        return files.toArray(new File[files.size()]);
+        return files.toArray(new File[0]);
     }
 
     //-----------------------------------------------------------------------

--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -1493,7 +1493,7 @@ public class FilenameUtils {
             list.add(buffer.toString());
         }
 
-        return list.toArray( new String[ list.size() ] );
+        return list.toArray( new String[ 0 ] );
     }
 
     /**
@@ -1576,7 +1576,7 @@ public class FilenameUtils {
             } else if (inet6Address.startsWith("::") && !octetList.isEmpty()) {
                 octetList.remove(0);
             }
-            octets = octetList.toArray(new String[octetList.size()]);
+            octets = octetList.toArray(new String[0]);
         }
         if (octets.length > IPV6_MAX_HEX_GROUPS) {
             return false;

--- a/src/main/java/org/apache/commons/io/comparator/CompositeFileComparator.java
+++ b/src/main/java/org/apache/commons/io/comparator/CompositeFileComparator.java
@@ -76,7 +76,7 @@ public class CompositeFileComparator extends AbstractFileComparator implements S
             for (final Comparator<File> comparator : delegates) {
                 list.add(comparator);
             }
-            this.delegates = (Comparator<File>[]) list.toArray(new Comparator<?>[list.size()]); //2
+            this.delegates = (Comparator<File>[]) list.toArray(new Comparator<?>[0]); //2
         }
     }
 

--- a/src/main/java/org/apache/commons/io/filefilter/FileFilterUtils.java
+++ b/src/main/java/org/apache/commons/io/filefilter/FileFilterUtils.java
@@ -89,7 +89,7 @@ public class FileFilterUtils {
                 acceptedFiles.add(file);
             }
         }
-        return acceptedFiles.toArray(new File[acceptedFiles.size()]);
+        return acceptedFiles.toArray(new File[0]);
     }
 
     /**
@@ -120,7 +120,7 @@ public class FileFilterUtils {
      */
     public static File[] filter(final IOFileFilter filter, final Iterable<File> files) {
         final List<File> acceptedFiles = filterList(filter, files);
-        return acceptedFiles.toArray(new File[acceptedFiles.size()]);
+        return acceptedFiles.toArray(new File[0]);
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/filefilter/NameFileFilter.java
+++ b/src/main/java/org/apache/commons/io/filefilter/NameFileFilter.java
@@ -126,7 +126,7 @@ public class NameFileFilter extends AbstractFileFilter implements Serializable {
         if (names == null) {
             throw new IllegalArgumentException("The list of names must not be null");
         }
-        this.names = names.toArray(new String[names.size()]);
+        this.names = names.toArray(new String[0]);
         this.caseSensitivity = caseSensitivity == null ? IOCase.SENSITIVE : caseSensitivity;
     }
 

--- a/src/main/java/org/apache/commons/io/filefilter/PrefixFileFilter.java
+++ b/src/main/java/org/apache/commons/io/filefilter/PrefixFileFilter.java
@@ -134,7 +134,7 @@ public class PrefixFileFilter extends AbstractFileFilter implements Serializable
         if (prefixes == null) {
             throw new IllegalArgumentException("The list of prefixes must not be null");
         }
-        this.prefixes = prefixes.toArray(new String[prefixes.size()]);
+        this.prefixes = prefixes.toArray(new String[0]);
         this.caseSensitivity = caseSensitivity == null ? IOCase.SENSITIVE : caseSensitivity;
     }
 

--- a/src/main/java/org/apache/commons/io/filefilter/SuffixFileFilter.java
+++ b/src/main/java/org/apache/commons/io/filefilter/SuffixFileFilter.java
@@ -135,7 +135,7 @@ public class SuffixFileFilter extends AbstractFileFilter implements Serializable
         if (suffixes == null) {
             throw new IllegalArgumentException("The list of suffixes must not be null");
         }
-        this.suffixes = suffixes.toArray(new String[suffixes.size()]);
+        this.suffixes = suffixes.toArray(new String[0]);
         this.caseSensitivity = caseSensitivity == null ? IOCase.SENSITIVE : caseSensitivity;
     }
 

--- a/src/main/java/org/apache/commons/io/filefilter/WildcardFileFilter.java
+++ b/src/main/java/org/apache/commons/io/filefilter/WildcardFileFilter.java
@@ -131,7 +131,7 @@ public class WildcardFileFilter extends AbstractFileFilter implements Serializab
         if (wildcards == null) {
             throw new IllegalArgumentException("The wildcard list must not be null");
         }
-        this.wildcards = wildcards.toArray(new String[wildcards.size()]);
+        this.wildcards = wildcards.toArray(new String[0]);
         this.caseSensitivity = caseSensitivity == null ? IOCase.SENSITIVE : caseSensitivity;
     }
 

--- a/src/main/java/org/apache/commons/io/filefilter/WildcardFilter.java
+++ b/src/main/java/org/apache/commons/io/filefilter/WildcardFilter.java
@@ -93,7 +93,7 @@ public class WildcardFilter extends AbstractFileFilter implements Serializable {
         if (wildcards == null) {
             throw new IllegalArgumentException("The wildcard list must not be null");
         }
-        this.wildcards = wildcards.toArray(new String[wildcards.size()]);
+        this.wildcards = wildcards.toArray(new String[0]);
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
toArray should, at least since Java 7, be used with new T[0] instead of size, since it is "faster, safer, and contractually cleaner" (https://shipilev.net/blog/2016/arrays-wisdom-ancients/#_conclusion)