### PR TITLE
Remove C-style array declaration

### DIFF
--- a/src/main/java/org/apache/commons/io/input/Tailer.java
+++ b/src/main/java/org/apache/commons/io/input/Tailer.java
@@ -130,7 +130,7 @@ public class Tailer implements Runnable {
     /**
      * Buffer on top of RandomAccessFile.
      */
-    private final byte inbuf[];
+    private final byte[] inbuf;
 
     /**
      * The file which will be tailed.


### PR DESCRIPTION
Remove C-style array declaration.
This is the only point in all project that use this instead of classic Java-style array declaration.