### PR TITLE
IO-170: Scalable Iterator for files, better than FileUtils.iterateFiles

### DIFF
--- a/src/main/java/org/apache/commons/io/iterator/ListFilesIterator.java
+++ b/src/main/java/org/apache/commons/io/iterator/ListFilesIterator.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.iterator;
+
+import org.apache.commons.io.filefilter.FileFilterUtils;
+import org.apache.commons.io.filefilter.IOFileFilter;
+
+import java.io.File;
+import java.io.FileFilter;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.NoSuchElementException;
+
+/**
+ * A true Iterator implementation to traverse a directory tree.
+ * This class is meant to to be used by utility methods on
+ * {@link org.apache.commons.io.FileUtils}
+ */
+public class ListFilesIterator implements Iterator<File> {
+
+    private final File directory;
+    private final IOFileFilter effFileFilter;
+    private final IOFileFilter effDirFilter;
+    private final boolean includeSubDirectories;
+    private final boolean recursive;
+
+    private File next = null;
+    private LinkedList<IteratorPosition> stack = new LinkedList<>();
+
+    public ListFilesIterator(final File directory, final IOFileFilter effFileFilter, final IOFileFilter effDirFilter,
+                             final boolean includeSubDirectories, final boolean recursive) {
+
+        this.directory = directory;
+        this.effFileFilter = effFileFilter;
+        this.effDirFilter = effDirFilter;
+        this.includeSubDirectories = includeSubDirectories;
+        this.recursive = recursive;
+
+        final File[] found = this.directory.listFiles((FileFilter) FileFilterUtils.or(effFileFilter, effDirFilter));
+
+        if (includeSubDirectories) {
+            stack.push(new IteratorPosition(new File[] {directory}, 0));
+        } else {
+            if (found.length > 0) {
+                stack.push(new IteratorPosition(found, 0));
+            }
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        this.next = null;
+        if (stack.isEmpty()) {
+            return false;
+        }
+
+        IteratorPosition iteratorPosition = removeFinishedDirs(stack.peekFirst());
+
+        if (iteratorPosition == null) {
+            return false;
+        }
+
+        moveNext(iteratorPosition);
+
+        if (this.next.isDirectory() && this.includeSubDirectories) {
+            return true;
+        }
+
+        while (this.next.isDirectory() && !this.includeSubDirectories) {
+            iteratorPosition = removeFinishedDirs(iteratorPosition);
+
+            if (iteratorPosition == null) {
+                return false;
+            }
+
+            moveNext(iteratorPosition);
+        }
+
+        return true;
+    }
+
+    /*
+     * Remove from stack when there is no more elements to process
+     */
+    private IteratorPosition removeFinishedDirs(IteratorPosition iteratorPosition) {
+        while (iteratorPosition != null && iteratorPosition.hasNext()) {
+            iteratorPosition = stack.peekFirst();
+
+            if (iteratorPosition != null && iteratorPosition.hasNext()) {
+                stack.pop();
+            }
+        }
+        return iteratorPosition;
+    }
+
+    /*
+     * Moves to the next element and if it's a directory updates the stack
+     */
+    private void moveNext(IteratorPosition iteratorPosition) {
+        this.next = iteratorPosition.next();
+        if (this.next.isDirectory() && this.recursive) {
+            final File[] found = this.next.listFiles((FileFilter) FileFilterUtils.or(effFileFilter, effDirFilter));
+
+            if (found.length > 0) {
+                stack.push(new IteratorPosition(found, 0));
+            }
+        }
+    }
+
+    @Override
+    public File next() {
+        if (this.next == null) {
+            throw new NoSuchElementException();
+        }
+        return this.next;
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException("remove");
+    }
+
+    /*
+     * Utility class representing the actual stack's position
+     */
+    private static class IteratorPosition {
+        public File[] found;
+        public int nextIndex;
+
+        public IteratorPosition(File[] found, int nextIndex) {
+            this.found = found;
+            this.nextIndex = nextIndex;
+        }
+
+        public boolean hasNext() {
+            return this.nextIndex >= this.found.length;
+        }
+
+        public File next() {
+            return found[this.nextIndex++];
+        }
+    }
+}

--- a/src/main/java/org/apache/commons/io/iterator/ListFilesIterator.java
+++ b/src/main/java/org/apache/commons/io/iterator/ListFilesIterator.java
@@ -41,6 +41,14 @@ public class ListFilesIterator implements Iterator<File> {
     private File next = null;
     private LinkedList<IteratorPosition> stack = new LinkedList<>();
 
+    /**
+     * Creates a new instance for traversing the given directory
+     * @param directory to be traversed
+     * @param effFileFilter the effective file filter to be used. Must be provided by {@link org.apache.commons.io.FileUtils}
+     * @param effDirFilter the effective directory filter to be used. Must be provided by {@link org.apache.commons.io.FileUtils}
+     * @param includeSubDirectories indicates if should include the directories
+     * @param recursive indicates if should process recursively
+     */
     public ListFilesIterator(final File directory, final IOFileFilter effFileFilter, final IOFileFilter effDirFilter,
                              final boolean includeSubDirectories, final boolean recursive) {
 
@@ -53,10 +61,10 @@ public class ListFilesIterator implements Iterator<File> {
         final File[] found = this.directory.listFiles((FileFilter) FileFilterUtils.or(effFileFilter, effDirFilter));
 
         if (includeSubDirectories) {
-            stack.push(new IteratorPosition(new File[] {directory}, 0));
+            stack.push(new IteratorPosition(new File[] {directory}));
         } else {
             if (found.length > 0) {
-                stack.push(new IteratorPosition(found, 0));
+                stack.push(new IteratorPosition(found));
             }
         }
     }
@@ -93,8 +101,10 @@ public class ListFilesIterator implements Iterator<File> {
         return true;
     }
 
-    /*
-     * Remove from stack when there is no more elements to process
+    /**
+     * Remove item from stack when there is no more elements to process
+     * @param iteratorPosition the current position on the stack
+     * @return the item to be processed or null if the process is finished
      */
     private IteratorPosition removeFinishedDirs(IteratorPosition iteratorPosition) {
         while (iteratorPosition != null && iteratorPosition.hasNext()) {
@@ -107,8 +117,9 @@ public class ListFilesIterator implements Iterator<File> {
         return iteratorPosition;
     }
 
-    /*
+    /**
      * Moves to the next element and if it's a directory updates the stack
+     * @param iteratorPosition the current position on the stack
      */
     private void moveNext(IteratorPosition iteratorPosition) {
         this.next = iteratorPosition.next();
@@ -116,7 +127,7 @@ public class ListFilesIterator implements Iterator<File> {
             final File[] found = this.next.listFiles((FileFilter) FileFilterUtils.or(effFileFilter, effDirFilter));
 
             if (found.length > 0) {
-                stack.push(new IteratorPosition(found, 0));
+                stack.push(new IteratorPosition(found));
             }
         }
     }
@@ -134,22 +145,33 @@ public class ListFilesIterator implements Iterator<File> {
         throw new UnsupportedOperationException("remove");
     }
 
-    /*
+    /**
      * Utility class representing the actual stack's position
      */
     private static class IteratorPosition {
         public File[] found;
-        public int nextIndex;
+        public int nextIndex = 0;
 
-        public IteratorPosition(File[] found, int nextIndex) {
+        /**
+         * Creates a new item for the stack
+         * @param found the array of files found
+         */
+        public IteratorPosition(File[] found) {
             this.found = found;
-            this.nextIndex = nextIndex;
         }
 
+        /**
+         * Checks if the current item has more files to be processed
+         * @return true if there are more items to process or false otherwise
+         */
         public boolean hasNext() {
             return this.nextIndex >= this.found.length;
         }
 
+        /**
+         * Returns the next file for this item
+         * @return
+         */
         public File next() {
             return found[this.nextIndex++];
         }

--- a/src/main/java/org/apache/commons/io/iterator/ListFilesIterator.java
+++ b/src/main/java/org/apache/commons/io/iterator/ListFilesIterator.java
@@ -170,7 +170,7 @@ public class ListFilesIterator implements Iterator<File> {
 
         /**
          * Returns the next file for this item
-         * @return
+         * @return the next file for this item
          */
         public File next() {
             return found[this.nextIndex++];

--- a/src/main/java/org/apache/commons/io/iterator/package.html
+++ b/src/main/java/org/apache/commons/io/iterator/package.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html>
+<body>
+<p>
+This package provides an iterator for traversing directories on an
+scalable way.
+</p>
+</body>
+</html>

--- a/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
@@ -1908,6 +1908,64 @@ public class FileUtilsTestCase {
     }
 
     @Test
+    public void testIterateFilesIgnoringDirs() throws Exception {
+        final File srcDir = temporaryFolder;
+
+        final File subDir1 = new File(srcDir, "subdir");
+        subDir1.mkdir();
+
+        final File subDir2 = new File(subDir1, "subdir2");
+        subDir2.mkdir();
+
+        final File someFileA = createTestFile(subDir2, "a.txt");
+        final File someFileB = createTestFile(subDir2, "b.txt");
+
+        final File subDir3 = new File(subDir2, "subdir3");
+        subDir3.mkdir();
+
+        final File someFileC = createTestFile(subDir3, "c.txt");
+
+        final File subDir4 = new File(subDir2, "subdir4");
+        subDir4.mkdir();
+
+        final File subDir5 = new File(subDir4, "subdir5");
+        subDir5.mkdir();
+
+        final File someFileD = createTestFile(subDir4, "d.txt");
+
+        final Collection<File> filesAndDirs = Arrays.asList(someFileA, someFileB, someFileC, someFileD);
+
+        int filesCount = 0;
+        final Iterator<File> files = FileUtils.iterateFiles(subDir1,
+                new WildcardFileFilter("*.*"),
+                new WildcardFileFilter("*"));
+        while (files.hasNext()) {
+            filesCount++;
+            final File file = files.next();
+            assertTrue(filesAndDirs.contains(file), "Should contain the directory/file");
+        }
+
+        assertEquals(filesCount, filesAndDirs.size());
+    }
+
+    private File createTestFile(File parent, String fileName) throws IOException {
+        final File someFile = new File(parent, fileName);
+        if (!someFile.getParentFile().exists()) {
+            throw new IOException("Cannot create file " + someFile
+                    + " as the parent directory does not exist");
+        }
+        final BufferedOutputStream output =
+                new BufferedOutputStream(new FileOutputStream(someFile));
+        try {
+            TestUtils.generateTestData(output, 100);
+        } finally {
+            IOUtils.closeQuietly(output);
+        }
+
+        return someFile;
+    }
+
+    @Test
     public void testIterateFilesAndDirs() throws IOException {
         final File srcDir = temporaryFolder;
 


### PR DESCRIPTION
I took an aproach of implementing a separate class with the iterator logic.
While this brings a little code duplication, it leads to a more scalable approach, as the iterator class processes only the necessary files and directories to return the next file.