### PR TITLE
Refactor ByteArrayOutputStream into synchronized and non-synchronized versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,10 @@ file comparators, endian transformation classes, and much more.
       <email>alban.peignier at free.fr</email>
     </contributor>
     <contributor>
+      <name>Adam Retter</name>
+      <organization>Evolved Binary</organization>
+    </contributor>
+    <contributor>
       <name>Ian Springer</name>
     </contributor>
     <contributor>
@@ -226,6 +230,11 @@ file comparators, endian transformation classes, and much more.
   </contributors>
 
   <dependencies>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>3.0.2</version>
+    </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -231,11 +231,6 @@ file comparators, endian transformation classes, and much more.
 
   <dependencies>
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
-      <version>3.0.2</version>
-    </dependency>
-    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <version>5.5.2</version>

--- a/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
@@ -1,0 +1,391 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.output;
+
+import org.apache.commons.io.input.ClosedInputStream;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.SequenceInputStream;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.apache.commons.io.IOUtils.EOF;
+
+/**
+ * This is the base class for implementing an output stream in which the data
+ * is written into a byte array. The buffer automatically grows as data
+ * is written to it.
+ * <p>
+ * The data can be retrieved using <code>toByteArray()</code> and
+ * <code>toString()</code>.
+ * <p>
+ * Closing an {@code AbstractByteArrayOutputStream} has no effect. The methods in
+ * this class can be called after the stream has been closed without
+ * generating an {@code IOException}.
+ * <p>
+ * This is the base for an alternative implementation of the
+ * {@link java.io.ByteArrayOutputStream} class. The original implementation
+ * only allocates 32 bytes at the beginning. As this class is designed for
+ * heavy duty it starts at 1024 bytes. In contrast to the original it doesn't
+ * reallocate the whole memory block but allocates additional buffers. This
+ * way no buffers need to be garbage collected and the contents don't have
+ * to be copied to the new buffer. This class is designed to behave exactly
+ * like the original. The only exception is the deprecated
+ * {@link java.io.ByteArrayOutputStream#toString(int)} method that has been
+ * ignored.
+ */
+public abstract class AbstractByteArrayOutputStream extends OutputStream {
+
+    static final int DEFAULT_SIZE = 1024;
+
+    /** A singleton empty byte array. */
+    private static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
+
+    /** The list of buffers, which grows and never reduces. */
+    private final List<byte[]> buffers = new ArrayList<>();
+    /** The index of the current buffer. */
+    private int currentBufferIndex;
+    /** The total count of bytes in all the filled buffers. */
+    private int filledBufferSum;
+    /** The current buffer. */
+    private byte[] currentBuffer;
+    /** The total count of bytes written. */
+    protected int count;
+    /** Flag to indicate if the buffers can be reused after reset */
+    private boolean reuseBuffers = true;
+
+    /**
+     * Makes a new buffer available either by allocating
+     * a new one or re-cycling an existing one.
+     *
+     * @param newcount  the size of the buffer if one is created
+     */
+    protected void needNewBuffer(final int newcount) {
+        if (currentBufferIndex < buffers.size() - 1) {
+            //Recycling old buffer
+            filledBufferSum += currentBuffer.length;
+
+            currentBufferIndex++;
+            currentBuffer = buffers.get(currentBufferIndex);
+        } else {
+            //Creating new buffer
+            int newBufferSize;
+            if (currentBuffer == null) {
+                newBufferSize = newcount;
+                filledBufferSum = 0;
+            } else {
+                newBufferSize = Math.max(
+                    currentBuffer.length << 1,
+                    newcount - filledBufferSum);
+                filledBufferSum += currentBuffer.length;
+            }
+
+            currentBufferIndex++;
+            currentBuffer = new byte[newBufferSize];
+            buffers.add(currentBuffer);
+        }
+    }
+
+    /**
+     * Write the bytes to byte array.
+     * @param b the bytes to write
+     * @param off The start offset
+     * @param len The number of bytes to write
+     */
+    @Override
+    public abstract void write(final byte[] b, final int off, final int len);
+
+    /**
+     * Write the bytes to byte array.
+     * @param b the bytes to write
+     * @param off The start offset
+     * @param len The number of bytes to write
+     */
+    protected void writeImpl(final byte[] b, final int off, final int len) {
+        final int newcount = count + len;
+        int remaining = len;
+        int inBufferPos = count - filledBufferSum;
+        while (remaining > 0) {
+            final int part = Math.min(remaining, currentBuffer.length - inBufferPos);
+            System.arraycopy(b, off + len - remaining, currentBuffer, inBufferPos, part);
+            remaining -= part;
+            if (remaining > 0) {
+                needNewBuffer(newcount);
+                inBufferPos = 0;
+            }
+        }
+        count = newcount;
+    }
+
+    /**
+     * Write a byte to byte array.
+     * @param b the byte to write
+     */
+    @Override
+    public abstract void write(final int b);
+
+    /**
+     * Write a byte to byte array.
+     * @param b the byte to write
+     */
+    protected void writeImpl(final int b) {
+        int inBufferPos = count - filledBufferSum;
+        if (inBufferPos == currentBuffer.length) {
+            needNewBuffer(count + 1);
+            inBufferPos = 0;
+        }
+        currentBuffer[inBufferPos] = (byte) b;
+        count++;
+    }
+
+
+    /**
+     * Writes the entire contents of the specified input stream to this
+     * byte stream. Bytes from the input stream are read directly into the
+     * internal buffers of this streams.
+     *
+     * @param in the input stream to read from
+     * @return total number of bytes read from the input stream
+     *         (and written to this stream)
+     * @throws IOException if an I/O error occurs while reading the input stream
+     * @since 1.4
+     */
+    public abstract int write(final InputStream in) throws IOException;
+
+    /**
+     * Writes the entire contents of the specified input stream to this
+     * byte stream. Bytes from the input stream are read directly into the
+     * internal buffers of this streams.
+     *
+     * @param in the input stream to read from
+     * @return total number of bytes read from the input stream
+     *         (and written to this stream)
+     * @throws IOException if an I/O error occurs while reading the input stream
+     * @since 2.7
+     */
+    protected int writeImpl(final InputStream in) throws IOException {
+        int readCount = 0;
+        int inBufferPos = count - filledBufferSum;
+        int n = in.read(currentBuffer, inBufferPos, currentBuffer.length - inBufferPos);
+        while (n != EOF) {
+            readCount += n;
+            inBufferPos += n;
+            count += n;
+            if (inBufferPos == currentBuffer.length) {
+                needNewBuffer(currentBuffer.length);
+                inBufferPos = 0;
+            }
+            n = in.read(currentBuffer, inBufferPos, currentBuffer.length - inBufferPos);
+        }
+        return readCount;
+    }
+
+    /**
+     * Return the current size of the byte array.
+     * @return the current size of the byte array
+     */
+    public abstract int size();
+
+    /**
+     * Closing a {@code ByteArrayOutputStream} has no effect. The methods in
+     * this class can be called after the stream has been closed without
+     * generating an {@code IOException}.
+     *
+     * @throws IOException never (this method should not declare this exception
+     * but it has to now due to backwards compatibility)
+     */
+    @Override
+    public void close() throws IOException {
+        //nop
+    }
+
+    /**
+     * @see java.io.ByteArrayOutputStream#reset()
+     */
+    public abstract void reset();
+
+    /**
+     * @see java.io.ByteArrayOutputStream#reset()
+     */
+    protected void resetImpl() {
+        count = 0;
+        filledBufferSum = 0;
+        currentBufferIndex = 0;
+        if (reuseBuffers) {
+            currentBuffer = buffers.get(currentBufferIndex);
+        } else {
+            //Throw away old buffers
+            currentBuffer = null;
+            final int size = buffers.get(0).length;
+            buffers.clear();
+            needNewBuffer(size);
+            reuseBuffers = true;
+        }
+    }
+
+    /**
+     * Writes the entire contents of this byte stream to the
+     * specified output stream.
+     *
+     * @param out  the output stream to write to
+     * @throws IOException if an I/O error occurs, such as if the stream is closed
+     * @see java.io.ByteArrayOutputStream#writeTo(OutputStream)
+     */
+    public abstract void writeTo(final OutputStream out) throws IOException;
+
+    /**
+     * Writes the entire contents of this byte stream to the
+     * specified output stream.
+     *
+     * @param out  the output stream to write to
+     * @throws IOException if an I/O error occurs, such as if the stream is closed
+     * @see java.io.ByteArrayOutputStream#writeTo(OutputStream)
+     */
+    protected void writeToImpl(final OutputStream out) throws IOException {
+        int remaining = count;
+        for (final byte[] buf : buffers) {
+            final int c = Math.min(buf.length, remaining);
+            out.write(buf, 0, c);
+            remaining -= c;
+            if (remaining == 0) {
+                break;
+            }
+        }
+    }
+
+    /**
+     * Gets the current contents of this byte stream as a Input Stream. The
+     * returned stream is backed by buffers of <code>this</code> stream,
+     * avoiding memory allocation and copy, thus saving space and time.<br>
+     *
+     * @return the current contents of this output stream.
+     * @see java.io.ByteArrayOutputStream#toByteArray()
+     * @see #reset()
+     * @since 2.5
+     */
+    public abstract InputStream toInputStream();
+
+    /**
+     * Gets the current contents of this byte stream as a Input Stream. The
+     * returned stream is backed by buffers of <code>this</code> stream,
+     * avoiding memory allocation and copy, thus saving space and time.<br>
+     *
+     * @return the current contents of this output stream.
+     * @see java.io.ByteArrayOutputStream#toByteArray()
+     * @see #reset()
+     * @since 2.7
+     */
+    protected InputStream toInputStreamImpl() {
+        int remaining = count;
+        if (remaining == 0) {
+            return new ClosedInputStream();
+        }
+        final List<ByteArrayInputStream> list = new ArrayList<>(buffers.size());
+        for (final byte[] buf : buffers) {
+            final int c = Math.min(buf.length, remaining);
+            list.add(new ByteArrayInputStream(buf, 0, c));
+            remaining -= c;
+            if (remaining == 0) {
+                break;
+            }
+        }
+        reuseBuffers = false;
+        return new SequenceInputStream(Collections.enumeration(list));
+    }
+
+    /**
+     * Gets the current contents of this byte stream as a byte array.
+     * The result is independent of this stream.
+     *
+     * @return the current contents of this output stream, as a byte array
+     * @see java.io.ByteArrayOutputStream#toByteArray()
+     */
+    public abstract byte[] toByteArray();
+
+    /**
+     * Gets the current contents of this byte stream as a byte array.
+     * The result is independent of this stream.
+     *
+     * @return the current contents of this output stream, as a byte array
+     * @see java.io.ByteArrayOutputStream#toByteArray()
+     */
+    protected byte[] toByteArrayImpl() {
+        int remaining = count;
+        if (remaining == 0) {
+            return EMPTY_BYTE_ARRAY;
+        }
+        final byte newbuf[] = new byte[remaining];
+        int pos = 0;
+        for (final byte[] buf : buffers) {
+            final int c = Math.min(buf.length, remaining);
+            System.arraycopy(buf, 0, newbuf, pos, c);
+            pos += c;
+            remaining -= c;
+            if (remaining == 0) {
+                break;
+            }
+        }
+        return newbuf;
+    }
+
+    /**
+     * Gets the current contents of this byte stream as a string
+     * using the platform default charset.
+     * @return the contents of the byte array as a String
+     * @see java.io.ByteArrayOutputStream#toString()
+     * @deprecated 2.5 use {@link #toString(String)} instead
+     */
+    @Override
+    @Deprecated
+    public String toString() {
+        // make explicit the use of the default charset
+        return new String(toByteArray(), Charset.defaultCharset());
+    }
+
+    /**
+     * Gets the current contents of this byte stream as a string
+     * using the specified encoding.
+     *
+     * @param enc  the name of the character encoding
+     * @return the string converted from the byte array
+     * @throws UnsupportedEncodingException if the encoding is not supported
+     * @see java.io.ByteArrayOutputStream#toString(String)
+     */
+    public String toString(final String enc) throws UnsupportedEncodingException {
+        return new String(toByteArray(), enc);
+    }
+
+    /**
+     * Gets the current contents of this byte stream as a string
+     * using the specified encoding.
+     *
+     * @param charset  the character encoding
+     * @return the string converted from the byte array
+     * @see java.io.ByteArrayOutputStream#toString(String)
+     * @since 2.5
+     */
+    public String toString(final Charset charset) {
+        return new String(toByteArray(), charset);
+    }
+
+}

