### PR TITLE
Prevent NullPointerException in ReversedLinesFileReader constructors

### DIFF
--- a/src/main/java/org/apache/commons/io/input/ReversedLinesFileReader.java
+++ b/src/main/java/org/apache/commons/io/input/ReversedLinesFileReader.java
@@ -133,7 +133,7 @@ public class ReversedLinesFileReader implements Closeable {
      */
     public ReversedLinesFileReader(final Path file, final int blockSize, final Charset encoding) throws IOException {
         this.blockSize = blockSize;
-        this.encoding = encoding;
+        this.encoding = Charsets.toCharset(encoding);
 
         // --- check & prepare encoding ---
         final Charset charset = Charsets.toCharset(encoding);
@@ -161,12 +161,12 @@ public class ReversedLinesFileReader implements Closeable {
             throw new UnsupportedEncodingException("For UTF-16, you need to specify the byte order (use UTF-16BE or " +
                     "UTF-16LE)");
         } else {
-            throw new UnsupportedEncodingException("Encoding " + encoding + " is not supported yet (feel free to " +
+            throw new UnsupportedEncodingException("Encoding " + this.encoding + " is not supported yet (feel free to " +
                     "submit a patch)");
         }
 
         // NOTE: The new line sequences are matched in the order given, so it is important that \r\n is BEFORE \n
-        newLineSequences = new byte[][] { "\r\n".getBytes(encoding), "\n".getBytes(encoding), "\r".getBytes(encoding) };
+        newLineSequences = new byte[][] { "\r\n".getBytes(this.encoding), "\n".getBytes(this.encoding), "\r".getBytes(this.encoding) };
 
         avoidNewlineSplitBufferSize = newLineSequences[0].length;
 

--- a/src/test/java/org/apache/commons/io/input/ReversedLinesFileReaderTestSimple.java
+++ b/src/test/java/org/apache/commons/io/input/ReversedLinesFileReaderTestSimple.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
+import java.nio.charset.Charset;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -66,6 +67,10 @@ public class ReversedLinesFileReaderTestSimple {
                 () -> new ReversedLinesFileReader(testFileEncodingBig5, IOUtils.DEFAULT_BUFFER_SIZE, "Big5").close());
     }
 
-
+    @Test
+    public void testNullEncoding() throws IOException, URISyntaxException {
+        new ReversedLinesFileReader(new File(this.getClass().getResource("/test-file-empty.bin").toURI()),
+                                    (Charset) null);
+    }
 
 }

--- a/src/test/java/org/apache/commons/io/input/ReversedLinesFileReaderTestSimple.java
+++ b/src/test/java/org/apache/commons/io/input/ReversedLinesFileReaderTestSimple.java
@@ -17,6 +17,7 @@
 package org.apache.commons.io.input;
 
 import static org.apache.commons.io.input.ReversedLinesFileReaderTestParamBlockSize.assertEqualsAndNoLineBreaks;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
@@ -26,11 +27,17 @@ import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.testtools.TestUtils;
+import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 
 public class ReversedLinesFileReaderTestSimple {
+
+    @TempDir
+    private static File temporaryFolder;
 
     private ReversedLinesFileReader reversedLinesFileReader;
 
@@ -69,8 +76,12 @@ public class ReversedLinesFileReaderTestSimple {
 
     @Test
     public void testNullEncoding() throws IOException, URISyntaxException {
-        new ReversedLinesFileReader(new File(this.getClass().getResource("/test-file-empty.bin").toURI()),
-                                    (Charset) null);
+        final File file = new File(temporaryFolder, "write.txt");
+        final String text = "Hello /u1234";
+        FileUtils.writeStringToFile(file, text, (Charset) null);
+        ReversedLinesFileReader rlfr =
+                new ReversedLinesFileReader(file, (Charset) null);
+        assertEquals(text, rlfr.readLine());
     }
 
 }

--- a/src/test/java/org/apache/commons/io/input/ReversedLinesFileReaderTestSimple.java
+++ b/src/test/java/org/apache/commons/io/input/ReversedLinesFileReaderTestSimple.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.io.TempDir;
 public class ReversedLinesFileReaderTestSimple {
 
     @TempDir
-    private static File temporaryFolder;
+    public static File temporaryFolder;
 
     private ReversedLinesFileReader reversedLinesFileReader;
 


### PR DESCRIPTION
In many parts of the Commons IO API, `null` may be passed as a Charset or the name of one, and Commons IO uses the platform's default character encoding.
I assumed that was the case for ReversedLinesFileReader, and the result was a null pointer exception.

Consider the following minimal example:

```
import java.io.File;
import java.io.IOException;
import java.nio.charset.Charset;
import org.apache.commons.io.input.ReversedLinesFileReader;

public class TestReversedLinesFileReader {
  public static void main(String[] args) throws IOException {
    ReversedLinesFileReader rfr =
        new ReversedLinesFileReader(new File("TestReversedLinesFileReader.java"),
                                    (Charset) null);
  }
}
```

Running this program results in:

```
Exception in thread "main" java.lang.NullPointerException
	at java.lang.String.getBytes(String.java:940)
	at org.apache.commons.io.input.ReversedLinesFileReader.<init>(ReversedLinesFileReader.java:130)
	at org.apache.commons.io.input.ReversedLinesFileReader.<init>(ReversedLinesFileReader.java:78)
	at TestReversedLinesFileReader.main(TestReversedLinesFileReader.java:8)
```

I assume that the `ReversedLinesFileReader` constructor is intended to accept `null` as an argument because of [this line](https://github.com/apache/commons-io/blob/6a78ef8903ef7c2c785b8d0cc08a150d1e2ba818/src/main/java/org/apache/commons/io/input/ReversedLinesFileReader.java#L139):

```
        final Charset charset = Charsets.toCharset(encoding);
```

which calls `toCharset(Charset)` which is a no-op unless its argument is `null`.  So there would be no purpose to that line except to handle a null `encoding` argument to the constructor.

The problem comes [a few lines later](https://github.com/apache/commons-io/blob/6a78ef8903ef7c2c785b8d0cc08a150d1e2ba818/src/main/java/org/apache/commons/io/input/ReversedLinesFileReader.java#L169) when the possibly-null value `encoding` is used:
This pull request changes the code so the `encoding` field is non-null even if the `encoding` formal parameter is null, and uses `this.encoding` instead of `encoding` in 4 locations.
I think that setting the field `encoding` to a non-null value is the right thing because there are three calls to `new String` that use `encoding` as if it is non-null.

An alternate fix would be to:
 * document the Charset argument as being non-null,
 * throw an exception within the constructor if a client passes null,
 * remove the declaration of the `charset` local variable, and
 * chang all uses of the `charset` local variable into uses of `encoding`.