### PR TITLE
CharSequenceReader.skip should return 0 instead of EOF on stream end

### DIFF
--- a/src/main/java/org/apache/commons/io/input/CharSequenceReader.java
+++ b/src/main/java/org/apache/commons/io/input/CharSequenceReader.java
@@ -272,7 +272,7 @@ public class CharSequenceReader extends Reader implements Serializable {
                     "Number of characters to skip is less than zero: " + n);
         }
         if (idx >= end()) {
-            return EOF;
+            return 0;
         }
         final int dest = (int)Math.min(end(), idx + n);
         final int count = dest - idx;

--- a/src/test/java/org/apache/commons/io/input/CharSequenceReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/CharSequenceReaderTest.java
@@ -89,11 +89,11 @@ public class CharSequenceReaderTest {
         final Reader reader = new CharSequenceReader("FooBar");
         assertEquals(3, reader.skip(3));
         checkRead(reader, "Bar");
-        assertEquals(-1, reader.skip(3));
+        assertEquals(0, reader.skip(3));
         reader.reset();
         assertEquals(2, reader.skip(2));
         assertEquals(4, reader.skip(10));
-        assertEquals(-1, reader.skip(1));
+        assertEquals(0, reader.skip(1));
         reader.close();
         assertEquals(6, reader.skip(20));
         assertEquals(-1, reader.read());
@@ -101,11 +101,11 @@ public class CharSequenceReaderTest {
         final Reader subReader = new CharSequenceReader("xFooBarx", 1, 7);
         assertEquals(3, subReader.skip(3));
         checkRead(subReader, "Bar");
-        assertEquals(-1, subReader.skip(3));
+        assertEquals(0, subReader.skip(3));
         subReader.reset();
         assertEquals(2, subReader.skip(2));
         assertEquals(4, subReader.skip(10));
-        assertEquals(-1, subReader.skip(1));
+        assertEquals(0, subReader.skip(1));
         subReader.close();
         assertEquals(6, subReader.skip(20));
         assertEquals(-1, subReader.read());


### PR DESCRIPTION
`Reader.skip(long n)` should return
> The number of characters actually skipped

The current implementation of `CharSequenceReader` instead returns `EOF`, which is -1. This should be 0, which is just what this PR changes.