### PR TITLE
Fixed a mistake in the FilenameUtils.concat()'s Javadoc about an absolute path.

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -134,7 +134,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action issue="IO-625" dev="ggregory" type="fix" due-to="Mikko Maunu">
         Corrected misleading exception message for FileUtils.copyDirectoryToDirectory.
       </action>
-      <action issue="IO-626" dev="Yuji Konishi" type="fix" due-to="Yuji Konishi">
+      <action issue="IO-626" dev="ggregory" type="fix" due-to="Yuji Konishi">
         A mistake in the FilenameUtils.concat()'s Javadoc about an absolute path.
       </action>
     </release>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -134,6 +134,9 @@ The <action> type attribute can be add,update,fix,remove.
       <action issue="IO-625" dev="ggregory" type="fix" due-to="Mikko Maunu">
         Corrected misleading exception message for FileUtils.copyDirectoryToDirectory.
       </action>
+      <action issue="IO-626" dev="Yuji Konishi" type="fix" due-to="Yuji Konishi">
+        A mistake in the FilenameUtils.concat()'s Javadoc about an absolute path.
+      </action>
     </release>
 
     <release version="2.6" date="2017-10-15" description="Java 7 required, Java 9 supported.">

--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -471,7 +471,7 @@ public class FilenameUtils {
      * /foo + /bar          --&gt;   /bar
      * /foo + C:/bar        --&gt;   C:/bar
      * /foo + C:bar         --&gt;   C:bar (*)
-     * /foo/a/ + ../bar     --&gt;   foo/bar
+     * /foo/a/ + ../bar     --&gt;   /foo/bar
      * /foo/ + ../../bar    --&gt;   null
      * /foo/ + /bar         --&gt;   /bar
      * /foo/.. + /bar       --&gt;   /bar


### PR DESCRIPTION
ng
/foo/a/ + ../bar     -->   foo/bar

ok
/foo/a/ + ../bar     -->   /foo/bar