### PR TITLE
[IO-625] FileUtils.copyDirectoryToDirectory does not reflect srcDir in exception message when srcDir is not a directory

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -131,6 +131,9 @@ The <action> type attribute can be add,update,fix,remove.
       <action issue="IO-617" dev="ggregory" type="add" due-to="Rob Spoor">
         Add classes Added TaggedReader, ClosedReader and BrokenReader. #85.
       </action>
+      <action issue="IO-625" dev="ggregory" type="fix" due-to="Mikko Maunu">
+        Corrected misleading exception message for FileUtils.copyDirectoryToDirectory.
+      </action>
     </release>
 
     <release version="2.6" date="2017-10-15" description="Java 7 required, Java 9 supported.">

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1207,6 +1207,7 @@ public class FileUtils {
      * @param destDir the directory to place the copy in, must not be {@code null}
      *
      * @throws NullPointerException if source or destination is {@code null}
+     * @throws IllegalArgumentException if {@code srcDir} or {@code destDir} is not a directory
      * @throws IOException          if source or destination is invalid
      * @throws IOException          if an IO error occurs during copying
      * @since 1.2
@@ -1216,7 +1217,7 @@ public class FileUtils {
             throw new NullPointerException("Source must not be null");
         }
         if (srcDir.exists() && srcDir.isDirectory() == false) {
-            throw new IllegalArgumentException("Source '" + destDir + "' is not a directory");
+            throw new IllegalArgumentException("Source '" + srcDir + "' is not a directory");
         }
         if (destDir == null) {
             throw new NullPointerException("Destination must not be null");

--- a/src/test/java/org/apache/commons/io/FileUtilsCopyDirectoryToDirectoryTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsCopyDirectoryToDirectoryTestCase.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * This class ensure the correctness of {@link FileUtils#copyDirectoryToDirectory(File, File)} (File,File)}.
+ * TODO: currently does not cover happy cases
+ *
+ * @see FileUtils#copyDirectoryToDirectory(File, File)
+ */
+public class FileUtilsCopyDirectoryToDirectoryTestCase {
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Test
+    public void copyDirectoryToDirectoryThrowsIllegalExceptionWithCorrectMessageWhenSrcDirIsNotDirectory() throws IOException {
+        File srcDir = temporaryFolder.newFile("notadirectory");
+        File destDir = temporaryFolder.newFolder("destinationDirectory");
+        String expectedMessage = String.format("Source '%s' is not a directory", srcDir);
+        assertExceptionTypeAndMessage(srcDir, destDir, IllegalArgumentException.class, expectedMessage);
+    }
+
+    @Test
+    public void copyDirectoryToDirectoryThrowsIllegalArgumentExceptionWithCorrectMessageWhenDstDirIsNotDirectory() throws IOException {
+        File srcDir = temporaryFolder.newFolder("sourceDirectory");
+        File destDir =  temporaryFolder.newFile("notadirectory");
+        String expectedMessage = String.format("Destination '%s' is not a directory", destDir);
+        assertExceptionTypeAndMessage(srcDir, destDir, IllegalArgumentException.class, expectedMessage);
+    }
+
+    @Test
+    public void copyDirectoryToDirectoryThrowsNullPointerExceptionWithCorrectMessageWhenSrcDirIsNull() throws IOException {
+        File srcDir = null;
+        File destinationDirectory =  temporaryFolder.newFolder("destinationDirectory");
+        String expectedMessage = "Source must not be null";
+        assertExceptionTypeAndMessage(srcDir, destinationDirectory, NullPointerException.class,  expectedMessage);
+    }
+
+    @Test
+    public void copyDirectoryToDirectoryThrowsNullPointerExceptionWithCorrectMessageWhenDstDirIsNull() throws IOException {
+        File srcDir = temporaryFolder.newFolder("sourceDirectory");
+        File destDir =  null;
+        String expectedMessage = "Destination must not be null";
+        assertExceptionTypeAndMessage(srcDir, destDir, NullPointerException.class, expectedMessage);
+    }
+
+    private static void assertExceptionTypeAndMessage(File srcDir, File destDir, Class expectedExceptionType, String expectedMessage) {
+        try {
+            FileUtils.copyDirectoryToDirectory(srcDir, destDir);
+        } catch (Exception e) {
+            String msg = e.getMessage();
+            assertEquals(expectedExceptionType, e.getClass());
+            assertEquals(expectedMessage, msg);
+            return;
+        }
+        fail();
+
+    }
+}

--- a/src/test/java/org/apache/commons/io/FileUtilsCopyDirectoryToDirectoryTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsCopyDirectoryToDirectoryTestCase.java
@@ -27,7 +27,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 /**
- * This class ensure the correctness of {@link FileUtils#copyDirectoryToDirectory(File, File)} (File,File)}.
+ * This class ensure the correctness of {@link FileUtils#copyDirectoryToDirectory(File, File)}.
  * TODO: currently does not cover happy cases
  *
  * @see FileUtils#copyDirectoryToDirectory(File, File)
@@ -35,50 +35,49 @@ import static org.junit.Assert.fail;
 public class FileUtilsCopyDirectoryToDirectoryTestCase {
 
     @Rule
-    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    public final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Test
     public void copyDirectoryToDirectoryThrowsIllegalExceptionWithCorrectMessageWhenSrcDirIsNotDirectory() throws IOException {
-        File srcDir = temporaryFolder.newFile("notadirectory");
-        File destDir = temporaryFolder.newFolder("destinationDirectory");
-        String expectedMessage = String.format("Source '%s' is not a directory", srcDir);
+        final File srcDir = temporaryFolder.newFile("notadirectory");
+        final File destDir = temporaryFolder.newFolder("destinationDirectory");
+        final String expectedMessage = String.format("Source '%s' is not a directory", srcDir);
         assertExceptionTypeAndMessage(srcDir, destDir, IllegalArgumentException.class, expectedMessage);
     }
 
     @Test
     public void copyDirectoryToDirectoryThrowsIllegalArgumentExceptionWithCorrectMessageWhenDstDirIsNotDirectory() throws IOException {
-        File srcDir = temporaryFolder.newFolder("sourceDirectory");
-        File destDir =  temporaryFolder.newFile("notadirectory");
+        final File srcDir = temporaryFolder.newFolder("sourceDirectory");
+        final File destDir =  temporaryFolder.newFile("notadirectory");
         String expectedMessage = String.format("Destination '%s' is not a directory", destDir);
         assertExceptionTypeAndMessage(srcDir, destDir, IllegalArgumentException.class, expectedMessage);
     }
 
     @Test
     public void copyDirectoryToDirectoryThrowsNullPointerExceptionWithCorrectMessageWhenSrcDirIsNull() throws IOException {
-        File srcDir = null;
-        File destinationDirectory =  temporaryFolder.newFolder("destinationDirectory");
-        String expectedMessage = "Source must not be null";
+        final File srcDir = null;
+        final File destinationDirectory =  temporaryFolder.newFolder("destinationDirectory");
+        final String expectedMessage = "Source must not be null";
         assertExceptionTypeAndMessage(srcDir, destinationDirectory, NullPointerException.class,  expectedMessage);
     }
 
     @Test
     public void copyDirectoryToDirectoryThrowsNullPointerExceptionWithCorrectMessageWhenDstDirIsNull() throws IOException {
-        File srcDir = temporaryFolder.newFolder("sourceDirectory");
-        File destDir =  null;
-        String expectedMessage = "Destination must not be null";
+        final File srcDir = temporaryFolder.newFolder("sourceDirectory");
+        final File destDir =  null;
+        final String expectedMessage = "Destination must not be null";
         assertExceptionTypeAndMessage(srcDir, destDir, NullPointerException.class, expectedMessage);
     }
 
-    private static void assertExceptionTypeAndMessage(File srcDir, File destDir, Class expectedExceptionType, String expectedMessage) {
+    private static void assertExceptionTypeAndMessage(final File srcDir, final File destDir, final Class expectedExceptionType, final String expectedMessage) {
         try {
             FileUtils.copyDirectoryToDirectory(srcDir, destDir);
-        } catch (Exception e) {
-            String msg = e.getMessage();
+        } catch (final Exception e) {
+            final String msg = e.getMessage();
             assertEquals(expectedExceptionType, e.getClass());
             assertEquals(expectedMessage, msg);
             return;
         }
         fail();
-
     }
 }


### PR DESCRIPTION
Fix and unit tests for https://issues.apache.org/jira/browse/IO-625.