### PR TITLE
Make array declaration in ThresholdingOutputStream consistent with other array declarations in the library

### DIFF
--- a/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
@@ -102,7 +102,7 @@ public abstract class ThresholdingOutputStream
      * @throws IOException if an error occurs.
      */
     @Override
-    public void write(final byte b[]) throws IOException
+    public void write(final byte[] b) throws IOException
     {
         checkThreshold(b.length);
         getStream().write(b);
@@ -121,7 +121,7 @@ public abstract class ThresholdingOutputStream
      * @throws IOException if an error occurs.
      */
     @Override
-    public void write(final byte b[], final int off, final int len) throws IOException
+    public void write(final byte[] b, final int off, final int len) throws IOException
     {
         checkThreshold(len);
         getStream().write(b, off, len);


### PR DESCRIPTION
`final byte b[]` → `final byte[] b` to move away from C-style array declarations and match other array declarations in the library.