### PR TITLE
Flush the OutputStream before calling toByteArray on underlying ByteArrayOutputStream

### DIFF
--- a/src/test/java/org/apache/commons/io/input/ClassLoaderObjectInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/ClassLoaderObjectInputStreamTest.java
@@ -47,6 +47,7 @@ public class ClassLoaderObjectInputStreamTest {
 
         final Object input = Boolean.FALSE;
         oos.writeObject(input);
+        oos.flush();
 
         final InputStream bais = new ByteArrayInputStream(baos.toByteArray());
         try (final ClassLoaderObjectInputStream clois = new ClassLoaderObjectInputStream(getClass().getClassLoader(),
@@ -65,6 +66,7 @@ public class ClassLoaderObjectInputStreamTest {
 
         final Object input = (long) 123;
         oos.writeObject(input);
+        oos.flush();
 
         final InputStream bais = new ByteArrayInputStream(baos.toByteArray());
         try (final ClassLoaderObjectInputStream clois = new ClassLoaderObjectInputStream(getClass().getClassLoader(),
@@ -178,6 +180,7 @@ public class ClassLoaderObjectInputStreamTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(Boolean.FALSE);
+        oos.flush();
         final InputStream bais = new ByteArrayInputStream(baos.toByteArray());
 
         try (final ClassLoaderObjectInputStream clois = new ClassLoaderObjectInputStream(getClass().getClassLoader(),
@@ -194,6 +197,7 @@ public class ClassLoaderObjectInputStreamTest {
         final ByteArrayOutputStream baos = new ByteArrayOutputStream();
         final ObjectOutputStream oos = new ObjectOutputStream(baos);
         oos.writeObject(Boolean.FALSE);
+        oos.flush();
         final InputStream bais = new ByteArrayInputStream(baos.toByteArray());
 
         try (final ClassLoaderObjectInputStream clois = new ClassLoaderObjectInputStream(getClass().getClassLoader(),

--- a/src/test/java/org/apache/commons/io/output/CountingOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/CountingOutputStreamTest.java
@@ -44,6 +44,7 @@ public class CountingOutputStreamTest {
             for (int i = 0; i < 20; i++) {
                 cos.write(i);
             }
+            cos.flush();
             assertByteArrayEquals("CountingOutputStream.write(int)", baos.toByteArray(), 0, 20);
             assertEquals("CountingOutputStream.getCount()", cos.getCount(), 20);
 
@@ -52,6 +53,7 @@ public class CountingOutputStreamTest {
                 array[i - 20] = (byte) i;
             }
             cos.write(array);
+            cos.flush();
             assertByteArrayEquals("CountingOutputStream.write(byte[])", baos.toByteArray(), 0, 30);
             assertEquals("CountingOutputStream.getCount()", cos.getCount(), 30);
 
@@ -59,6 +61,7 @@ public class CountingOutputStreamTest {
                 array[i - 25] = (byte) i;
             }
             cos.write(array, 5, 5);
+            cos.flush();
             assertByteArrayEquals("CountingOutputStream.write(byte[], int, int)", baos.toByteArray(), 0, 35);
             assertEquals("CountingOutputStream.getCount()", cos.getCount(), 35);
 
@@ -68,6 +71,7 @@ public class CountingOutputStreamTest {
             for (int i = 0; i < 10; i++) {
                 cos.write(i);
             }
+            cos.flush();
             assertByteArrayEquals("CountingOutputStream.write(int)", baos.toByteArray(), 35, 45);
             assertEquals("CountingOutputStream.getCount()", cos.getCount(), 10);
         }

--- a/src/test/java/org/apache/commons/io/output/TeeOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/TeeOutputStreamTest.java
@@ -93,6 +93,7 @@ public class TeeOutputStreamTest {
                 tos.write(i);
                 expected.write(i);
             }
+            tos.flush();
             assertByteArrayEquals("TeeOutputStream.write(int)", expected.toByteArray(), baos1.toByteArray());
             assertByteArrayEquals("TeeOutputStream.write(int)", expected.toByteArray(), baos2.toByteArray());
 
@@ -101,6 +102,7 @@ public class TeeOutputStreamTest {
                 array[i - 20] = (byte) i;
             }
             tos.write(array);
+            tos.flush();
             expected.write(array);
             assertByteArrayEquals("TeeOutputStream.write(byte[])", expected.toByteArray(), baos1.toByteArray());
             assertByteArrayEquals("TeeOutputStream.write(byte[])", expected.toByteArray(), baos2.toByteArray());
@@ -109,6 +111,7 @@ public class TeeOutputStreamTest {
                 array[i - 25] = (byte) i;
             }
             tos.write(array, 5, 5);
+            tos.flush();
             expected.write(array, 5, 5);
             assertByteArrayEquals("TeeOutputStream.write(byte[], int, int)", expected.toByteArray(),
                     baos1.toByteArray());

--- a/src/test/java/org/apache/commons/io/serialization/MoreComplexObjectTest.java
+++ b/src/test/java/org/apache/commons/io/serialization/MoreComplexObjectTest.java
@@ -48,6 +48,7 @@ public class MoreComplexObjectTest extends ClosingBase {
         final ByteArrayOutputStream bos = willClose(new ByteArrayOutputStream());
         final ObjectOutputStream oos = willClose(new ObjectOutputStream(bos));
         oos.writeObject(original);
+        oos.close();
         inputStream = willClose(new ByteArrayInputStream(bos.toByteArray()));
     }
 


### PR DESCRIPTION
When an `OutputStream` instance wraps an underlying `ByteArrayOutputStream` instance, it is [recommended](http://stackoverflow.com/questions/2984538/how-to-use-bytearrayoutputstream-and-dataoutputstream-simultaneously-java) to flush or close the `OutputStream` before invoking the underlying instances's `toByteArray()`.

This pull request adds a call to `flush` method before calls to the `toByteArray` methods.
