### PR TITLE
IO-665  ensure that passing a null InputStream results in NPE with tests

### DIFF
--- a/src/main/java/org/apache/commons/io/input/XmlStreamReader.java
+++ b/src/main/java/org/apache/commons/io/input/XmlStreamReader.java
@@ -135,7 +135,7 @@ public class XmlStreamReader extends Reader {
      * @throws IOException thrown if there is a problem reading the file.
      */
     public XmlStreamReader(final File file) throws IOException {
-        this(new FileInputStream(file));
+        this(new FileInputStream(Objects.requireNonNull(file)));
     }
 
     /**
@@ -240,7 +240,7 @@ public class XmlStreamReader extends Reader {
      *         the URL.
      */
     public XmlStreamReader(final URL url) throws IOException {
-        this(url.openConnection(), null);
+        this(Objects.requireNonNull(url, "url").openConnection(), null);
     }
 
     /**
@@ -263,6 +263,7 @@ public class XmlStreamReader extends Reader {
      *         the URLConnection.
      */
     public XmlStreamReader(final URLConnection conn, final String defaultEncoding) throws IOException {
+        Objects.requireNonNull(conn, "conm");
         this.defaultEncoding = defaultEncoding;
         final boolean lenient = true;
         final String contentType = conn.getContentType();
@@ -335,6 +336,7 @@ public class XmlStreamReader extends Reader {
      */
     public XmlStreamReader(final InputStream inputStream, final String httpContentType,
             final boolean lenient, final String defaultEncoding) throws IOException {
+        Objects.requireNonNull(inputStream, "inputStream");
         this.defaultEncoding = defaultEncoding;
         final BOMInputStream bom = new BOMInputStream(new BufferedInputStream(inputStream, BUFFER_SIZE), false, BOMS);
         final BOMInputStream pis = new BOMInputStream(bom, true, XML_GUESS_BYTES);

--- a/src/main/java/org/apache/commons/io/input/XmlStreamReader.java
+++ b/src/main/java/org/apache/commons/io/input/XmlStreamReader.java
@@ -30,6 +30,7 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.text.MessageFormat;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -213,6 +214,7 @@ public class XmlStreamReader extends Reader {
      */
     public XmlStreamReader(final InputStream inputStream, final boolean lenient, final String defaultEncoding)
             throws IOException {
+        Objects.requireNonNull(inputStream, "inputStream");
         this.defaultEncoding = defaultEncoding;
         final BOMInputStream bom = new BOMInputStream(new BufferedInputStream(inputStream, BUFFER_SIZE), false, BOMS);
         final BOMInputStream pis = new BOMInputStream(bom, true, XML_GUESS_BYTES);

--- a/src/test/java/org/apache/commons/io/input/XmlStreamReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/XmlStreamReaderTest.java
@@ -84,7 +84,7 @@ public class XmlStreamReaderTest {
 
     @Test
     protected void testNullFileInput() throws IOException {
-        assertThrows(NullPointerException.class, ()-> new XmlStreamReader((File)null));
+        assertThrows(NullPointerException.class, () -> new XmlStreamReader((File)null));
     }
 
     @Test
@@ -94,12 +94,12 @@ public class XmlStreamReaderTest {
 
     @Test
     protected void testNullURLInput() throws IOException {
-         assertThrows(NullPointerException.class, ()-> new XmlStreamReader((URL)null));
+         assertThrows(NullPointerException.class, () -> new XmlStreamReader((URL)null));
     }
 
     @Test
     protected void testNullURLConnectionInput() throws IOException {
-          assertThrows(NullPointerException.class, ()-> new XmlStreamReader((URLConnection)null, "US-ASCII"));
+          assertThrows(NullPointerException.class, () -> new XmlStreamReader((URLConnection)null, "US-ASCII"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/input/XmlStreamReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/XmlStreamReaderTest.java
@@ -17,19 +17,24 @@
 package org.apache.commons.io.input;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.net.URL;
+import java.net.URLConnection;
 import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;
@@ -76,6 +81,26 @@ public class XmlStreamReaderTest {
         } catch (final IOException ex) {
             assertTrue(ex.getMessage().contains("Invalid encoding,"));
         }
+    }
+
+    @Test
+    protected void testNullFileInput() throws IOException {
+        assertThrows(NullPointerException.class, ()-> new XmlStreamReader((File)null));
+    }
+
+    @Test
+    protected void testNullInputStreamInput() throws IOException {
+        assertThrows(NullPointerException.class, () -> new XmlStreamReader((InputStream) null));
+    }
+
+    @Test
+    protected void testNullURLInput() throws IOException {
+         assertThrows(NullPointerException.class, ()-> new XmlStreamReader((URL)null));
+    }
+
+    @Test
+    protected void testNullURLConnectionInput() throws IOException {
+          assertThrows(NullPointerException.class, ()-> new XmlStreamReader((URLConnection)null, "US-ASCII"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/input/XmlStreamReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/XmlStreamReaderTest.java
@@ -34,7 +34,6 @@ import java.text.MessageFormat;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.Test;
 import org.junitpioneer.jupiter.DefaultLocale;


### PR DESCRIPTION
This pr adds a null check for the InputStream constructor of XmlStreamReader.  This makes it so that each contractor of type ( File, URL, URLConnection, InputStream ) throws NPE if passed a NULL for that type.

Tests were added as well for each type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apache/commons-io/112)
<!-- Reviewable:end -->
