### PR TITLE
Add a MarkShieldInputStream

### DIFF
--- a/src/main/java/org/apache/commons/io/input/MarkShieldInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/MarkShieldInputStream.java
@@ -31,7 +31,7 @@ import java.io.InputStream;
  * the stream, but it it is not desirable to allow marking of the stream.
  * </p>
  *
- * @since 2.8
+ * @since 2.8.0
  */
 public class MarkShieldInputStream extends ProxyInputStream {
 

--- a/src/main/java/org/apache/commons/io/input/MarkShieldInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/MarkShieldInputStream.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.input;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * This is an alternative to {@link java.io.ByteArrayInputStream}
+ * which removes the synchronization overhead for non-concurrent
+ * access; as such this class is not thread-safe.
+ *
+ * Proxy stream that prevents the underlying input stream from being marked/reset.
+ * <p>
+ * This class is typically used in cases where an input stream that supports
+ * marking needs to be passed to a component that wants to explicitly mark
+ * the stream, but it it is not desirable to allow marking of the stream.
+ * </p>
+ *
+ * @since 2.8
+ */
+public class MarkShieldInputStream extends ProxyInputStream {
+
+    /**
+     * Creates a proxy that shields the given input stream from being
+     * marked or rest.
+     *
+     * @param in underlying input stream
+     */
+    public MarkShieldInputStream(final InputStream in) {
+        super(in);
+    }
+
+    @SuppressWarnings("sync-override")
+    @Override
+    public void mark(final int readlimit) {
+        // no-op
+    }
+
+    @Override
+    public boolean markSupported() {
+        return false;
+    }
+
+    @SuppressWarnings("sync-override")
+    @Override
+    public void reset() throws IOException {
+        throw new IOException("mark/reset not supported");
+    }
+}

--- a/src/test/java/org/apache/commons/io/input/MarkShieldInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/MarkShieldInputStreamTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.input;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class MarkShieldInputStreamTest {
+
+    @Test
+    public void markIsNoOpWhenUnderlyingDoesNotSupport() throws IOException {
+        try (final MarkTestableInputStream in = new MarkTestableInputStream(new NullInputStream(64, false, false));
+             final MarkShieldInputStream msis = new MarkShieldInputStream(in)) {
+
+            msis.mark(1024);
+
+            assertEquals(0, in.markcount);
+            assertEquals(0, in.readlimit);
+        }
+    }
+
+    @Test
+    public void markIsNoOpWhenUnderlyingSupports() throws IOException {
+        try (final MarkTestableInputStream in = new MarkTestableInputStream(new NullInputStream(64, true, false));
+             final MarkShieldInputStream msis = new MarkShieldInputStream(in)) {
+
+            msis.mark(1024);
+
+            assertEquals(0, in.markcount);
+            assertEquals(0, in.readlimit);
+        }
+    }
+
+    @Test
+    public void markSupportedIsFalseWhenUnderlyingFalse() throws IOException {
+        // test wrapping an underlying stream which does NOT support marking
+        try (final InputStream is = new NullInputStream(64, false, false)) {
+            assertFalse(is.markSupported());
+
+            try (final MarkShieldInputStream msis = new MarkShieldInputStream(is)) {
+                assertFalse(msis.markSupported());
+            }
+        }
+    }
+
+    @Test
+    public void markSupportedIsFalseWhenUnderlyingTrue() throws IOException {
+        // test wrapping an underlying stream which supports marking
+        try (final InputStream is = new NullInputStream(64, true, false)) {
+            assertTrue(is.markSupported());
+
+            try (final MarkShieldInputStream msis = new MarkShieldInputStream(is)) {
+                assertFalse(msis.markSupported());
+            }
+        }
+    }
+
+    @Test
+    public void resetThrowsExceptionWhenUnderylingDoesNotSupport() throws IOException {
+        // test wrapping an underlying stream which does NOT support marking
+        try (final MarkShieldInputStream msis = new MarkShieldInputStream(
+                new NullInputStream(64, false, false))) {
+            assertThrows(IOException.class, () -> msis.reset());
+        }
+    }
+
+    @Test
+    public void resetThrowsExceptionWhenUnderylingSupports() throws IOException {
+        // test wrapping an underlying stream which supports marking
+        try (final MarkShieldInputStream msis = new MarkShieldInputStream(
+                new NullInputStream(64, true, false))) {
+            assertThrows(IOException.class, () -> msis.reset());
+        }
+    }
+
+    private static class MarkTestableInputStream extends ProxyInputStream {
+        int markcount;
+        int readlimit;
+
+        public MarkTestableInputStream(final InputStream in) {
+            super(in);
+        }
+
+        @SuppressWarnings("sync-override")
+        @Override
+        public void mark(final int readlimit) {
+            // record that `mark` was called
+            this.markcount++;
+            this.readlimit = readlimit;
+
+            // invoke on super
+            super.mark(readlimit);
+        }
+    }
+}


### PR DESCRIPTION
This is similar to the `CloseShieldInputStream` but it focuses on the mark, markSupported, and reset methods.