--- a/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
@@ -38,12 +38,9 @@ import static org.apache.commons.io.IOUtils.EOF;
  * <p>
  * The data can be retrieved using <code>toByteArray()</code> and
  * <code>toString()</code>.
- * </p>
- * <p>
  * Closing an {@code AbstractByteArrayOutputStream} has no effect. The methods in
  * this class can be called after the stream has been closed without
  * generating an {@code IOException}.
- * </p>
  * <p>
  * This is the base for an alternative implementation of the
  * {@link java.io.ByteArrayOutputStream} class. The original implementation
@@ -55,7 +52,6 @@ import static org.apache.commons.io.IOUtils.EOF;
  * like the original. The only exception is the deprecated
  * {@link java.io.ByteArrayOutputStream#toString(int)} method that has been
  * ignored.
- * </p>
  *
  * @since 2.7
  */

--- a/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
@@ -38,10 +38,12 @@ import static org.apache.commons.io.IOUtils.EOF;
  * <p>
  * The data can be retrieved using <code>toByteArray()</code> and
  * <code>toString()</code>.
+ * </p>
  * <p>
  * Closing an {@code AbstractByteArrayOutputStream} has no effect. The methods in
  * this class can be called after the stream has been closed without
  * generating an {@code IOException}.
+ * </p>
  * <p>
  * This is the base for an alternative implementation of the
  * {@link java.io.ByteArrayOutputStream} class. The original implementation
@@ -53,6 +55,9 @@ import static org.apache.commons.io.IOUtils.EOF;
  * like the original. The only exception is the deprecated
  * {@link java.io.ByteArrayOutputStream#toString(int)} method that has been
  * ignored.
+ * </p>
+ *
+ * @since 2.7
  */
 public abstract class AbstractByteArrayOutputStream extends OutputStream {
 
@@ -107,7 +112,7 @@ public abstract class AbstractByteArrayOutputStream extends OutputStream {
     }
 
     /**
-     * Write the bytes to byte array.
+     * Writes the bytes to the byte array.
      * @param b the bytes to write
      * @param off The start offset
      * @param len The number of bytes to write
@@ -116,7 +121,7 @@ public abstract class AbstractByteArrayOutputStream extends OutputStream {
     public abstract void write(final byte[] b, final int off, final int len);
 
     /**
-     * Write the bytes to byte array.
+     * Writes the bytes to the byte array.
      * @param b the bytes to write
      * @param off The start offset
      * @param len The number of bytes to write
@@ -201,7 +206,8 @@ public abstract class AbstractByteArrayOutputStream extends OutputStream {
     }
 
     /**
-     * Return the current size of the byte array.
+     * Returns the current size of the byte array.
+     *
      * @return the current size of the byte array
      */
     public abstract int size();

--- a/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
@@ -41,6 +41,7 @@ import static org.apache.commons.io.IOUtils.EOF;
  * Closing an {@code AbstractByteArrayOutputStream} has no effect. The methods in
  * this class can be called after the stream has been closed without
  * generating an {@code IOException}.
+ * </p>
  * <p>
  * This is the base for an alternative implementation of the
  * {@link java.io.ByteArrayOutputStream} class. The original implementation
@@ -52,6 +53,7 @@ import static org.apache.commons.io.IOUtils.EOF;
  * like the original. The only exception is the deprecated
  * {@link java.io.ByteArrayOutputStream#toString(int)} method that has been
  * ignored.
+ * </p>
  *
  * @since 2.7
  */

--- a/src/main/java/org/apache/commons/io/output/ByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ByteArrayOutputStream.java
@@ -102,6 +102,7 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
      * same data as result InputStream.
      * <p>
      * This method is useful where,
+     * </p>
      * <ul>
      * <li>Source InputStream is slow.</li>
      * <li>It has network resources associated, so we cannot keep it open for
@@ -128,6 +129,7 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
      * same data as result InputStream.
      * <p>
      * This method is useful where,
+     * </p>
      * <ul>
      * <li>Source InputStream is slow.</li>
      * <li>It has network resources associated, so we cannot keep it open for

--- a/src/main/java/org/apache/commons/io/output/ByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ByteArrayOutputStream.java
@@ -112,7 +112,6 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
      * avoids unnecessary allocation and copy of byte[].<br>
      * This method buffers the input internally, so there is no need to use a
      * <code>BufferedInputStream</code>.
-     * </p>
      *
      * @param input Stream to be fully buffered.
      * @return A fully buffered stream.
@@ -139,7 +138,6 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
      * avoids unnecessary allocation and copy of byte[].<br>
      * This method buffers the input internally, so there is no need to use a
      * <code>BufferedInputStream</code>.
-     * </p>
      *
      * @param input Stream to be fully buffered.
      * @param size the initial buffer size

--- a/src/main/java/org/apache/commons/io/output/ByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ByteArrayOutputStream.java
@@ -20,14 +20,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 /**
  * This class implements a ThreadSafe version of
  * {@link AbstractByteArrayOutputStream} using instance
  * synchronisation.
  */
-@ThreadSafe
+//@ThreadSafe
 public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
 
     /**

--- a/src/main/java/org/apache/commons/io/output/ByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ByteArrayOutputStream.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
- * This class implements a ThreadSafe version of
+ * Implements a ThreadSafe version of
  * {@link AbstractByteArrayOutputStream} using instance
  * synchronisation.
  */
@@ -112,6 +112,7 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
      * avoids unnecessary allocation and copy of byte[].<br>
      * This method buffers the input internally, so there is no need to use a
      * <code>BufferedInputStream</code>.
+     * </p>
      *
      * @param input Stream to be fully buffered.
      * @return A fully buffered stream.
@@ -138,6 +139,7 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
      * avoids unnecessary allocation and copy of byte[].<br>
      * This method buffers the input internally, so there is no need to use a
      * <code>BufferedInputStream</code>.
+     * </p>
      *
      * @param input Stream to be fully buffered.
      * @param size the initial buffer size

--- a/src/main/java/org/apache/commons/io/output/FastByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/FastByteArrayOutputStream.java
@@ -20,21 +20,22 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import javax.annotation.concurrent.ThreadSafe;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
- * This class implements a ThreadSafe version of
- * {@link AbstractByteArrayOutputStream} using instance
- * synchronisation.
+ * This class implements a version of {@link AbstractByteArrayOutputStream}
+ * <b>without</b> any concurrent thread safety.
+ *
+ * @since 2.7
  */
-@ThreadSafe
-public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
+@NotThreadSafe
+public final class FastByteArrayOutputStream extends AbstractByteArrayOutputStream {
 
     /**
      * Creates a new byte array output stream. The buffer capacity is
      * initially 1024 bytes, though its size increases if necessary.
      */
-    public ByteArrayOutputStream() {
+    public FastByteArrayOutputStream() {
         this(DEFAULT_SIZE);
     }
 
@@ -45,14 +46,12 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
      * @param size  the initial size
      * @throws IllegalArgumentException if size is negative
      */
-    public ByteArrayOutputStream(final int size) {
+    public FastByteArrayOutputStream(final int size) {
         if (size < 0) {
             throw new IllegalArgumentException(
                 "Negative initial size: " + size);
         }
-        synchronized (this) {
-            needNewBuffer(size);
-        }
+        needNewBuffer(size);
     }
 
     @Override
@@ -66,23 +65,21 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
         } else if (len == 0) {
             return;
         }
-        synchronized (this) {
-            writeImpl(b, off, len);
-        }
+        writeImpl(b, off, len);
     }
 
     @Override
-    public synchronized void write(final int b) {
+    public void write(final int b) {
         writeImpl(b);
     }
 
     @Override
-    public synchronized int write(final InputStream in) throws IOException {
+    public int write(final InputStream in) throws IOException {
         return writeImpl(in);
     }
 
     @Override
-    public synchronized int size() {
+    public int size() {
         return count;
     }
 
@@ -90,19 +87,19 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
      * @see java.io.ByteArrayOutputStream#reset()
      */
     @Override
-    public synchronized void reset() {
+    public void reset() {
         resetImpl();
     }
 
     @Override
-    public synchronized void writeTo(final OutputStream out) throws IOException {
+    public void writeTo(final OutputStream out) throws IOException {
         writeToImpl(out);
     }
 
     /**
      * Fetches entire contents of an <code>InputStream</code> and represent
      * same data as result InputStream.
-     * <p>
+     *
      * This method is useful where,
      * <ul>
      * <li>Source InputStream is slow.</li>
@@ -118,7 +115,6 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
      * @param input Stream to be fully buffered.
      * @return A fully buffered stream.
      * @throws IOException if an I/O error occurs
-     * @since 2.0
      */
     public static InputStream toBufferedInputStream(final InputStream input)
             throws IOException {
@@ -145,24 +141,23 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
      * @param size the initial buffer size
      * @return A fully buffered stream.
      * @throws IOException if an I/O error occurs
-     * @since 2.5
      */
     public static InputStream toBufferedInputStream(final InputStream input, final int size)
             throws IOException {
         // It does not matter if a ByteArrayOutputStream is not closed as close() is a no-op
         @SuppressWarnings("resource")
-        final ByteArrayOutputStream output = new ByteArrayOutputStream(size);
+        final FastByteArrayOutputStream output = new FastByteArrayOutputStream(size);
         output.write(input);
         return output.toInputStream();
     }
 
     @Override
-    public synchronized InputStream toInputStream() {
+    public InputStream toInputStream() {
         return toInputStreamImpl();
     }
 
     @Override
-    public synchronized byte[] toByteArray() {
+    public byte[] toByteArray() {
         return toByteArrayImpl();
     }
 }

--- a/src/main/java/org/apache/commons/io/output/FastByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/FastByteArrayOutputStream.java
@@ -20,15 +20,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import javax.annotation.concurrent.NotThreadSafe;
-
 /**
  * This class implements a version of {@link AbstractByteArrayOutputStream}
  * <b>without</b> any concurrent thread safety.
  *
  * @since 2.7
  */
-@NotThreadSafe
+//@NotThreadSafe
 public final class FastByteArrayOutputStream extends AbstractByteArrayOutputStream {
 
     /**

--- a/src/main/java/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream.java
@@ -27,13 +27,13 @@ import java.io.OutputStream;
  * @since 2.7
  */
 //@NotThreadSafe
-public final class FastByteArrayOutputStream extends AbstractByteArrayOutputStream {
+public final class UnsynchronizedByteArrayOutputStream extends AbstractByteArrayOutputStream {
 
     /**
      * Creates a new byte array output stream. The buffer capacity is
      * initially 1024 bytes, though its size increases if necessary.
      */
-    public FastByteArrayOutputStream() {
+    public UnsynchronizedByteArrayOutputStream() {
         this(DEFAULT_SIZE);
     }
 
@@ -44,7 +44,7 @@ public final class FastByteArrayOutputStream extends AbstractByteArrayOutputStre
      * @param size  the initial size
      * @throws IllegalArgumentException if size is negative
      */
-    public FastByteArrayOutputStream(final int size) {
+    public UnsynchronizedByteArrayOutputStream(final int size) {
         if (size < 0) {
             throw new IllegalArgumentException(
                 "Negative initial size: " + size);
@@ -144,7 +144,7 @@ public final class FastByteArrayOutputStream extends AbstractByteArrayOutputStre
             throws IOException {
         // It does not matter if a ByteArrayOutputStream is not closed as close() is a no-op
         @SuppressWarnings("resource")
-        final FastByteArrayOutputStream output = new FastByteArrayOutputStream(size);
+        final UnsynchronizedByteArrayOutputStream output = new UnsynchronizedByteArrayOutputStream(size);
         output.write(input);
         return output.toInputStream();
     }

--- a/src/main/java/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
- * This class implements a version of {@link AbstractByteArrayOutputStream}
+ * Implements a version of {@link AbstractByteArrayOutputStream}
  * <b>without</b> any concurrent thread safety.
  *
  * @since 2.7
@@ -97,7 +97,7 @@ public final class UnsynchronizedByteArrayOutputStream extends AbstractByteArray
     /**
      * Fetches entire contents of an <code>InputStream</code> and represent
      * same data as result InputStream.
-     *
+     * <p>
      * This method is useful where,
      * <ul>
      * <li>Source InputStream is slow.</li>
@@ -109,6 +109,7 @@ public final class UnsynchronizedByteArrayOutputStream extends AbstractByteArray
      * avoids unnecessary allocation and copy of byte[].<br>
      * This method buffers the input internally, so there is no need to use a
      * <code>BufferedInputStream</code>.
+     * </p>
      *
      * @param input Stream to be fully buffered.
      * @return A fully buffered stream.
@@ -134,6 +135,7 @@ public final class UnsynchronizedByteArrayOutputStream extends AbstractByteArray
      * avoids unnecessary allocation and copy of byte[].<br>
      * This method buffers the input internally, so there is no need to use a
      * <code>BufferedInputStream</code>.
+     * </p>
      *
      * @param input Stream to be fully buffered.
      * @param size the initial buffer size

--- a/src/main/java/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream.java
@@ -99,6 +99,7 @@ public final class UnsynchronizedByteArrayOutputStream extends AbstractByteArray
      * same data as result InputStream.
      * <p>
      * This method is useful where,
+     * </p>
      * <ul>
      * <li>Source InputStream is slow.</li>
      * <li>It has network resources associated, so we cannot keep it open for
@@ -124,6 +125,7 @@ public final class UnsynchronizedByteArrayOutputStream extends AbstractByteArray
      * same data as result InputStream.
      * <p>
      * This method is useful where,
+     * </p>
      * <ul>
      * <li>Source InputStream is slow.</li>
      * <li>It has network resources associated, so we cannot keep it open for

--- a/src/main/java/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream.java
@@ -109,7 +109,6 @@ public final class UnsynchronizedByteArrayOutputStream extends AbstractByteArray
      * avoids unnecessary allocation and copy of byte[].<br>
      * This method buffers the input internally, so there is no need to use a
      * <code>BufferedInputStream</code>.
-     * </p>
      *
      * @param input Stream to be fully buffered.
      * @return A fully buffered stream.
@@ -135,7 +134,6 @@ public final class UnsynchronizedByteArrayOutputStream extends AbstractByteArray
      * avoids unnecessary allocation and copy of byte[].<br>
      * This method buffers the input internally, so there is no need to use a
      * <code>BufferedInputStream</code>.
-     * </p>
      *
      * @param input Stream to be fully buffered.
      * @param size the initial buffer size

--- a/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTestCase.java
+++ b/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTestCase.java
@@ -329,10 +329,10 @@ public class ByteArrayOutputStreamTestCase {
 
     private static Stream<Arguments> baosFactories() {
         final BAOSFactory syncBaosFactory = size -> new ByteArrayOutputStream(size);
-        final BAOSFactory nonSyncBaosFactory = size -> new FastByteArrayOutputStream(size);
+        final BAOSFactory unSyncBaosFactory = size -> new UnsynchronizedByteArrayOutputStream(size);
         return Stream.of(
                 Arguments.of(ByteArrayOutputStream.class.getSimpleName(), syncBaosFactory),
-                Arguments.of(FastByteArrayOutputStream.class.getSimpleName(), nonSyncBaosFactory)
+                Arguments.of(UnsynchronizedByteArrayOutputStream.class.getSimpleName(), unSyncBaosFactory)
         );
     }
 
@@ -347,14 +347,14 @@ public class ByteArrayOutputStreamTestCase {
     private static Stream<Arguments> toBufferedInputStreamFunctionFactories() {
         final IOFunction<InputStream, InputStream> syncBaosToBufferedInputStream = ByteArrayOutputStream::toBufferedInputStream;
         final IOFunction<InputStream, InputStream> syncBaosToBufferedInputStreamWithSize = is -> ByteArrayOutputStream.toBufferedInputStream(is, 1024);
-        final IOFunction<InputStream, InputStream> nonSyncBaosToBufferedInputStream = FastByteArrayOutputStream::toBufferedInputStream;
-        final IOFunction<InputStream, InputStream> nonSyncBaosToBufferedInputStreamWithSize = is -> FastByteArrayOutputStream.toBufferedInputStream(is, 1024);
+        final IOFunction<InputStream, InputStream> unSyncBaosToBufferedInputStream = UnsynchronizedByteArrayOutputStream::toBufferedInputStream;
+        final IOFunction<InputStream, InputStream> unSyncBaosToBufferedInputStreamWithSize = is -> UnsynchronizedByteArrayOutputStream.toBufferedInputStream(is, 1024);
 
         return Stream.of(
             Arguments.of("ByteArrayOutputStream.toBufferedInputStream(InputStream)", syncBaosToBufferedInputStream),
             Arguments.of("ByteArrayOutputStream.toBufferedInputStream(InputStream, int)", syncBaosToBufferedInputStreamWithSize),
-            Arguments.of("FastByteArrayOutputStream.toBufferedInputStream(InputStream)", nonSyncBaosToBufferedInputStream),
-            Arguments.of("FastByteArrayOutputStream.toBufferedInputStream(InputStream, int)", nonSyncBaosToBufferedInputStreamWithSize)
+            Arguments.of("UnsynchronizedByteArrayOutputStream.toBufferedInputStream(InputStream)", unSyncBaosToBufferedInputStream),
+            Arguments.of("UnsynchronizedByteArrayOutputStream.toBufferedInputStream(InputStream, int)", unSyncBaosToBufferedInputStreamWithSize)
         );
     }
 

--- a/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTestCase.java
+++ b/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTestCase.java
@@ -329,10 +329,10 @@ public class ByteArrayOutputStreamTestCase {
 
     private static Stream<Arguments> baosFactories() {
         final BAOSFactory syncBaosFactory = size -> new ByteArrayOutputStream(size);
-        final BAOSFactory nonSyncBaos = size -> new FastByteArrayOutputStream(size);
+        final BAOSFactory nonSyncBaosFactory = size -> new FastByteArrayOutputStream(size);
         return Stream.of(
                 Arguments.of(ByteArrayOutputStream.class.getSimpleName(), syncBaosFactory),
-                Arguments.of(FastByteArrayOutputStream.class.getSimpleName(), nonSyncBaos)
+                Arguments.of(FastByteArrayOutputStream.class.getSimpleName(), nonSyncBaosFactory)
         );
     }
 

--- a/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTestCase.java
+++ b/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTestCase.java
@@ -104,6 +104,13 @@ public class ByteArrayOutputStreamTestCase {
 
     @ParameterizedTest(name = "[{index}] {0}")
     @MethodSource("baosFactories")
+    public void testWriteZero(final String baosName, final BAOSFactory baosFactory) {
+        final AbstractByteArrayOutputStream baout = baosFactory.instance();
+        baout.write(new byte[0], 0, 0);
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}")
+    @MethodSource("baosFactories")
     public void testInvalidWriteOffsetUnder(final String baosName, final BAOSFactory baosFactory) {
         final AbstractByteArrayOutputStream baout = baosFactory.instance();
         assertThrows(IndexOutOfBoundsException.class, () ->
@@ -328,19 +335,38 @@ public class ByteArrayOutputStreamTestCase {
     }
 
     private static Stream<Arguments> baosFactories() {
-        final BAOSFactory syncBaosFactory = size -> new ByteArrayOutputStream(size);
-        final BAOSFactory unSyncBaosFactory = size -> new UnsynchronizedByteArrayOutputStream(size);
         return Stream.of(
-                Arguments.of(ByteArrayOutputStream.class.getSimpleName(), syncBaosFactory),
-                Arguments.of(UnsynchronizedByteArrayOutputStream.class.getSimpleName(), unSyncBaosFactory)
+                Arguments.of(ByteArrayOutputStream.class.getSimpleName(), new ByteArrayOutputStreamFactory()),
+                Arguments.of(UnsynchronizedByteArrayOutputStream.class.getSimpleName(), new UnsynchronizedByteArrayOutputStreamFactory())
         );
     }
 
-    @FunctionalInterface
-    private interface BAOSFactory {
-        default AbstractByteArrayOutputStream instance() {
-            return instance(AbstractByteArrayOutputStream.DEFAULT_SIZE);
+    private static class ByteArrayOutputStreamFactory implements BAOSFactory {
+        @Override
+        public AbstractByteArrayOutputStream instance() {
+            return new ByteArrayOutputStream();
         }
+
+        @Override
+        public AbstractByteArrayOutputStream instance(final int size) {
+            return new ByteArrayOutputStream(size);
+        }
+    }
+
+    private static class UnsynchronizedByteArrayOutputStreamFactory implements BAOSFactory {
+        @Override
+        public AbstractByteArrayOutputStream instance() {
+            return new UnsynchronizedByteArrayOutputStream();
+        }
+
+        @Override
+        public AbstractByteArrayOutputStream instance(final int size) {
+            return new UnsynchronizedByteArrayOutputStream(size);
+        }
+    }
+
+    private interface BAOSFactory<T extends AbstractByteArrayOutputStream> {
+        AbstractByteArrayOutputStream instance();
         AbstractByteArrayOutputStream instance(final int size);
     }
 


### PR DESCRIPTION
This abstracts the functionality of `ByteArrayOutputStream` into `AbstractByteArrayOutputStream`.  Synchronized and non-synchronized (for performance) implementations are then provided in `ByteArrayOutputStream` and `FastByteArrayOutputStream`.

Tests are also provided.

p.s. I have just submitted by ICLA by email.