### PR TITLE
Unsynchronized ByteArrayInputStream implementation

### DIFF
--- a/src/main/java/org/apache/commons/io/input/UnsynchronizedByteArrayInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/UnsynchronizedByteArrayInputStream.java
@@ -57,6 +57,8 @@ public class UnsynchronizedByteArrayInputStream extends InputStream {
     private int markedOffset;
 
     /**
+     * Creates a new byte array input stream.
+     *
      * @param data the buffer
      */
     public UnsynchronizedByteArrayInputStream(final byte[] data) {
@@ -68,6 +70,8 @@ public class UnsynchronizedByteArrayInputStream extends InputStream {
     }
 
     /**
+     * Creates a new byte array input stream.
+     *
      * @param data the buffer
      * @param offset the offset into the buffer
      *
@@ -86,6 +90,8 @@ public class UnsynchronizedByteArrayInputStream extends InputStream {
 
 
     /**
+     * Creates a new byte array input stream.
+     *
      * @param data the buffer
      * @param offset the offset into the buffer
      * @param length the length of the buffer

--- a/src/main/java/org/apache/commons/io/input/UnsynchronizedByteArrayInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/UnsynchronizedByteArrayInputStream.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.input;
+
+import java.io.InputStream;
+import java.util.Objects;
+
+import static java.lang.Math.min;
+
+/**
+ * This is an alternative to {@link java.io.ByteArrayInputStream}
+ * which removes the synchronization overhead for non-concurrent
+ * access; as such this class is not thread-safe.
+ *
+ * @since 2.7
+ */
+//@NotThreadSafe
+public class UnsynchronizedByteArrayInputStream extends InputStream {
+
+    public static final int END_OF_STREAM = -1;
+
+    /**
+     * The underlying data buffer.
+     */
+    private final byte[] data;
+
+    /**
+     * End Of Data.
+     *
+     * Similar to data.length,
+     * i.e. the last readable offset + 1.
+     */
+    private final int eod;
+
+    /**
+     * Current offset in the data buffer.
+     */
+    private int offset;
+
+    /**
+     * The current mark (if any).
+     */
+    private int markedOffset;
+
+    /**
+     * @param data the buffer
+     */
+    public UnsynchronizedByteArrayInputStream(final byte[] data) {
+        Objects.requireNonNull(data);
+        this.data = data;
+        this.offset = 0;
+        this.eod = data.length;
+        this.markedOffset = this.offset;
+    }
+
+    /**
+     * @param data the buffer
+     * @param offset the offset into the buffer
+     *
+     * @throws IllegalArgumentException if the offset is less than zero
+     */
+    public UnsynchronizedByteArrayInputStream(final byte[] data, final int offset) {
+        Objects.requireNonNull(data);
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset cannot be negative");
+        }
+        this.data = data;
+        this.offset = min(offset, data.length > 0 ? data.length: offset);
+        this.eod = data.length;
+        this.markedOffset = this.offset;
+    }
+
+
+    /**
+     * @param data the buffer
+     * @param offset the offset into the buffer
+     * @param length the length of the buffer
+     *
+     * @throws IllegalArgumentException if the offset or length less than zero
+     */
+    public UnsynchronizedByteArrayInputStream(final byte[] data, final int offset, final int length) {
+        Objects.requireNonNull(data);
+        if (offset < 0) {
+            throw new IllegalArgumentException("offset cannot be negative");
+        }
+        if (length < 0) {
+            throw new IllegalArgumentException("length cannot be negative");
+        }
+        this.data = data;
+        this.offset = min(offset, data.length > 0 ? data.length : offset);
+        this.eod = min(this.offset + length, data.length);
+        this.markedOffset = this.offset;
+    }
+
+    @Override
+    public int available() {
+        return offset < eod ? eod - offset : 0;
+    }
+
+    @Override
+    public int read() {
+        return offset < eod ? data[offset++] & 0xff : END_OF_STREAM;
+    }
+
+    @Override
+    public int read(final byte[] b) {
+        Objects.requireNonNull(b);
+        return read(b, 0, b.length);
+    }
+
+    @Override
+    public int read(final byte[] b, final int off, final int len) {
+        Objects.requireNonNull(b);
+        if (off < 0 || len < 0 || off + len > b.length) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        if (offset >= eod) {
+            return END_OF_STREAM;
+        }
+
+        int actualLen = eod - offset;
+        if (len < actualLen) {
+            actualLen = len;
+        }
+        if (actualLen <= 0) {
+            return 0;
+        }
+        System.arraycopy(data, offset, b, off, actualLen);
+        offset += actualLen;
+        return actualLen;
+    }
+
+    @Override
+    public long skip(final long n) {
+        if(n < 0) {
+            throw new IllegalArgumentException("Skipping backward is not supported");
+        }
+
+        long actualSkip = eod - offset;
+        if (n < actualSkip) {
+            actualSkip = n;
+        }
+
+        offset += actualSkip;
+        return actualSkip;
+    }
+
+    @Override
+    public boolean markSupported() {
+        return true;
+    }
+
+    @Override
+    public void mark(final int readlimit) {
+        this.markedOffset = this.offset;
+    }
+
+    @Override
+    public void reset() {
+        this.offset = this.markedOffset;
+    }
+}

--- a/src/main/java/org/apache/commons/io/output/ByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ByteArrayOutputStream.java
@@ -158,7 +158,7 @@ public class ByteArrayOutputStream extends AbstractByteArrayOutputStream {
 
     @Override
     public synchronized InputStream toInputStream() {
-        return toInputStreamImpl();
+        return toInputStreamImpl(java.io.ByteArrayInputStream::new);
     }
 
     @Override

--- a/src/main/java/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/UnsynchronizedByteArrayOutputStream.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.io.output;
 
+import org.apache.commons.io.input.UnsynchronizedByteArrayInputStream;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -153,7 +155,7 @@ public final class UnsynchronizedByteArrayOutputStream extends AbstractByteArray
 
     @Override
     public InputStream toInputStream() {
-        return toInputStreamImpl();
+        return toInputStreamImpl(UnsynchronizedByteArrayInputStream::new);
     }
 
     @Override

--- a/src/test/java/org/apache/commons/io/input/UnsynchronizedByteArrayInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/UnsynchronizedByteArrayInputStreamTest.java
@@ -1,0 +1,341 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.input;
+
+import org.junit.jupiter.api.Test;
+
+import static org.apache.commons.io.input.UnsynchronizedByteArrayInputStream.END_OF_STREAM;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Basic unit tests for the alternative ByteArrayInputStream implementation.
+ */
+public class UnsynchronizedByteArrayInputStreamTest {
+
+    @Test
+    public void testConstructor1() {
+        final byte[] empty = new byte[0];
+        final byte[] one = new byte[1];
+        final byte[] some = new byte[25];
+
+        UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(empty);
+        assertEquals(empty.length, is.available());
+
+        is = new UnsynchronizedByteArrayInputStream(one);
+        assertEquals(one.length, is.available());
+
+        is = new UnsynchronizedByteArrayInputStream(some);
+        assertEquals(some.length, is.available());
+    }
+
+    @Test
+    public void testConstructor2() {
+        final byte[] empty = new byte[0];
+        final byte[] one = new byte[1];
+        final byte[] some = new byte[25];
+
+        UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(empty, 0);
+        assertEquals(empty.length, is.available());
+        is = new UnsynchronizedByteArrayInputStream(empty, 1);
+        assertEquals(0, is.available());
+
+        is = new UnsynchronizedByteArrayInputStream(one, 0);
+        assertEquals(one.length, is.available());
+        is = new UnsynchronizedByteArrayInputStream(one, 1);
+        assertEquals(0, is.available());
+        is = new UnsynchronizedByteArrayInputStream(one, 2);
+        assertEquals(0, is.available());
+
+        is = new UnsynchronizedByteArrayInputStream(some, 0);
+        assertEquals(some.length, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, 1);
+        assertEquals(some.length - 1, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, 10);
+        assertEquals(some.length - 10, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, some.length);
+        assertEquals(0, is.available());
+    }
+
+    @Test
+    public void testConstructor3() {
+        final byte[] empty = new byte[0];
+        final byte[] one = new byte[1];
+        final byte[] some = new byte[25];
+
+        UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(empty, 0);
+        assertEquals(empty.length, is.available());
+        is = new UnsynchronizedByteArrayInputStream(empty, 1);
+        assertEquals(0, is.available());
+        is = new UnsynchronizedByteArrayInputStream(empty, 0,1);
+        assertEquals(0, is.available());
+        is = new UnsynchronizedByteArrayInputStream(empty, 1,1);
+        assertEquals(0, is.available());
+
+        is = new UnsynchronizedByteArrayInputStream(one, 0);
+        assertEquals(one.length, is.available());
+        is = new UnsynchronizedByteArrayInputStream(one, 1);
+        assertEquals(one.length - 1, is.available());
+        is = new UnsynchronizedByteArrayInputStream(one, 2);
+        assertEquals(0, is.available());
+        is = new UnsynchronizedByteArrayInputStream(one, 0, 1);
+        assertEquals(1, is.available());
+        is = new UnsynchronizedByteArrayInputStream(one, 1, 1);
+        assertEquals(0, is.available());
+        is = new UnsynchronizedByteArrayInputStream(one, 0, 2);
+        assertEquals(1, is.available());
+        is = new UnsynchronizedByteArrayInputStream(one, 2, 1);
+        assertEquals(0, is.available());
+        is = new UnsynchronizedByteArrayInputStream(one, 2, 2);
+        assertEquals(0, is.available());
+
+        is = new UnsynchronizedByteArrayInputStream(some, 0);
+        assertEquals(some.length, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, 1);
+        assertEquals(some.length - 1, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, 10);
+        assertEquals(some.length - 10, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, some.length);
+        assertEquals(0, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, some.length, some.length);
+        assertEquals(0, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, some.length - 1, some.length);
+        assertEquals(1, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, 0, 7);
+        assertEquals(7, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, 7, 7);
+        assertEquals(7, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, 0, some.length * 2);
+        assertEquals(some.length, is.available());
+        is = new UnsynchronizedByteArrayInputStream(some, some.length - 1, 7);
+        assertEquals(1, is.available());
+    }
+
+    @Test
+    public void testInvalidConstructor2OffsetUnder() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new UnsynchronizedByteArrayInputStream(new byte[0], -1);
+        });
+    }
+
+    @Test
+    public void testInvalidConstructor3OffsetUnder() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new UnsynchronizedByteArrayInputStream(new byte[0], -1, 1);
+        });
+    }
+
+    @Test
+    public void testInvalidConstructor3LengthUnder() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new UnsynchronizedByteArrayInputStream(new byte[0], 0, -1);
+        });
+    }
+
+    @Test
+    public void testReadSingle() {
+        UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[0]);
+        assertEquals(END_OF_STREAM, is.read());
+
+        is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertEquals(0xa, is.read());
+        assertEquals(0xb, is.read());
+        assertEquals(0xc, is.read());
+        assertEquals(END_OF_STREAM, is.read());
+    }
+
+    @Test
+    public void testReadArray() {
+        byte[] buf = new byte[10];
+        UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[0]);
+        int read = is.read(buf);
+        assertEquals(END_OF_STREAM, read);
+        assertArrayEquals(new byte[10], buf);
+
+        buf = new byte[0];
+        is = new UnsynchronizedByteArrayInputStream(new byte[]{(byte) 0xa, (byte) 0xb, (byte) 0xc});
+        read = is.read(buf);
+        assertEquals(0, read);
+
+        buf = new byte[10];
+        is = new UnsynchronizedByteArrayInputStream(new byte[]{(byte) 0xa, (byte) 0xb, (byte) 0xc});
+        read = is.read(buf);
+        assertEquals(3, read);
+        assertEquals(0xa, buf[0]);
+        assertEquals(0xb, buf[1]);
+        assertEquals(0xc, buf[2]);
+        assertEquals(0, buf[3]);
+
+        buf = new byte[2];
+        is = new UnsynchronizedByteArrayInputStream(new byte[]{(byte) 0xa, (byte) 0xb, (byte) 0xc});
+        read = is.read(buf);
+        assertEquals(2, read);
+        assertEquals(0xa, buf[0]);
+        assertEquals(0xb, buf[1]);
+        read = is.read(buf);
+        assertEquals(1, read);
+        assertEquals(0xc, buf[0]);
+    }
+
+    @Test
+    public void testInvalidReadArrayNull() {
+        final byte[] buf = null;
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertThrows(NullPointerException.class, () -> {
+            is.read(buf);
+        });
+    }
+
+    @Test
+    public void testReadArrayExplicit() {
+        byte[] buf = new byte[10];
+        UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[0]);
+        int read = is.read(buf, 0, 10);
+        assertEquals(END_OF_STREAM, read);
+        assertArrayEquals(new byte[10], buf);
+
+        buf = new byte[10];
+        is = new UnsynchronizedByteArrayInputStream(new byte[0]);
+        read = is.read(buf, 4, 2);
+        assertEquals(END_OF_STREAM, read);
+        assertArrayEquals(new byte[10], buf);
+
+        buf = new byte[10];
+        is = new UnsynchronizedByteArrayInputStream(new byte[0]);
+        read = is.read(buf, 4, 6);
+        assertEquals(END_OF_STREAM, read);
+        assertArrayEquals(new byte[10], buf);
+
+        buf = new byte[0];
+        is = new UnsynchronizedByteArrayInputStream(new byte[]{(byte) 0xa, (byte) 0xb, (byte) 0xc});
+        read = is.read(buf, 0,0);
+        assertEquals(0, read);
+
+        buf = new byte[10];
+        is = new UnsynchronizedByteArrayInputStream(new byte[]{(byte) 0xa, (byte) 0xb, (byte) 0xc});
+        read = is.read(buf, 0, 2);
+        assertEquals(2, read);
+        assertEquals(0xa, buf[0]);
+        assertEquals(0xb, buf[1]);
+        assertEquals(0, buf[2]);
+        read = is.read(buf, 0, 10);
+        assertEquals(1, read);
+        assertEquals(0xc, buf[0]);
+    }
+
+    @Test
+    public void testInvalidReadArrayExplicitOffsetUnder() {
+        final byte[] buf = new byte[0];
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            is.read(buf, -1, 1);
+        });
+    }
+
+    @Test
+    public void testInvalidReadArrayExplicitLenUnder() {
+        final byte[] buf = new byte[0];
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            is.read(buf, 0, -1);
+        });
+    }
+
+    @Test
+    public void testInvalidReadArrayExplicitRangeOver() {
+        final byte[] buf = new byte[0];
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            is.read(buf, 0, 1);
+        });
+    }
+
+    @Test
+    public void testMarkReset() {
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertTrue(is.markSupported());
+        assertEquals(0xa, is.read());
+        assertTrue(is.markSupported());
+
+        is.mark(10);
+
+        assertEquals(0xb, is.read());
+        assertEquals(0xc, is.read());
+
+        is.reset();
+
+        assertEquals(0xb, is.read());
+        assertEquals(0xc, is.read());
+        assertEquals(END_OF_STREAM, is.read());
+
+        is.reset();
+
+        assertEquals(0xb, is.read());
+        assertEquals(0xc, is.read());
+        assertEquals(END_OF_STREAM, is.read());
+    }
+
+    @Test
+    public void testSkip() {
+        UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertEquals(3, is.available());
+
+        is.skip(1);
+        assertEquals(2, is.available());
+        assertEquals(0xb, is.read());
+
+        is.skip(1);
+        assertEquals(0, is.available());
+        assertEquals(END_OF_STREAM, is.read());
+
+
+        is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertEquals(3, is.available());
+        is.skip(0);
+        assertEquals(3, is.available());
+        assertEquals(0xa, is.read());
+
+
+        is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertEquals(3, is.available());
+        is.skip(2);
+        assertEquals(1, is.available());
+        assertEquals(0xc, is.read());
+        assertEquals(END_OF_STREAM, is.read());
+
+
+        is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertEquals(3, is.available());
+        is.skip(3);
+        assertEquals(0, is.available());
+        assertEquals(END_OF_STREAM, is.read());
+
+
+        is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertEquals(3, is.available());
+        is.skip(999);
+        assertEquals(0, is.available());
+        assertEquals(END_OF_STREAM, is.read());
+    }
+
+    @Test
+    public void testInavlidSkipNUnder() {
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertThrows(IllegalArgumentException.class, () -> {
+            is.skip(-1);
+        });
+    }
+}

