### PR TITLE
Avoid Code Duplication: Reuse Sleep from ThreadMonitor

### DIFF
--- a/src/main/java/org/apache/commons/io/ThreadMonitor.java
+++ b/src/main/java/org/apache/commons/io/ThreadMonitor.java
@@ -37,7 +37,7 @@ package org.apache.commons.io;
  * </pre>
  *
  */
-class ThreadMonitor implements Runnable {
+public class ThreadMonitor implements Runnable {
 
     private final Thread thread;
     private final long timeout;
@@ -121,7 +121,7 @@ class ThreadMonitor implements Runnable {
      * @param ms the number of milliseconds to sleep for
      * @throws InterruptedException if interrupted
      */
-    private static void sleep(final long ms) throws InterruptedException {
+    public static void sleep(final long ms) throws InterruptedException {
         final long finishAt = System.currentTimeMillis() + ms;
         long remaining = ms;
         do {

--- a/src/test/java/org/apache/commons/io/DemuxTestCase.java
+++ b/src/test/java/org/apache/commons/io/DemuxTestCase.java
@@ -166,7 +166,7 @@ public class DemuxTestCase {
                     m_buffer.append((char) ch);
 
                     final int sleepTime = Math.abs(c_random.nextInt() % 10);
-                    TestUtils.sleep(sleepTime);
+                    ThreadMonitor.sleep(sleepTime);
                     ch = m_demux.read();
                 }
             } catch (final Exception e) {
@@ -199,7 +199,7 @@ public class DemuxTestCase {
                     //System.out.println( "Writing: " + (char)m_data[ i ] );
                     m_demux.write(element);
                     final int sleepTime = Math.abs(c_random.nextInt() % 10);
-                    TestUtils.sleep(sleepTime);
+                    ThreadMonitor.sleep(sleepTime);
                 } catch (final Exception e) {
                     e.printStackTrace();
                 }

--- a/src/test/java/org/apache/commons/io/FileCleaningTrackerTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileCleaningTrackerTestCase.java
@@ -301,7 +301,7 @@ public class FileCleaningTrackerTestCase {
         assertFalse(theInstance.exitWhenFinished);
         theInstance.exitWhenFinished();
         for (int i = 0; i < 20 && theInstance.reaper.isAlive(); i++) {
-            TestUtils.sleep(500L);  // allow reaper thread to die
+           ThreadMonitor.sleep(500L);  // allow reaper thread to die
         }
         assertTrue(theInstance.exitWhenFinished);
         assertFalse(theInstance.reaper.isAlive());
@@ -312,7 +312,7 @@ public class FileCleaningTrackerTestCase {
         int count = 0;
         while(file.exists() && count++ < 40) {
             try {
-                TestUtils.sleep(500L);
+               ThreadMonitor.sleep(500L);
             } catch (final InterruptedException ignore) {
             }
             file = new File(file.getPath());
@@ -328,7 +328,7 @@ public class FileCleaningTrackerTestCase {
 
     private void waitUntilTrackCount() throws Exception {
         System.gc();
-        TestUtils.sleep(500);
+        ThreadMonitor.sleep(500);
         int count = 0;
         while(theInstance.getTrackCount() != 0 && count++ < 5) {
             List<String> list = new ArrayList<>();
@@ -341,7 +341,7 @@ public class FileCleaningTrackerTestCase {
             }
             list = null;
             System.gc();
-            TestUtils.sleep(1000);
+            ThreadMonitor.sleep(1000);
         }
         if (theInstance.getTrackCount() != 0) {
             throw new IllegalStateException("Your JVM is not releasing References, try running the testcase with less memory (-Xmx)");

--- a/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
@@ -1009,7 +1009,7 @@ public class FileUtilsTestCase {
 
         do {
             try {
-                TestUtils.sleep(1000);
+               ThreadMonitor.sleep(1000);
             } catch (final InterruptedException ie) {
                 // ignore
             }
@@ -1031,7 +1031,7 @@ public class FileUtilsTestCase {
 
         do {
             try {
-                TestUtils.sleep(1000);
+               ThreadMonitor.sleep(1000);
             } catch (final InterruptedException ie) {
                 // ignore
             }

--- a/src/test/java/org/apache/commons/io/ThreadMonitorTestCase.java
+++ b/src/test/java/org/apache/commons/io/ThreadMonitorTestCase.java
@@ -34,7 +34,7 @@ public class ThreadMonitorTestCase {
     public void testTimeout() {
         try {
             final Thread monitor = ThreadMonitor.start(100);
-            TestUtils.sleep(200);
+            ThreadMonitor.sleep(200);
             ThreadMonitor.stop(monitor);
             fail("Expected InterruptedException");
         } catch (final InterruptedException e) {
@@ -49,7 +49,7 @@ public class ThreadMonitorTestCase {
     public void testCompletedWithoutTimeout() {
         try {
             final Thread monitor = ThreadMonitor.start(200);
-            TestUtils.sleep(100);
+            ThreadMonitor.sleep(100);
             ThreadMonitor.stop(monitor);
         } catch (final InterruptedException e) {
             fail("Timed Out");
@@ -66,7 +66,7 @@ public class ThreadMonitorTestCase {
         try {
             final Thread monitor = ThreadMonitor.start(-1);
             assertNull("Timeout -1, Monitor should be null", monitor);
-            TestUtils.sleep(100);
+            ThreadMonitor.sleep(100);
             ThreadMonitor.stop(monitor);
         } catch (final Exception e) {
             fail("Timeout -1, threw " + e);
@@ -76,7 +76,7 @@ public class ThreadMonitorTestCase {
         try {
             final Thread monitor = ThreadMonitor.start(0);
             assertNull("Timeout 0, Monitor should be null", monitor);
-            TestUtils.sleep(100);
+            ThreadMonitor.sleep(100);
             ThreadMonitor.stop(monitor);
         } catch (final Exception e) {
             fail("Timeout 0, threw " + e);

--- a/src/test/java/org/apache/commons/io/filefilter/FileFilterTestCase.java
+++ b/src/test/java/org/apache/commons/io/filefilter/FileFilterTestCase.java
@@ -42,6 +42,7 @@ import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOCase;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.ThreadMonitor;
 import org.apache.commons.io.testtools.TestUtils;
 import org.junit.Rule;
 import org.junit.Test;
@@ -809,7 +810,7 @@ public class FileFilterTestCase {
 
         do {
             try {
-                TestUtils.sleep(1000);
+               ThreadMonitor.sleep(1000);
             } catch(final InterruptedException ie) {
                 // ignore
             }
@@ -828,7 +829,7 @@ public class FileFilterTestCase {
 
         do {
             try {
-                TestUtils.sleep(1000);
+               ThreadMonitor.sleep(1000);
             } catch(final InterruptedException ie) {
                 // ignore
             }

--- a/src/test/java/org/apache/commons/io/input/TailerTest.java
+++ b/src/test/java/org/apache/commons/io/input/TailerTest.java
@@ -45,6 +45,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.ThreadMonitor;
 import org.apache.commons.io.testtools.TestUtils;
 import org.junit.After;
 import org.junit.Rule;
@@ -153,7 +154,7 @@ public class TailerTest {
             out.close(); // ensure data is written
 
            final long testDelayMillis = delay * 10;
-           TestUtils.sleep(testDelayMillis);
+           ThreadMonitor.sleep(testDelayMillis);
            final List<String> tailerlines = listener.getLines();
            assertEquals("line count",lines.size(),tailerlines.size());
            for(int i = 0,len = lines.size();i<len;i++){
@@ -182,12 +183,12 @@ public class TailerTest {
         // Write some lines to the file
         writeString(file, "Line");
 
-        TestUtils.sleep(delay * 2);
+        ThreadMonitor.sleep(delay * 2);
         List<String> lines = listener.getLines();
         assertEquals("1 line count", 0, lines.size());
 
         writeString(file, " one\n");
-        TestUtils.sleep(delay * 2);
+        ThreadMonitor.sleep(delay * 2);
         lines = listener.getLines();
 
         assertEquals("1 line count", 1, lines.size());
@@ -213,7 +214,7 @@ public class TailerTest {
         // Write some lines to the file
         write(file, "Line one", "Line two");
         final long testDelayMillis = delayMillis * 10;
-        TestUtils.sleep(testDelayMillis);
+        ThreadMonitor.sleep(testDelayMillis);
         List<String> lines = listener.getLines();
         assertEquals("1 line count", 2, lines.size());
         assertEquals("1 line 1", "Line one", lines.get(0));
@@ -222,7 +223,7 @@ public class TailerTest {
 
         // Write another line to the file
         write(file, "Line three");
-        TestUtils.sleep(testDelayMillis);
+        ThreadMonitor.sleep(testDelayMillis);
         lines = listener.getLines();
         assertEquals("2 line count", 1, lines.size());
         assertEquals("2 line 3", "Line three", lines.get(0));
@@ -240,11 +241,11 @@ public class TailerTest {
         final boolean exists = file.exists();
         assertFalse("File should not exist", exists);
         createFile(file, 0);
-        TestUtils.sleep(testDelayMillis);
+        ThreadMonitor.sleep(testDelayMillis);
 
         // Write another line
         write(file, "Line four");
-        TestUtils.sleep(testDelayMillis);
+        ThreadMonitor.sleep(testDelayMillis);
         lines = listener.getLines();
         assertEquals("4 line count", 1, lines.size());
         assertEquals("4 line 3", "Line four", lines.get(0));
@@ -252,7 +253,7 @@ public class TailerTest {
 
         // Stop
         thread.interrupt();
-        TestUtils.sleep(testDelayMillis * 4);
+        ThreadMonitor.sleep(testDelayMillis * 4);
         write(file, "Line five");
         assertEquals("4 line count", 0, listener.getLines().size());
         assertNotNull("Missing InterruptedException", listener.exception);
@@ -278,15 +279,15 @@ public class TailerTest {
 
         // write a few lines
         write(file, "line1", "line2", "line3");
-        TestUtils.sleep(testDelayMillis);
+        ThreadMonitor.sleep(testDelayMillis);
 
         // write a few lines
         write(file, "line4", "line5", "line6");
-        TestUtils.sleep(testDelayMillis);
+        ThreadMonitor.sleep(testDelayMillis);
 
         // write a few lines
         write(file, "line7", "line8", "line9");
-        TestUtils.sleep(testDelayMillis);
+        ThreadMonitor.sleep(testDelayMillis);
 
         // May be > 3 times due to underlying OS behaviour wrt streams
         assertTrue("end of file reached at least 3 times", listener.reachedEndOfFile >= 3);
@@ -313,7 +314,7 @@ public class TailerTest {
                 } catch (final FileNotFoundException ignore) {
                 }
                 try {
-                    TestUtils.sleep(200L);
+                   ThreadMonitor.sleep(200L);
                 } catch (final InterruptedException ignore) {
                     // ignore
                 }
@@ -349,9 +350,9 @@ public class TailerTest {
         final int delay = 100;
         final int idle = 50; // allow time for thread to work
         tailer = Tailer.create(file, listener, delay, false);
-        TestUtils.sleep(idle);
+        ThreadMonitor.sleep(idle);
         tailer.stop();
-        TestUtils.sleep(delay+idle);
+        ThreadMonitor.sleep(delay+idle);
         assertNull("Should not generate Exception", listener.exception);
         assertEquals("Expected init to be called", 1 , listener.initialised);
         assertTrue("fileNotFound should be called", listener.notFound > 0);
@@ -374,9 +375,9 @@ public class TailerTest {
         final Thread thread = new Thread(tailer);
         thread.setDaemon(true);
         thread.start();
-        TestUtils.sleep(idle);
+        ThreadMonitor.sleep(idle);
         thread.interrupt();
-        TestUtils.sleep(delay + idle);
+        ThreadMonitor.sleep(delay + idle);
         assertNotNull("Missing InterruptedException", listener.exception);
         assertTrue("Unexpected Exception: " + listener.exception, listener.exception instanceof InterruptedException);
         assertEquals("Expected init to be called", 1, listener.initialised);
@@ -395,9 +396,9 @@ public class TailerTest {
         tailer = new Tailer(file, listener, delay, false);
         final Executor exec = new ScheduledThreadPoolExecutor(1);
         exec.execute(tailer);
-        TestUtils.sleep(idle);
+        ThreadMonitor.sleep(idle);
         tailer.stop();
-        TestUtils.sleep(delay+idle);
+        ThreadMonitor.sleep(delay+idle);
         assertNull("Should not generate Exception", listener.exception);
         assertEquals("Expected init to be called", 1 , listener.initialised);
         assertTrue("fileNotFound should be called", listener.notFound > 0);
@@ -419,7 +420,7 @@ public class TailerTest {
         // Write some lines to the file
         writeString(file, "CRLF\r\n", "LF\n", "CR\r", "CRCR\r\r", "trail");
         final long testDelayMillis = delayMillis * 10;
-        TestUtils.sleep(testDelayMillis);
+        ThreadMonitor.sleep(testDelayMillis);
         final List<String> lines = listener.getLines();
         assertEquals("line count", 4, lines.size());
         assertEquals("line 1", "CRLF", lines.get(0));

--- a/src/test/java/org/apache/commons/io/testtools/TestUtils.java
+++ b/src/test/java/org/apache/commons/io/testtools/TestUtils.java
@@ -34,6 +34,7 @@ import java.io.Writer;
 import java.util.Arrays;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.ThreadMonitor;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 
 import junit.framework.AssertionFailedError;
@@ -213,27 +214,9 @@ public abstract class TestUtils {
         }
     }
 
-    /**
-     * Sleep for a guaranteed number of milliseconds unless interrupted.
-     *
-     * This method exists because Thread.sleep(100) can sleep for 0, 70, 100 or 200ms or anything else
-     * it deems appropriate. Read the docs on Thread.sleep for further details.
-     *
-     * @param ms the number of milliseconds to sleep for
-     * @throws InterruptedException if interrupted
-     */
-    public static void sleep(final long ms) throws InterruptedException {
-        final long finishAt = System.currentTimeMillis() + ms;
-        long remaining = ms;
-        do {
-            Thread.sleep(remaining);
-            remaining = finishAt - System.currentTimeMillis();
-        } while (remaining > 0);
-    }
-
     public static void sleepQuietly(final long ms) {
         try {
-            sleep(ms);
+            ThreadMonitor.sleep(ms);
         } catch (final InterruptedException ignored){
         }
     }


### PR DESCRIPTION
It makes no sense to duplicate code, like the sleep method, just to keep the interface private.