### PR TITLE
Implemented CharSequenceReader.ready

### DIFF
--- a/src/main/java/org/apache/commons/io/input/CharSequenceReader.java
+++ b/src/main/java/org/apache/commons/io/input/CharSequenceReader.java
@@ -166,6 +166,16 @@ public class CharSequenceReader extends Reader implements Serializable {
     }
 
     /**
+     * Tells whether this stream is ready to be read.
+     *
+     * @return {@code true} if more characters from the character sequence are available, or {@code false} otherwise.
+     */
+    @Override
+    public boolean ready() {
+        return idx < end();
+    }
+
+    /**
      * Mark the current position.
      *
      * @param readAheadLimit ignored

--- a/src/test/java/org/apache/commons/io/input/CharSequenceReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/CharSequenceReaderTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.io.input;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -49,6 +50,43 @@ public class CharSequenceReaderTest {
         checkRead(subReader, "Foo");
         subReader.close();
         checkRead(subReader, "Foo");
+    }
+
+    @Test
+    public void testReady() throws IOException {
+        final Reader reader = new CharSequenceReader("FooBar");
+        assertTrue(reader.ready());
+        reader.skip(3);
+        assertTrue(reader.ready());
+        checkRead(reader, "Bar");
+        assertFalse(reader.ready());
+        reader.reset();
+        assertTrue(reader.ready());
+        reader.skip(2);
+        assertTrue(reader.ready());
+        reader.skip(10);
+        assertFalse(reader.ready());
+        reader.close();
+        assertTrue(reader.ready());
+        reader.skip(20);
+        assertFalse(reader.ready());
+
+        final Reader subReader = new CharSequenceReader("xFooBarx", 1, 7);
+        assertTrue(subReader.ready());
+        subReader.skip(3);
+        assertTrue(subReader.ready());
+        checkRead(subReader, "Bar");
+        assertFalse(subReader.ready());
+        subReader.reset();
+        assertTrue(subReader.ready());
+        subReader.skip(2);
+        assertTrue(subReader.ready());
+        subReader.skip(10);
+        assertFalse(subReader.ready());
+        subReader.close();
+        assertTrue(subReader.ready());
+        subReader.skip(20);
+        assertFalse(subReader.ready());
     }
 
     @Test


### PR DESCRIPTION
`Reader.ready()` should return
> True if the next read() is guaranteed not to block for input, false otherwise

The default implementation is to return false, and that's what `CharSequenceReader` inherits. This change overrides `ready()` to return `true` if there characters can still be returned.