--- a/src/test/java/org/apache/commons/io/input/UnsynchronizedByteArrayInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/UnsynchronizedByteArrayInputStreamTest.java
@@ -19,7 +19,10 @@ package org.apache.commons.io.input;
 import org.junit.jupiter.api.Test;
 
 import static org.apache.commons.io.input.UnsynchronizedByteArrayInputStream.END_OF_STREAM;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Basic unit tests for the alternative ByteArrayInputStream implementation.
@@ -132,13 +135,6 @@ public class UnsynchronizedByteArrayInputStreamTest {
     }
 
     @Test
-    public void testInvalidConstructor3OffsetUnder() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            new UnsynchronizedByteArrayInputStream(new byte[0], -1, 1);
-        });
-    }
-
-    @Test
     public void testInvalidConstructor3LengthUnder() {
         assertThrows(IllegalArgumentException.class, () -> {
             new UnsynchronizedByteArrayInputStream(new byte[0], 0, -1);
@@ -146,12 +142,76 @@ public class UnsynchronizedByteArrayInputStreamTest {
     }
 
     @Test
-    public void testReadSingle() {
-        UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[0]);
+    public void testInvalidConstructor3OffsetUnder() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            new UnsynchronizedByteArrayInputStream(new byte[0], -1, 1);
+        });
+    }
+
+    @Test
+    public void testInvalidReadArrayExplicitLenUnder() {
+        final byte[] buf = new byte[0];
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            is.read(buf, 0, -1);
+        });
+    }
+
+    @Test
+    public void testInvalidReadArrayExplicitOffsetUnder() {
+        final byte[] buf = new byte[0];
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            is.read(buf, -1, 1);
+        });
+    }
+
+    @Test
+    public void testInvalidReadArrayExplicitRangeOver() {
+        final byte[] buf = new byte[0];
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertThrows(IndexOutOfBoundsException.class, () -> {
+            is.read(buf, 0, 1);
+        });
+    }
+
+    @Test
+    public void testInvalidReadArrayNull() {
+        final byte[] buf = null;
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertThrows(NullPointerException.class, () -> {
+            is.read(buf);
+        });
+    }
+
+    @Test
+    public void testInvalidSkipNUnder() {
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertThrows(IllegalArgumentException.class, () -> {
+            is.skip(-1);
+        });
+    }
+
+    @Test
+    public void testMarkReset() {
+        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertTrue(is.markSupported());
+        assertEquals(0xa, is.read());
+        assertTrue(is.markSupported());
+
+        is.mark(10);
+
+        assertEquals(0xb, is.read());
+        assertEquals(0xc, is.read());
+
+        is.reset();
+
+        assertEquals(0xb, is.read());
+        assertEquals(0xc, is.read());
         assertEquals(END_OF_STREAM, is.read());
 
-        is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
-        assertEquals(0xa, is.read());
+        is.reset();
+
         assertEquals(0xb, is.read());
         assertEquals(0xc, is.read());
         assertEquals(END_OF_STREAM, is.read());
@@ -188,15 +248,6 @@ public class UnsynchronizedByteArrayInputStreamTest {
         read = is.read(buf);
         assertEquals(1, read);
         assertEquals(0xc, buf[0]);
-    }
-
-    @Test
-    public void testInvalidReadArrayNull() {
-        final byte[] buf = null;
-        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
-        assertThrows(NullPointerException.class, () -> {
-            is.read(buf);
-        });
     }
 
     @Test
@@ -237,52 +288,12 @@ public class UnsynchronizedByteArrayInputStreamTest {
     }
 
     @Test
-    public void testInvalidReadArrayExplicitOffsetUnder() {
-        final byte[] buf = new byte[0];
-        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
-        assertThrows(IndexOutOfBoundsException.class, () -> {
-            is.read(buf, -1, 1);
-        });
-    }
-
-    @Test
-    public void testInvalidReadArrayExplicitLenUnder() {
-        final byte[] buf = new byte[0];
-        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
-        assertThrows(IndexOutOfBoundsException.class, () -> {
-            is.read(buf, 0, -1);
-        });
-    }
-
-    @Test
-    public void testInvalidReadArrayExplicitRangeOver() {
-        final byte[] buf = new byte[0];
-        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
-        assertThrows(IndexOutOfBoundsException.class, () -> {
-            is.read(buf, 0, 1);
-        });
-    }
-
-    @Test
-    public void testMarkReset() {
-        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
-        assertTrue(is.markSupported());
-        assertEquals(0xa, is.read());
-        assertTrue(is.markSupported());
-
-        is.mark(10);
-
-        assertEquals(0xb, is.read());
-        assertEquals(0xc, is.read());
-
-        is.reset();
-
-        assertEquals(0xb, is.read());
-        assertEquals(0xc, is.read());
+    public void testReadSingle() {
+        UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[0]);
         assertEquals(END_OF_STREAM, is.read());
 
-        is.reset();
-
+        is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
+        assertEquals(0xa, is.read());
         assertEquals(0xb, is.read());
         assertEquals(0xc, is.read());
         assertEquals(END_OF_STREAM, is.read());
@@ -329,13 +340,5 @@ public class UnsynchronizedByteArrayInputStreamTest {
         is.skip(999);
         assertEquals(0, is.available());
         assertEquals(END_OF_STREAM, is.read());
-    }
-
-    @Test
-    public void testInavlidSkipNUnder() {
-        final UnsynchronizedByteArrayInputStream is = new UnsynchronizedByteArrayInputStream(new byte[] {(byte)0xa, (byte)0xb, (byte)0xc});
-        assertThrows(IllegalArgumentException.class, () -> {
-            is.skip(-1);
-        });
     }
 }


### PR DESCRIPTION
Builds upon the previous work of https://github.com/apache/commons-io/pull/108 by adding an `UnsynchronizedByteArrayInputStream`.

Calls to `UnsynchronizedByteArrayOutputStream#toInputStream()` now return `UnsynchronizedByteArrayInputStream` as the implementation instead of `java.io.ByteArrayInputStream`.