### PR TITLE
[IO-676] Add isFileNewer() and isFileOlder() methods that support the Java 8 Date/Time API.

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -38,10 +38,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.chrono.ChronoLocalDate;
+import java.time.chrono.ChronoLocalDateTime;
+import java.time.chrono.ChronoZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -89,9 +90,6 @@ import org.apache.commons.io.output.NullOutputStream;
  * </p>
  */
 public class FileUtils {
-    private static final String LOCAL_DATE = "localDate";
-    private static final String ZONE_ID = "zoneId";
-
     /**
      * The number of bytes in a kilobyte.
      */
@@ -1731,79 +1729,79 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified {@code File} is newer than the specified {@code ZonedDateTime}.
+     * Tests if the specified {@code File} is newer than the specified {@code ChronoZonedDateTime}.
      *
-     * @param file          the {@code File} of which the modification date must be compared
-     * @param zonedDateTime the date reference
-     * @return true if the {@code File} exists and has been modified after the given {@code ZonedDateTime}.
+     * @param file                the {@code File} of which the modification date must be compared
+     * @param chronoZonedDateTime the date reference
+     * @return true if the {@code File} exists and has been modified after the given
+     * {@code ChronoZonedDateTime}.
      * @throws NullPointerException if the file or zoned date time is {@code null}
      */
-    public static boolean isFileNewer(final File file, final ZonedDateTime zonedDateTime) {
-        Objects.requireNonNull(zonedDateTime, "zonedDateTime");
-        return isFileNewer(file, zonedDateTime.toInstant());
+    public static boolean isFileNewer(final File file, final ChronoZonedDateTime<?> chronoZonedDateTime) {
+        Objects.requireNonNull(chronoZonedDateTime, "chronoZonedDateTime");
+        return isFileNewer(file, chronoZonedDateTime.toInstant());
     }
 
     /**
-     * Tests if the specified {@code File} is newer than the specified {@code LocalDateTime}
+     * Tests if the specified {@code File} is newer than the specified {@code ChronoLocalDateTime}
      * at the system-default time zone.
      *
-     * @param file          the {@code File} of which the modification date must be compared
-     * @param localDateTime the date reference
+     * @param file                the {@code File} of which the modification date must be compared
+     * @param chronoLocalDateTime the date reference
      * @return true if the {@code File} exists and has been modified after the given
-     * {@code LocalDateTime} at the system-default time zone.
+     * {@code ChronoLocalDateTime} at the system-default time zone.
      * @throws NullPointerException if the file or local date time is {@code null}
      */
-    public static boolean isFileNewer(final File file, final LocalDateTime localDateTime) {
-        return isFileNewer(file, localDateTime, ZoneId.systemDefault());
+    public static boolean isFileNewer(final File file, final ChronoLocalDateTime<?> chronoLocalDateTime) {
+        return isFileNewer(file, chronoLocalDateTime, ZoneId.systemDefault());
     }
 
     /**
-     * Tests if the specified {@code File} is newer than the specified {@code LocalDateTime}
+     * Tests if the specified {@code File} is newer than the specified {@code ChronoLocalDateTime}
      * at the specified {@code ZoneId}.
      *
-     * @param file          the {@code File} of which the modification date must be compared
-     * @param localDateTime the date reference
-     * @param zoneId        the time zone
+     * @param file                the {@code File} of which the modification date must be compared
+     * @param chronoLocalDateTime the date reference
+     * @param zoneId              the time zone
      * @return true if the {@code File} exists and has been modified after the given
-     * {@code LocalDateTime} at the given {@code ZoneId}.
+     * {@code ChronoLocalDateTime} at the given {@code ZoneId}.
      * @throws NullPointerException if the file, local date time or zone ID is {@code null}
      */
-    public static boolean isFileNewer(final File file, final LocalDateTime localDateTime, final ZoneId zoneId) {
-        Objects.requireNonNull(localDateTime, "localDateTime");
-        Objects.requireNonNull(zoneId, ZONE_ID);
-        return isFileNewer(file, localDateTime.atZone(zoneId));
+    public static boolean isFileNewer(final File file, final ChronoLocalDateTime<?> chronoLocalDateTime, final ZoneId zoneId) {
+        Objects.requireNonNull(chronoLocalDateTime, "chronoLocalDateTime");
+        Objects.requireNonNull(zoneId, "zoneId");
+        return isFileNewer(file, chronoLocalDateTime.atZone(zoneId));
     }
 
     /**
-     * Tests if the specified {@code File} is newer than the specified {@code LocalDate}
-     * at the system-default time zone.
+     * Tests if the specified {@code File} is newer than the specified {@code ChronoLocalDate}
+     * at the current time.
      *
-     * @param file      the {@code File} of which the modification date must be compared
-     * @param localDate the date reference
+     * @param file            the {@code File} of which the modification date must be compared
+     * @param chronoLocalDate the date reference
      * @return true if the {@code File} exists and has been modified after the given
-     * {@code LocalDate} at the system-default time zone.
+     * {@code ChronoLocalDate} at the current time.
      * @throws NullPointerException if the file or local date is {@code null}
      */
-    public static boolean isFileNewer(final File file, final LocalDate localDate) {
-        Objects.requireNonNull(localDate, LOCAL_DATE);
-        return isFileNewer(file, localDate.atStartOfDay());
+    public static boolean isFileNewer(final File file, final ChronoLocalDate chronoLocalDate) {
+        return isFileNewer(file, chronoLocalDate, LocalTime.now());
     }
 
     /**
-     * Tests if the specified {@code File} is newer than the specified {@code LocalDate}
-     * at the specified {@code ZoneId}.
+     * Tests if the specified {@code File} is newer than the specified {@code ChronoLocalDate}
+     * at the specified time.
      *
-     * @param file      the {@code File} of which the modification date must be compared
-     * @param localDate the date reference
-     * @param zoneId    the time zone
+     * @param file            the {@code File} of which the modification date must be compared
+     * @param chronoLocalDate the date reference
+     * @param localTime       the time reference
      * @return true if the {@code File} exists and has been modified after the given
-     * {@code LocalDate} at the given {@code ZoneId}.
+     * {@code ChronoLocalDate} at the given time.
      * @throws NullPointerException if the file, local date or zone ID is {@code null}
      */
-    public static boolean isFileNewer(final File file, final LocalDate localDate, final ZoneId zoneId) {
-        Objects.requireNonNull(localDate, LOCAL_DATE);
-        Objects.requireNonNull(zoneId, ZONE_ID);
-        return isFileNewer(file, localDate.atStartOfDay(zoneId));
+    public static boolean isFileNewer(final File file, final ChronoLocalDate chronoLocalDate, final LocalTime localTime) {
+        Objects.requireNonNull(chronoLocalDate, "chronoLocalDate");
+        Objects.requireNonNull(localTime, "localTime");
+        return isFileNewer(file, chronoLocalDate.atTime(localTime));
     }
 
     /**
@@ -1868,79 +1866,79 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified {@code File} is older than the specified {@code ZonedDateTime}.
+     * Tests if the specified {@code File} is older than the specified {@code ChronoZonedDateTime}.
      *
-     * @param file          the {@code File} of which the modification date must be compared
-     * @param zonedDateTime the date reference
-     * @return true if the {@code File} exists and has been modified before the given {@code ZonedDateTime}.
+     * @param file                the {@code File} of which the modification date must be compared
+     * @param chronoZonedDateTime the date reference
+     * @return true if the {@code File} exists and has been modified before the given
+     * {@code ChronoZonedDateTime}.
      * @throws NullPointerException if the file or zoned date time is {@code null}
      */
-    public static boolean isFileOlder(final File file, final ZonedDateTime zonedDateTime) {
-        Objects.requireNonNull(zonedDateTime, "zonedDateTime");
-        return isFileOlder(file, zonedDateTime.toInstant());
+    public static boolean isFileOlder(final File file, final ChronoZonedDateTime<?> chronoZonedDateTime) {
+        Objects.requireNonNull(chronoZonedDateTime, "chronoZonedDateTime");
+        return isFileOlder(file, chronoZonedDateTime.toInstant());
     }
 
     /**
-     * Tests if the specified {@code File} is older than the specified {@code LocalDateTime}
+     * Tests if the specified {@code File} is older than the specified {@code ChronoLocalDateTime}
      * at the system-default time zone.
      *
-     * @param file          the {@code File} of which the modification date must be compared
-     * @param localDateTime the date reference
+     * @param file                the {@code File} of which the modification date must be compared
+     * @param chronoLocalDateTime the date reference
      * @return true if the {@code File} exists and has been modified before the given
-     * {@code LocalDateTime} at the system-default time zone.
+     * {@code ChronoLocalDateTime} at the system-default time zone.
      * @throws NullPointerException if the file or local date time is {@code null}
      */
-    public static boolean isFileOlder(final File file, final LocalDateTime localDateTime) {
-        return isFileOlder(file, localDateTime, ZoneId.systemDefault());
+    public static boolean isFileOlder(final File file, final ChronoLocalDateTime<?> chronoLocalDateTime) {
+        return isFileOlder(file, chronoLocalDateTime, ZoneId.systemDefault());
     }
 
     /**
-     * Tests if the specified {@code File} is older than the specified
-     * {@code LocalDateTime} at the specified {@code ZoneId}.
-     *
-     * @param file          the {@code File} of which the modification date must be compared
-     * @param localDateTime the date reference
-     * @param zoneId        the time zone
-     * @return true if the {@code File} exists and has been modified before the given
-     * {@code LocalDateTime} at the given {@code ZoneId}.
-     * @throws NullPointerException if the file, local date time or zone ID is {@code null}
-     */
-    public static boolean isFileOlder(final File file, final LocalDateTime localDateTime, final ZoneId zoneId) {
-        Objects.requireNonNull(localDateTime, "localDateTime");
-        Objects.requireNonNull(zoneId, ZONE_ID);
-        return isFileOlder(file, localDateTime.atZone(zoneId));
-    }
-
-    /**
-     * Tests if the specified {@code File} is older than the specified  {@code LocalDate}
-     * at the system-default time zone.
-     *
-     * @param file      the {@code File} of which the modification date must be compared
-     * @param localDate the date reference
-     * @return true if the {@code File} exists and has been modified before the
-     * given {@code LocalDate} at the system-default time zone.
-     * @throws NullPointerException if the file or local date is {@code null}
-     */
-    public static boolean isFileOlder(final File file, final LocalDate localDate) {
-        Objects.requireNonNull(localDate, LOCAL_DATE);
-        return isFileOlder(file, localDate.atStartOfDay());
-    }
-
-    /**
-     * Tests if the specified {@code File} is older than the specified {@code LocalDate}
+     * Tests if the specified {@code File} is older than the specified {@code ChronoLocalDateTime}
      * at the specified {@code ZoneId}.
      *
-     * @param file      the {@code File} of which the modification date must be compared
-     * @param localDate the date reference
-     * @param zoneId    the time zone
+     * @param file          the {@code File} of which the modification date must be compared
+     * @param chronoLocalDateTime the date reference
+     * @param zoneId        the time zone
      * @return true if the {@code File} exists and has been modified before the given
-     * {@code LocalDate} at the given {@code ZoneId}.
-     * @throws IllegalArgumentException if the file, local date or zone ID is {@code null}
+     * {@code ChronoLocalDateTime} at the given {@code ZoneId}.
+     * @throws NullPointerException if the file, local date time or zone ID is {@code null}
      */
-    public static boolean isFileOlder(final File file, final LocalDate localDate, final ZoneId zoneId) {
-        Objects.requireNonNull(localDate, LOCAL_DATE);
-        Objects.requireNonNull(zoneId, ZONE_ID);
-        return isFileOlder(file, localDate.atStartOfDay(zoneId));
+    public static boolean isFileOlder(final File file, final ChronoLocalDateTime<?> chronoLocalDateTime, final ZoneId zoneId) {
+        Objects.requireNonNull(chronoLocalDateTime, "chronoLocalDateTime");
+        Objects.requireNonNull(zoneId, "zoneId");
+        return isFileOlder(file, chronoLocalDateTime.atZone(zoneId));
+    }
+
+    /**
+     * Tests if the specified {@code File} is older than the specified {@code ChronoLocalDate}
+     * at the current time.
+     *
+     * @param file            the {@code File} of which the modification date must be compared
+     * @param chronoLocalDate the date reference
+     * @return true if the {@code File} exists and has been modified before the given
+     * {@code ChronoLocalDate} at the current time.
+     * @throws NullPointerException if the file or local date is {@code null}
+     */
+    public static boolean isFileOlder(final File file, final ChronoLocalDate chronoLocalDate) {
+        return isFileOlder(file, chronoLocalDate, LocalTime.now());
+    }
+
+    /**
+     * Tests if the specified {@code File} is older than the specified {@code ChronoLocalDate}
+     * at the specified {@code LocalTime}.
+     *
+     * @param file            the {@code File} of which the modification date must be compared
+     * @param chronoLocalDate the date reference
+     * @param localTime       the time reference
+     * @return true if the {@code File} exists and has been modified before the
+     * given {@code ChronoLocalDate} at the specified time.
+     * @throws NullPointerException if the file, local date or local time is {@code null}
+     */
+    public static boolean isFileOlder(final File file, final ChronoLocalDate chronoLocalDate, final LocalTime localTime) {
+        Objects.requireNonNull(chronoLocalDate, "chronoLocalDate");
+        Objects.requireNonNull(localTime, "localTime");
+        return isFileOlder(file, chronoLocalDate.atTime(localTime));
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1722,6 +1722,8 @@ public class FileUtils {
      * @param instant the date reference
      * @return true if the {@code File} exists and has been modified after the given {@code Instant}.
      * @throws NullPointerException if the file or instant is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileNewer(final File file, final Instant instant) {
         Objects.requireNonNull(instant, "instant");
@@ -1736,6 +1738,8 @@ public class FileUtils {
      * @return true if the {@code File} exists and has been modified after the given
      * {@code ChronoZonedDateTime}.
      * @throws NullPointerException if the file or zoned date time is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileNewer(final File file, final ChronoZonedDateTime<?> chronoZonedDateTime) {
         Objects.requireNonNull(chronoZonedDateTime, "chronoZonedDateTime");
@@ -1751,6 +1755,8 @@ public class FileUtils {
      * @return true if the {@code File} exists and has been modified after the given
      * {@code ChronoLocalDateTime} at the system-default time zone.
      * @throws NullPointerException if the file or local date time is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileNewer(final File file, final ChronoLocalDateTime<?> chronoLocalDateTime) {
         return isFileNewer(file, chronoLocalDateTime, ZoneId.systemDefault());
@@ -1766,6 +1772,8 @@ public class FileUtils {
      * @return true if the {@code File} exists and has been modified after the given
      * {@code ChronoLocalDateTime} at the given {@code ZoneId}.
      * @throws NullPointerException if the file, local date time or zone ID is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileNewer(final File file, final ChronoLocalDateTime<?> chronoLocalDateTime, final ZoneId zoneId) {
         Objects.requireNonNull(chronoLocalDateTime, "chronoLocalDateTime");
@@ -1782,6 +1790,8 @@ public class FileUtils {
      * @return true if the {@code File} exists and has been modified after the given
      * {@code ChronoLocalDate} at the current time.
      * @throws NullPointerException if the file or local date is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileNewer(final File file, final ChronoLocalDate chronoLocalDate) {
         return isFileNewer(file, chronoLocalDate, LocalTime.now());
@@ -1797,6 +1807,8 @@ public class FileUtils {
      * @return true if the {@code File} exists and has been modified after the given
      * {@code ChronoLocalDate} at the given time.
      * @throws NullPointerException if the file, local date or zone ID is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileNewer(final File file, final ChronoLocalDate chronoLocalDate, final LocalTime localTime) {
         Objects.requireNonNull(chronoLocalDate, "chronoLocalDate");
@@ -1859,6 +1871,8 @@ public class FileUtils {
      * @param instant the date reference
      * @return true if the {@code File} exists and has been modified before the given {@code Instant}.
      * @throws NullPointerException if the file or instant is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileOlder(final File file, final Instant instant) {
         Objects.requireNonNull(instant, "instant");
@@ -1873,6 +1887,8 @@ public class FileUtils {
      * @return true if the {@code File} exists and has been modified before the given
      * {@code ChronoZonedDateTime}.
      * @throws NullPointerException if the file or zoned date time is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileOlder(final File file, final ChronoZonedDateTime<?> chronoZonedDateTime) {
         Objects.requireNonNull(chronoZonedDateTime, "chronoZonedDateTime");
@@ -1888,6 +1904,8 @@ public class FileUtils {
      * @return true if the {@code File} exists and has been modified before the given
      * {@code ChronoLocalDateTime} at the system-default time zone.
      * @throws NullPointerException if the file or local date time is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileOlder(final File file, final ChronoLocalDateTime<?> chronoLocalDateTime) {
         return isFileOlder(file, chronoLocalDateTime, ZoneId.systemDefault());
@@ -1903,6 +1921,8 @@ public class FileUtils {
      * @return true if the {@code File} exists and has been modified before the given
      * {@code ChronoLocalDateTime} at the given {@code ZoneId}.
      * @throws NullPointerException if the file, local date time or zone ID is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileOlder(final File file, final ChronoLocalDateTime<?> chronoLocalDateTime, final ZoneId zoneId) {
         Objects.requireNonNull(chronoLocalDateTime, "chronoLocalDateTime");
@@ -1919,6 +1939,8 @@ public class FileUtils {
      * @return true if the {@code File} exists and has been modified before the given
      * {@code ChronoLocalDate} at the current time.
      * @throws NullPointerException if the file or local date is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileOlder(final File file, final ChronoLocalDate chronoLocalDate) {
         return isFileOlder(file, chronoLocalDate, LocalTime.now());
@@ -1934,6 +1956,8 @@ public class FileUtils {
      * @return true if the {@code File} exists and has been modified before the
      * given {@code ChronoLocalDate} at the specified time.
      * @throws NullPointerException if the file, local date or local time is {@code null}
+     *
+     * @since 2.8
      */
     public static boolean isFileOlder(final File file, final ChronoLocalDate chronoLocalDate, final LocalTime localTime) {
         Objects.requireNonNull(chronoLocalDate, "chronoLocalDate");

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -89,6 +89,8 @@ import org.apache.commons.io.output.NullOutputStream;
  * </p>
  */
 public class FileUtils {
+    private static final String NO_SPECIFIED_LOCALDATE = "No specified localDate";
+    private static final String NO_SPECIFIED_ZONEID = "No specified zoneID";
 
     /**
      * The number of bytes in a kilobyte.
@@ -1731,6 +1733,119 @@ public class FileUtils {
     }
 
     /**
+     * Tests if the specified <code>File</code> is newer than the specified
+     * <code>Instant</code>.
+     *
+     * @param file    the <code>File</code> of which the modification date
+     *                must be compared, must not be {@code null}
+     * @param instant the date reference, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * after the given <code>Instant</code>.
+     * @throws IllegalArgumentException if the file or instant is {@code null}
+     */
+    public static boolean isFileNewer(final File file, final Instant instant) {
+        if (instant == null) {
+            throw new IllegalArgumentException("No specified instant");
+        }
+        return isFileNewer(file, instant.toEpochMilli());
+    }
+
+    /**
+     * Tests if the specified <code>File</code> is newer than the specified
+     * <code>ZonedDateTime</code>.
+     *
+     * @param file          the <code>File</code> of which the modification date
+     *                      must be compared, must not be {@code null}
+     * @param zonedDateTime the date reference, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * after the given <code>ZonedDateTime</code>.
+     * @throws IllegalArgumentException if the file or zoned date time is {@code null}
+     */
+    public static boolean isFileNewer(final File file, final ZonedDateTime zonedDateTime) {
+        if (zonedDateTime == null) {
+            throw new IllegalArgumentException("No specified zonedDateTime");
+        }
+        return isFileNewer(file, zonedDateTime.toInstant());
+    }
+
+    /**
+     * Tests if the specified <code>File</code> is newer than the specified
+     * <code>LocalDateTime</code> at the system-default time zone.
+     *
+     * @param file          the <code>File</code> of which the modification date
+     *                      must be compared, must not be {@code null}
+     * @param localDateTime the date reference, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * after the given <code>LocalDateTime</code> at the system-default time zone.
+     * @throws IllegalArgumentException if the file or local date time is {@code null}
+     */
+    public static boolean isFileNewer(final File file, final LocalDateTime localDateTime) {
+        return isFileNewer(file, localDateTime, ZoneId.systemDefault());
+    }
+
+    /**
+     * Tests if the specified <code>File</code> is newer than the specified
+     * <code>LocalDateTime</code> at the specified <code>ZoneId</code>.
+     *
+     * @param file          the <code>File</code> of which the modification date
+     *                      must be compared, must not be {@code null}
+     * @param localDateTime the date reference, must not be {@code null}
+     * @param zoneId        the time zone, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * after the given <code>LocalDateTime</code> at the given <code>ZoneId</code>.
+     * @throws IllegalArgumentException if the file, local date time or zone ID is {@code null}
+     */
+    public static boolean isFileNewer(final File file, final LocalDateTime localDateTime, final ZoneId zoneId) {
+        if (localDateTime == null) {
+            throw new IllegalArgumentException("No specified localDateTime");
+        }
+        if (zoneId == null) {
+            throw new IllegalArgumentException(NO_SPECIFIED_ZONEID);
+        }
+        return isFileNewer(file, localDateTime.atZone(zoneId));
+    }
+
+    /**
+     * Tests if the specified <code>File</code> is newer than the specified
+     * <code>LocalDate</code> at the system-default time zone.
+     *
+     * @param file      the <code>File</code> of which the modification date
+     *                  must be compared, must not be {@code null}
+     * @param localDate the date reference, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * after the given <code>LocalDate</code> at the system-default time zone.
+     * @throws IllegalArgumentException if the file or local date is {@code null}
+     */
+    public static boolean isFileNewer(final File file, final LocalDate localDate) {
+        if (localDate == null) {
+            throw new IllegalArgumentException(NO_SPECIFIED_LOCALDATE);
+        }
+        return isFileNewer(file, localDate.atStartOfDay());
+    }
+
+    /**
+     * Tests if the specified <code>File</code> is newer than the specified
+     * <code>LocalDate</code> at the specified <code>ZoneId</code>.
+     *
+     * @param file      the <code>File</code> of which the modification date
+     *                  must be compared, must not be {@code null}
+     * @param localDate the date reference, must not be {@code null}
+     * @param zoneId    the time zone, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * after the given <code>LocalDate</code> at the given <code>ZoneId</code>.
+     * @throws IllegalArgumentException if the file, local date or zone ID is {@code null}
+     */
+    public static boolean isFileNewer(final File file, final LocalDate localDate, final ZoneId zoneId) {
+        if (localDate == null) {
+            throw new IllegalArgumentException(NO_SPECIFIED_LOCALDATE);
+        }
+        if (zoneId == null) {
+            throw new IllegalArgumentException(NO_SPECIFIED_ZONEID);
+        }
+        return isFileNewer(file, localDate.atStartOfDay(zoneId));
+    }
+
+    /**
      * Tests if the specified <code>File</code> is older than the specified
      * <code>Date</code>.
      *
@@ -1864,7 +1979,7 @@ public class FileUtils {
             throw new IllegalArgumentException("No specified localDateTime");
         }
         if (zoneId == null) {
-            throw new IllegalArgumentException("No specified zoneID");
+            throw new IllegalArgumentException(NO_SPECIFIED_ZONEID);
         }
         return isFileOlder(file, localDateTime.atZone(zoneId));
     }
@@ -1882,7 +1997,7 @@ public class FileUtils {
      */
     public static boolean isFileOlder(final File file, final LocalDate localDate) {
         if (localDate == null) {
-            throw new IllegalArgumentException("No specified localDate");
+            throw new IllegalArgumentException(NO_SPECIFIED_LOCALDATE);
         }
         return isFileOlder(file, localDate.atStartOfDay());
     }
@@ -1901,10 +2016,10 @@ public class FileUtils {
      */
     public static boolean isFileOlder(final File file, final LocalDate localDate, final ZoneId zoneId) {
         if (localDate == null) {
-            throw new IllegalArgumentException("No specified localDate");
+            throw new IllegalArgumentException(NO_SPECIFIED_LOCALDATE);
         }
         if (zoneId == null) {
-            throw new IllegalArgumentException("No specified zoneID");
+            throw new IllegalArgumentException(NO_SPECIFIED_ZONEID);
         }
         return isFileOlder(file, localDate.atStartOfDay(zoneId));
     }

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -37,6 +37,11 @@ import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
@@ -1789,6 +1794,119 @@ public class FileUtils {
             return false;
         }
         return file.lastModified() < timeMillis;
+    }
+
+    /**
+     * Tests if the specified <code>File</code> is older than the specified
+     * <code>Instant</code>.
+     *
+     * @param file    the <code>File</code> of which the modification date
+     *                must be compared, must not be {@code null}
+     * @param instant the date reference, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * before the given <code>Instant</code>.
+     * @throws IllegalArgumentException if the file or instant is {@code null}
+     */
+    public static boolean isFileOlder(final File file, final Instant instant) {
+        if (instant == null) {
+            throw new IllegalArgumentException("No specified instant");
+        }
+        return isFileOlder(file, instant.toEpochMilli());
+    }
+
+    /**
+     * Tests if the specified <code>File</code> is older than the specified
+     * <code>ZonedDateTime</code>.
+     *
+     * @param file          the <code>File</code> of which the modification date
+     *                      must be compared, must not be {@code null}
+     * @param zonedDateTime the date reference, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * before the given <code>ZonedDateTime</code>.
+     * @throws IllegalArgumentException if the file or zoned date time is {@code null}
+     */
+    public static boolean isFileOlder(final File file, final ZonedDateTime zonedDateTime) {
+        if (zonedDateTime == null) {
+            throw new IllegalArgumentException("No specified zonedDateTime");
+        }
+        return isFileOlder(file, zonedDateTime.toInstant());
+    }
+
+    /**
+     * Tests if the specified <code>File</code> is older than the specified
+     * <code>LocalDateTime</code> at the system-default time zone.
+     *
+     * @param file          the <code>File</code> of which the modification date
+     *                      must be compared, must not be {@code null}
+     * @param localDateTime the date reference, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * before the given <code>LocalDateTime</code> at the system-default time zone.
+     * @throws IllegalArgumentException if the file or local date time is {@code null}
+     */
+    public static boolean isFileOlder(final File file, final LocalDateTime localDateTime) {
+        return isFileOlder(file, localDateTime, ZoneId.systemDefault());
+    }
+
+    /**
+     * Tests if the specified <code>File</code> is older than the specified
+     * <code>LocalDateTime</code> at the specified <code>ZoneId</code>.
+     *
+     * @param file          the <code>File</code> of which the modification date
+     *                      must be compared, must not be {@code null}
+     * @param localDateTime the date reference, must not be {@code null}
+     * @param zoneId        the time zone, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * before the given <code>LocalDateTime</code> at the given <code>ZoneId</code>.
+     * @throws IllegalArgumentException if the file, local date time or zone ID is {@code null}
+     */
+    public static boolean isFileOlder(final File file, final LocalDateTime localDateTime, final ZoneId zoneId) {
+        if (localDateTime == null) {
+            throw new IllegalArgumentException("No specified localDateTime");
+        }
+        if (zoneId == null) {
+            throw new IllegalArgumentException("No specified zoneID");
+        }
+        return isFileOlder(file, localDateTime.atZone(zoneId));
+    }
+
+    /**
+     * Tests if the specified <code>File</code> is older than the specified
+     * <code>LocalDate</code> at the system-default time zone.
+     *
+     * @param file      the <code>File</code> of which the modification date
+     *                  must be compared, must not be {@code null}
+     * @param localDate the date reference, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * before the given <code>LocalDate</code> at the system-default time zone.
+     * @throws IllegalArgumentException if the file or local date is {@code null}
+     */
+    public static boolean isFileOlder(final File file, final LocalDate localDate) {
+        if (localDate == null) {
+            throw new IllegalArgumentException("No specified localDate");
+        }
+        return isFileOlder(file, localDate.atStartOfDay());
+    }
+
+    /**
+     * Tests if the specified <code>File</code> is older than the specified
+     * <code>LocalDate</code> at the specified <code>ZoneId</code>.
+     *
+     * @param file      the <code>File</code> of which the modification date
+     *                  must be compared, must not be {@code null}
+     * @param localDate the date reference, must not be {@code null}
+     * @param zoneId    the time zone, must not be {@code null}
+     * @return true if the <code>File</code> exists and has been modified
+     * before the given <code>LocalDate</code> at the given <code>ZoneId</code>.
+     * @throws IllegalArgumentException if the file, local date or zone ID is {@code null}
+     */
+    public static boolean isFileOlder(final File file, final LocalDate localDate, final ZoneId zoneId) {
+        if (localDate == null) {
+            throw new IllegalArgumentException("No specified localDate");
+        }
+        if (zoneId == null) {
+            throw new IllegalArgumentException("No specified zoneID");
+        }
+        return isFileOlder(file, localDate.atStartOfDay(zoneId));
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -89,8 +89,8 @@ import org.apache.commons.io.output.NullOutputStream;
  * </p>
  */
 public class FileUtils {
-    private static final String NO_SPECIFIED_LOCALDATE = "No specified localDate";
-    private static final String NO_SPECIFIED_ZONEID = "No specified zoneID";
+    private static final String LOCAL_DATE = "localDate";
+    private static final String ZONE_ID = "zoneId";
 
     /**
      * The number of bytes in a kilobyte.
@@ -1673,13 +1673,10 @@ public class FileUtils {
      * @param date the date reference
      * @return true if the {@code File} exists and has been modified
      * after the given {@code Date}.
-     * @throws IllegalArgumentException if the file is {@code null}
-     * @throws IllegalArgumentException if the date is {@code null}
+     * @throws NullPointerException if the file or date is {@code null}
      */
     public static boolean isFileNewer(final File file, final Date date) {
-        if (date == null) {
-            throw new IllegalArgumentException("No specified date");
-        }
+        Objects.requireNonNull(date, "date");
         return isFileNewer(file, date.getTime());
     }
 
@@ -1691,13 +1688,11 @@ public class FileUtils {
      * @param reference the {@code File} of which the modification date is used
      * @return true if the {@code File} exists and has been modified more
      * recently than the reference {@code File}
-     * @throws IllegalArgumentException if the file is {@code null}
-     * @throws IllegalArgumentException if the reference file is {@code null} or doesn't exist
+     * @throws NullPointerException if the file or reference file is {@code null}
+     * @throws IllegalArgumentException if the reference file doesn't exist
      */
     public static boolean isFileNewer(final File file, final File reference) {
-        if (reference == null) {
-            throw new IllegalArgumentException("No specified reference file");
-        }
+        Objects.requireNonNull(reference, "reference");
         if (!reference.exists()) {
             throw new IllegalArgumentException("The reference file '"
                     + reference + "' doesn't exist");
@@ -1712,12 +1707,10 @@ public class FileUtils {
      * @param timeMillis the time reference measured in milliseconds since the
      *                   epoch (00:00:00 GMT, January 1, 1970)
      * @return true if the {@code File} exists and has been modified after the given time reference.
-     * @throws IllegalArgumentException if the file is {@code null}
+     * @throws NullPointerException if the file is {@code null}
      */
     public static boolean isFileNewer(final File file, final long timeMillis) {
-        if (file == null) {
-            throw new IllegalArgumentException("No specified file");
-        }
+        Objects.requireNonNull(file, "file");
         if (!file.exists()) {
             return false;
         }
@@ -1730,12 +1723,10 @@ public class FileUtils {
      * @param file    the {@code File} of which the modification date must be compared
      * @param instant the date reference
      * @return true if the {@code File} exists and has been modified after the given {@code Instant}.
-     * @throws IllegalArgumentException if the file or instant is {@code null}
+     * @throws NullPointerException if the file or instant is {@code null}
      */
     public static boolean isFileNewer(final File file, final Instant instant) {
-        if (instant == null) {
-            throw new IllegalArgumentException("No specified instant");
-        }
+        Objects.requireNonNull(instant, "instant");
         return isFileNewer(file, instant.toEpochMilli());
     }
 
@@ -1745,12 +1736,10 @@ public class FileUtils {
      * @param file          the {@code File} of which the modification date must be compared
      * @param zonedDateTime the date reference
      * @return true if the {@code File} exists and has been modified after the given {@code ZonedDateTime}.
-     * @throws IllegalArgumentException if the file or zoned date time is {@code null}
+     * @throws NullPointerException if the file or zoned date time is {@code null}
      */
     public static boolean isFileNewer(final File file, final ZonedDateTime zonedDateTime) {
-        if (zonedDateTime == null) {
-            throw new IllegalArgumentException("No specified zonedDateTime");
-        }
+        Objects.requireNonNull(zonedDateTime, "zonedDateTime");
         return isFileNewer(file, zonedDateTime.toInstant());
     }
 
@@ -1762,7 +1751,7 @@ public class FileUtils {
      * @param localDateTime the date reference
      * @return true if the {@code File} exists and has been modified after the given
      * {@code LocalDateTime} at the system-default time zone.
-     * @throws IllegalArgumentException if the file or local date time is {@code null}
+     * @throws NullPointerException if the file or local date time is {@code null}
      */
     public static boolean isFileNewer(final File file, final LocalDateTime localDateTime) {
         return isFileNewer(file, localDateTime, ZoneId.systemDefault());
@@ -1777,15 +1766,11 @@ public class FileUtils {
      * @param zoneId        the time zone
      * @return true if the {@code File} exists and has been modified after the given
      * {@code LocalDateTime} at the given {@code ZoneId}.
-     * @throws IllegalArgumentException if the file, local date time or zone ID is {@code null}
+     * @throws NullPointerException if the file, local date time or zone ID is {@code null}
      */
     public static boolean isFileNewer(final File file, final LocalDateTime localDateTime, final ZoneId zoneId) {
-        if (localDateTime == null) {
-            throw new IllegalArgumentException("No specified localDateTime");
-        }
-        if (zoneId == null) {
-            throw new IllegalArgumentException(NO_SPECIFIED_ZONEID);
-        }
+        Objects.requireNonNull(localDateTime, "localDateTime");
+        Objects.requireNonNull(zoneId, ZONE_ID);
         return isFileNewer(file, localDateTime.atZone(zoneId));
     }
 
@@ -1797,12 +1782,10 @@ public class FileUtils {
      * @param localDate the date reference
      * @return true if the {@code File} exists and has been modified after the given
      * {@code LocalDate} at the system-default time zone.
-     * @throws IllegalArgumentException if the file or local date is {@code null}
+     * @throws NullPointerException if the file or local date is {@code null}
      */
     public static boolean isFileNewer(final File file, final LocalDate localDate) {
-        if (localDate == null) {
-            throw new IllegalArgumentException(NO_SPECIFIED_LOCALDATE);
-        }
+        Objects.requireNonNull(localDate, LOCAL_DATE);
         return isFileNewer(file, localDate.atStartOfDay());
     }
 
@@ -1815,15 +1798,11 @@ public class FileUtils {
      * @param zoneId    the time zone
      * @return true if the {@code File} exists and has been modified after the given
      * {@code LocalDate} at the given {@code ZoneId}.
-     * @throws IllegalArgumentException if the file, local date or zone ID is {@code null}
+     * @throws NullPointerException if the file, local date or zone ID is {@code null}
      */
     public static boolean isFileNewer(final File file, final LocalDate localDate, final ZoneId zoneId) {
-        if (localDate == null) {
-            throw new IllegalArgumentException(NO_SPECIFIED_LOCALDATE);
-        }
-        if (zoneId == null) {
-            throw new IllegalArgumentException(NO_SPECIFIED_ZONEID);
-        }
+        Objects.requireNonNull(localDate, LOCAL_DATE);
+        Objects.requireNonNull(zoneId, ZONE_ID);
         return isFileNewer(file, localDate.atStartOfDay(zoneId));
     }
 
@@ -1833,13 +1812,10 @@ public class FileUtils {
      * @param file the {@code File} of which the modification date must be compared
      * @param date the date reference
      * @return true if the {@code File} exists and has been modified before the given {@code Date}.
-     * @throws IllegalArgumentException if the file is {@code null}
-     * @throws IllegalArgumentException if the date is {@code null}
+     * @throws NullPointerException if the file or date is {@code null}
      */
     public static boolean isFileOlder(final File file, final Date date) {
-        if (date == null) {
-            throw new IllegalArgumentException("No specified date");
-        }
+        Objects.requireNonNull(date, "date");
         return isFileOlder(file, date.getTime());
     }
 
@@ -1850,14 +1826,11 @@ public class FileUtils {
      * @param file      the {@code File} of which the modification date must be compared
      * @param reference the {@code File} of which the modification date is used
      * @return true if the {@code File} exists and has been modified before the reference {@code File}
-     * @throws IllegalArgumentException if the file is {@code null}
-     * @throws IllegalArgumentException if the reference file is {@code null} or doesn't exist
+     * @throws NullPointerException if the file or reference file is {@code null}
+     * @throws IllegalArgumentException if the reference file doesn't exist
      */
     public static boolean isFileOlder(final File file, final File reference) {
-        if (reference == null) {
-            throw new IllegalArgumentException("No specified reference file");
-        }
-        if (!reference.exists()) {
+        if (!Objects.requireNonNull(reference, "reference").exists()) {
             throw new IllegalArgumentException("The reference file '"
                     + reference + "' doesn't exist");
         }
@@ -1871,12 +1844,10 @@ public class FileUtils {
      * @param timeMillis the time reference measured in milliseconds since the
      *                   epoch (00:00:00 GMT, January 1, 1970)
      * @return true if the {@code File} exists and has been modified before the given time reference.
-     * @throws IllegalArgumentException if the file is {@code null}
+     * @throws NullPointerException if the file is {@code null}
      */
     public static boolean isFileOlder(final File file, final long timeMillis) {
-        if (file == null) {
-            throw new IllegalArgumentException("No specified file");
-        }
+        Objects.requireNonNull(file, "file");
         if (!file.exists()) {
             return false;
         }
@@ -1889,12 +1860,10 @@ public class FileUtils {
      * @param file    the {@code File} of which the modification date must be compared
      * @param instant the date reference
      * @return true if the {@code File} exists and has been modified before the given {@code Instant}.
-     * @throws IllegalArgumentException if the file or instant is {@code null}
+     * @throws NullPointerException if the file or instant is {@code null}
      */
     public static boolean isFileOlder(final File file, final Instant instant) {
-        if (instant == null) {
-            throw new IllegalArgumentException("No specified instant");
-        }
+        Objects.requireNonNull(instant, "instant");
         return isFileOlder(file, instant.toEpochMilli());
     }
 
@@ -1904,12 +1873,10 @@ public class FileUtils {
      * @param file          the {@code File} of which the modification date must be compared
      * @param zonedDateTime the date reference
      * @return true if the {@code File} exists and has been modified before the given {@code ZonedDateTime}.
-     * @throws IllegalArgumentException if the file or zoned date time is {@code null}
+     * @throws NullPointerException if the file or zoned date time is {@code null}
      */
     public static boolean isFileOlder(final File file, final ZonedDateTime zonedDateTime) {
-        if (zonedDateTime == null) {
-            throw new IllegalArgumentException("No specified zonedDateTime");
-        }
+        Objects.requireNonNull(zonedDateTime, "zonedDateTime");
         return isFileOlder(file, zonedDateTime.toInstant());
     }
 
@@ -1921,7 +1888,7 @@ public class FileUtils {
      * @param localDateTime the date reference
      * @return true if the {@code File} exists and has been modified before the given
      * {@code LocalDateTime} at the system-default time zone.
-     * @throws IllegalArgumentException if the file or local date time is {@code null}
+     * @throws NullPointerException if the file or local date time is {@code null}
      */
     public static boolean isFileOlder(final File file, final LocalDateTime localDateTime) {
         return isFileOlder(file, localDateTime, ZoneId.systemDefault());
@@ -1936,15 +1903,11 @@ public class FileUtils {
      * @param zoneId        the time zone
      * @return true if the {@code File} exists and has been modified before the given
      * {@code LocalDateTime} at the given {@code ZoneId}.
-     * @throws IllegalArgumentException if the file, local date time or zone ID is {@code null}
+     * @throws NullPointerException if the file, local date time or zone ID is {@code null}
      */
     public static boolean isFileOlder(final File file, final LocalDateTime localDateTime, final ZoneId zoneId) {
-        if (localDateTime == null) {
-            throw new IllegalArgumentException("No specified localDateTime");
-        }
-        if (zoneId == null) {
-            throw new IllegalArgumentException(NO_SPECIFIED_ZONEID);
-        }
+        Objects.requireNonNull(localDateTime, "localDateTime");
+        Objects.requireNonNull(zoneId, ZONE_ID);
         return isFileOlder(file, localDateTime.atZone(zoneId));
     }
 
@@ -1956,12 +1919,10 @@ public class FileUtils {
      * @param localDate the date reference
      * @return true if the {@code File} exists and has been modified before the
      * given {@code LocalDate} at the system-default time zone.
-     * @throws IllegalArgumentException if the file or local date is {@code null}
+     * @throws NullPointerException if the file or local date is {@code null}
      */
     public static boolean isFileOlder(final File file, final LocalDate localDate) {
-        if (localDate == null) {
-            throw new IllegalArgumentException(NO_SPECIFIED_LOCALDATE);
-        }
+        Objects.requireNonNull(localDate, LOCAL_DATE);
         return isFileOlder(file, localDate.atStartOfDay());
     }
 
@@ -1977,12 +1938,8 @@ public class FileUtils {
      * @throws IllegalArgumentException if the file, local date or zone ID is {@code null}
      */
     public static boolean isFileOlder(final File file, final LocalDate localDate, final ZoneId zoneId) {
-        if (localDate == null) {
-            throw new IllegalArgumentException(NO_SPECIFIED_LOCALDATE);
-        }
-        if (zoneId == null) {
-            throw new IllegalArgumentException(NO_SPECIFIED_ZONEID);
-        }
+        Objects.requireNonNull(localDate, LOCAL_DATE);
+        Objects.requireNonNull(zoneId, ZONE_ID);
         return isFileOlder(file, localDate.atStartOfDay(zoneId));
     }
 

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1667,14 +1667,12 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is newer than the specified
-     * <code>Date</code>.
+     * Tests if the specified {@code File} is newer than the specified {@code Date}.
      *
-     * @param file the <code>File</code> of which the modification date
-     *             must be compared, must not be {@code null}
-     * @param date the date reference, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * after the given <code>Date</code>.
+     * @param file the {@code File} of which the modification date must be compared
+     * @param date the date reference
+     * @return true if the {@code File} exists and has been modified
+     * after the given {@code Date}.
      * @throws IllegalArgumentException if the file is {@code null}
      * @throws IllegalArgumentException if the date is {@code null}
      */
@@ -1687,15 +1685,12 @@ public class FileUtils {
 
     //-----------------------------------------------------------------------
     /**
-     * Tests if the specified <code>File</code> is newer than the reference
-     * <code>File</code>.
+     * Tests if the specified {@code File} is newer than the reference {@code File}.
      *
-     * @param file      the <code>File</code> of which the modification date must
-     *                  be compared, must not be {@code null}
-     * @param reference the <code>File</code> of which the modification date
-     *                  is used, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified more
-     * recently than the reference <code>File</code>
+     * @param file      the {@code File} of which the modification date must be compared
+     * @param reference the {@code File} of which the modification date is used
+     * @return true if the {@code File} exists and has been modified more
+     * recently than the reference {@code File}
      * @throws IllegalArgumentException if the file is {@code null}
      * @throws IllegalArgumentException if the reference file is {@code null} or doesn't exist
      */
@@ -1711,15 +1706,12 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is newer than the specified
-     * time reference.
+     * Tests if the specified {@code File} is newer than the specified time reference.
      *
-     * @param file       the <code>File</code> of which the modification date must
-     *                   be compared, must not be {@code null}
+     * @param file       the {@code File} of which the modification date must be compared
      * @param timeMillis the time reference measured in milliseconds since the
      *                   epoch (00:00:00 GMT, January 1, 1970)
-     * @return true if the <code>File</code> exists and has been modified after
-     * the given time reference.
+     * @return true if the {@code File} exists and has been modified after the given time reference.
      * @throws IllegalArgumentException if the file is {@code null}
      */
     public static boolean isFileNewer(final File file, final long timeMillis) {
@@ -1733,14 +1725,11 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is newer than the specified
-     * <code>Instant</code>.
+     * Tests if the specified {@code File} is newer than the specified {@code Instant}.
      *
-     * @param file    the <code>File</code> of which the modification date
-     *                must be compared, must not be {@code null}
-     * @param instant the date reference, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * after the given <code>Instant</code>.
+     * @param file    the {@code File} of which the modification date must be compared
+     * @param instant the date reference
+     * @return true if the {@code File} exists and has been modified after the given {@code Instant}.
      * @throws IllegalArgumentException if the file or instant is {@code null}
      */
     public static boolean isFileNewer(final File file, final Instant instant) {
@@ -1751,14 +1740,11 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is newer than the specified
-     * <code>ZonedDateTime</code>.
+     * Tests if the specified {@code File} is newer than the specified {@code ZonedDateTime}.
      *
-     * @param file          the <code>File</code> of which the modification date
-     *                      must be compared, must not be {@code null}
-     * @param zonedDateTime the date reference, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * after the given <code>ZonedDateTime</code>.
+     * @param file          the {@code File} of which the modification date must be compared
+     * @param zonedDateTime the date reference
+     * @return true if the {@code File} exists and has been modified after the given {@code ZonedDateTime}.
      * @throws IllegalArgumentException if the file or zoned date time is {@code null}
      */
     public static boolean isFileNewer(final File file, final ZonedDateTime zonedDateTime) {
@@ -1769,14 +1755,13 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is newer than the specified
-     * <code>LocalDateTime</code> at the system-default time zone.
+     * Tests if the specified {@code File} is newer than the specified {@code LocalDateTime}
+     * at the system-default time zone.
      *
-     * @param file          the <code>File</code> of which the modification date
-     *                      must be compared, must not be {@code null}
-     * @param localDateTime the date reference, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * after the given <code>LocalDateTime</code> at the system-default time zone.
+     * @param file          the {@code File} of which the modification date must be compared
+     * @param localDateTime the date reference
+     * @return true if the {@code File} exists and has been modified after the given
+     * {@code LocalDateTime} at the system-default time zone.
      * @throws IllegalArgumentException if the file or local date time is {@code null}
      */
     public static boolean isFileNewer(final File file, final LocalDateTime localDateTime) {
@@ -1784,15 +1769,14 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is newer than the specified
-     * <code>LocalDateTime</code> at the specified <code>ZoneId</code>.
+     * Tests if the specified {@code File} is newer than the specified {@code LocalDateTime}
+     * at the specified {@code ZoneId}.
      *
-     * @param file          the <code>File</code> of which the modification date
-     *                      must be compared, must not be {@code null}
-     * @param localDateTime the date reference, must not be {@code null}
-     * @param zoneId        the time zone, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * after the given <code>LocalDateTime</code> at the given <code>ZoneId</code>.
+     * @param file          the {@code File} of which the modification date must be compared
+     * @param localDateTime the date reference
+     * @param zoneId        the time zone
+     * @return true if the {@code File} exists and has been modified after the given
+     * {@code LocalDateTime} at the given {@code ZoneId}.
      * @throws IllegalArgumentException if the file, local date time or zone ID is {@code null}
      */
     public static boolean isFileNewer(final File file, final LocalDateTime localDateTime, final ZoneId zoneId) {
@@ -1806,14 +1790,13 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is newer than the specified
-     * <code>LocalDate</code> at the system-default time zone.
+     * Tests if the specified {@code File} is newer than the specified {@code LocalDate}
+     * at the system-default time zone.
      *
-     * @param file      the <code>File</code> of which the modification date
-     *                  must be compared, must not be {@code null}
-     * @param localDate the date reference, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * after the given <code>LocalDate</code> at the system-default time zone.
+     * @param file      the {@code File} of which the modification date must be compared
+     * @param localDate the date reference
+     * @return true if the {@code File} exists and has been modified after the given
+     * {@code LocalDate} at the system-default time zone.
      * @throws IllegalArgumentException if the file or local date is {@code null}
      */
     public static boolean isFileNewer(final File file, final LocalDate localDate) {
@@ -1824,15 +1807,14 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is newer than the specified
-     * <code>LocalDate</code> at the specified <code>ZoneId</code>.
+     * Tests if the specified {@code File} is newer than the specified {@code LocalDate}
+     * at the specified {@code ZoneId}.
      *
-     * @param file      the <code>File</code> of which the modification date
-     *                  must be compared, must not be {@code null}
-     * @param localDate the date reference, must not be {@code null}
-     * @param zoneId    the time zone, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * after the given <code>LocalDate</code> at the given <code>ZoneId</code>.
+     * @param file      the {@code File} of which the modification date must be compared
+     * @param localDate the date reference
+     * @param zoneId    the time zone
+     * @return true if the {@code File} exists and has been modified after the given
+     * {@code LocalDate} at the given {@code ZoneId}.
      * @throws IllegalArgumentException if the file, local date or zone ID is {@code null}
      */
     public static boolean isFileNewer(final File file, final LocalDate localDate, final ZoneId zoneId) {
@@ -1846,14 +1828,11 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is older than the specified
-     * <code>Date</code>.
+     * Tests if the specified {@code File} is older than the specified {@code Date}.
      *
-     * @param file the <code>File</code> of which the modification date
-     *             must be compared, must not be {@code null}
-     * @param date the date reference, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * before the given <code>Date</code>.
+     * @param file the {@code File} of which the modification date must be compared
+     * @param date the date reference
+     * @return true if the {@code File} exists and has been modified before the given {@code Date}.
      * @throws IllegalArgumentException if the file is {@code null}
      * @throws IllegalArgumentException if the date is {@code null}
      */
@@ -1866,15 +1845,11 @@ public class FileUtils {
 
     //-----------------------------------------------------------------------
     /**
-     * Tests if the specified <code>File</code> is older than the reference
-     * <code>File</code>.
+     * Tests if the specified {@code File} is older than the reference {@code File}.
      *
-     * @param file      the <code>File</code> of which the modification date must
-     *                  be compared, must not be {@code null}
-     * @param reference the <code>File</code> of which the modification date
-     *                  is used, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified before
-     * the reference <code>File</code>
+     * @param file      the {@code File} of which the modification date must be compared
+     * @param reference the {@code File} of which the modification date is used
+     * @return true if the {@code File} exists and has been modified before the reference {@code File}
      * @throws IllegalArgumentException if the file is {@code null}
      * @throws IllegalArgumentException if the reference file is {@code null} or doesn't exist
      */
@@ -1890,15 +1865,12 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is older than the specified
-     * time reference.
+     * Tests if the specified {@code File} is older than the specified time reference.
      *
-     * @param file       the <code>File</code> of which the modification date must
-     *                   be compared, must not be {@code null}
+     * @param file       the {@code File} of which the modification date must be compared
      * @param timeMillis the time reference measured in milliseconds since the
      *                   epoch (00:00:00 GMT, January 1, 1970)
-     * @return true if the <code>File</code> exists and has been modified before
-     * the given time reference.
+     * @return true if the {@code File} exists and has been modified before the given time reference.
      * @throws IllegalArgumentException if the file is {@code null}
      */
     public static boolean isFileOlder(final File file, final long timeMillis) {
@@ -1912,14 +1884,11 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is older than the specified
-     * <code>Instant</code>.
+     * Tests if the specified {@code File} is older than the specified {@code Instant}.
      *
-     * @param file    the <code>File</code> of which the modification date
-     *                must be compared, must not be {@code null}
-     * @param instant the date reference, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * before the given <code>Instant</code>.
+     * @param file    the {@code File} of which the modification date must be compared
+     * @param instant the date reference
+     * @return true if the {@code File} exists and has been modified before the given {@code Instant}.
      * @throws IllegalArgumentException if the file or instant is {@code null}
      */
     public static boolean isFileOlder(final File file, final Instant instant) {
@@ -1930,14 +1899,11 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is older than the specified
-     * <code>ZonedDateTime</code>.
+     * Tests if the specified {@code File} is older than the specified {@code ZonedDateTime}.
      *
-     * @param file          the <code>File</code> of which the modification date
-     *                      must be compared, must not be {@code null}
-     * @param zonedDateTime the date reference, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * before the given <code>ZonedDateTime</code>.
+     * @param file          the {@code File} of which the modification date must be compared
+     * @param zonedDateTime the date reference
+     * @return true if the {@code File} exists and has been modified before the given {@code ZonedDateTime}.
      * @throws IllegalArgumentException if the file or zoned date time is {@code null}
      */
     public static boolean isFileOlder(final File file, final ZonedDateTime zonedDateTime) {
@@ -1948,14 +1914,13 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is older than the specified
-     * <code>LocalDateTime</code> at the system-default time zone.
+     * Tests if the specified {@code File} is older than the specified {@code LocalDateTime}
+     * at the system-default time zone.
      *
-     * @param file          the <code>File</code> of which the modification date
-     *                      must be compared, must not be {@code null}
-     * @param localDateTime the date reference, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * before the given <code>LocalDateTime</code> at the system-default time zone.
+     * @param file          the {@code File} of which the modification date must be compared
+     * @param localDateTime the date reference
+     * @return true if the {@code File} exists and has been modified before the given
+     * {@code LocalDateTime} at the system-default time zone.
      * @throws IllegalArgumentException if the file or local date time is {@code null}
      */
     public static boolean isFileOlder(final File file, final LocalDateTime localDateTime) {
@@ -1963,15 +1928,14 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is older than the specified
-     * <code>LocalDateTime</code> at the specified <code>ZoneId</code>.
+     * Tests if the specified {@code File} is older than the specified
+     * {@code LocalDateTime} at the specified {@code ZoneId}.
      *
-     * @param file          the <code>File</code> of which the modification date
-     *                      must be compared, must not be {@code null}
-     * @param localDateTime the date reference, must not be {@code null}
-     * @param zoneId        the time zone, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * before the given <code>LocalDateTime</code> at the given <code>ZoneId</code>.
+     * @param file          the {@code File} of which the modification date must be compared
+     * @param localDateTime the date reference
+     * @param zoneId        the time zone
+     * @return true if the {@code File} exists and has been modified before the given
+     * {@code LocalDateTime} at the given {@code ZoneId}.
      * @throws IllegalArgumentException if the file, local date time or zone ID is {@code null}
      */
     public static boolean isFileOlder(final File file, final LocalDateTime localDateTime, final ZoneId zoneId) {
@@ -1985,14 +1949,13 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is older than the specified
-     * <code>LocalDate</code> at the system-default time zone.
+     * Tests if the specified {@code File} is older than the specified  {@code LocalDate}
+     * at the system-default time zone.
      *
-     * @param file      the <code>File</code> of which the modification date
-     *                  must be compared, must not be {@code null}
-     * @param localDate the date reference, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * before the given <code>LocalDate</code> at the system-default time zone.
+     * @param file      the {@code File} of which the modification date must be compared
+     * @param localDate the date reference
+     * @return true if the {@code File} exists and has been modified before the
+     * given {@code LocalDate} at the system-default time zone.
      * @throws IllegalArgumentException if the file or local date is {@code null}
      */
     public static boolean isFileOlder(final File file, final LocalDate localDate) {
@@ -2003,15 +1966,14 @@ public class FileUtils {
     }
 
     /**
-     * Tests if the specified <code>File</code> is older than the specified
-     * <code>LocalDate</code> at the specified <code>ZoneId</code>.
+     * Tests if the specified {@code File} is older than the specified {@code LocalDate}
+     * at the specified {@code ZoneId}.
      *
-     * @param file      the <code>File</code> of which the modification date
-     *                  must be compared, must not be {@code null}
-     * @param localDate the date reference, must not be {@code null}
-     * @param zoneId    the time zone, must not be {@code null}
-     * @return true if the <code>File</code> exists and has been modified
-     * before the given <code>LocalDate</code> at the given <code>ZoneId</code>.
+     * @param file      the {@code File} of which the modification date must be compared
+     * @param localDate the date reference
+     * @param zoneId    the time zone
+     * @return true if the {@code File} exists and has been modified before the given
+     * {@code LocalDate} at the given {@code ZoneId}.
      * @throws IllegalArgumentException if the file, local date or zone ID is {@code null}
      */
     public static boolean isFileOlder(final File file, final LocalDate localDate, final ZoneId zoneId) {

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1727,7 +1727,7 @@ public class FileUtils {
      */
     public static boolean isFileNewer(final File file, final Instant instant) {
         Objects.requireNonNull(instant, "instant");
-        return isFileNewer(file, instant.toEpochMilli());
+        return isFileNewer(file, instant.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
     }
 
     /**
@@ -1876,7 +1876,7 @@ public class FileUtils {
      */
     public static boolean isFileOlder(final File file, final Instant instant) {
         Objects.requireNonNull(instant, "instant");
-        return isFileOlder(file, instant.toEpochMilli());
+        return isFileOlder(file, instant.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
     }
 
     /**

--- a/src/test/java/org/apache/commons/io/FileUtilsFileNewerTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsFileNewerTestCase.java
@@ -146,8 +146,8 @@ public class FileUtilsFileNewerTestCase {
      */
     @Test
     public void testIsFileNewerNoFile() {
-        assertThrows(IllegalArgumentException.class, () -> FileUtils.isFileNewer(null,0),
-                "File not specified");
+        assertThrows(NullPointerException.class, () -> FileUtils.isFileNewer(null,0),
+                "file");
     }
 
     /**
@@ -157,8 +157,8 @@ public class FileUtilsFileNewerTestCase {
      */
     @Test
     public void testIsFileNewerNoDate() {
-        assertThrows(IllegalArgumentException.class, () -> FileUtils.isFileNewer(m_testFile1, (Date) null),
-                "Date not specified");
+        assertThrows(NullPointerException.class, () -> FileUtils.isFileNewer(m_testFile1, (Date) null),
+                "date");
     }
 
     /**
@@ -168,7 +168,7 @@ public class FileUtilsFileNewerTestCase {
      */
     @Test
     public void testIsFileNewerNoFileReference() {
-        assertThrows(IllegalArgumentException.class, () -> FileUtils.isFileNewer(m_testFile1, (File) null),
-                "Reference file is not specified");
+        assertThrows(NullPointerException.class, () -> FileUtils.isFileNewer(m_testFile1, (File) null),
+                "reference");
     }
 }

--- a/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
@@ -1127,32 +1127,32 @@ public class FileUtilsTestCase {
         // Null File
         try {
             FileUtils.isFileNewer(null, now);
-            fail("Newer Null, expected IllegalArgumentExcepion");
-        } catch (final IllegalArgumentException expected) {
+            fail("Newer Null, expected NullPointerException");
+        } catch (final NullPointerException expected) {
             // expected result
         }
 
         // Null reference File
         try {
             FileUtils.isFileNewer(oldFile, (File) null);
-            fail("Newer Null reference, expected IllegalArgumentExcepion");
-        } catch (final IllegalArgumentException ignore) {
+            fail("Newer Null reference, expected NullPointerException");
+        } catch (final NullPointerException ignore) {
             // expected result
         }
 
         // Invalid reference File
         try {
             FileUtils.isFileNewer(oldFile, invalidFile);
-            fail("Newer invalid reference, expected IllegalArgumentExcepion");
-        } catch (final IllegalArgumentException ignore) {
+            fail("Newer invalid reference, expected NullPointerException");
+        } catch (final NullPointerException ignore) {
             // expected result
         }
 
         // Null reference Date
         try {
             FileUtils.isFileNewer(oldFile, (Date) null);
-            fail("Newer Null date, expected IllegalArgumentExcepion");
-        } catch (final IllegalArgumentException ignore) {
+            fail("Newer Null date, expected NullPointerException");
+        } catch (final NullPointerException ignore) {
             // expected result
         }
 
@@ -1161,32 +1161,32 @@ public class FileUtilsTestCase {
         // Null File
         try {
             FileUtils.isFileOlder(null, now);
-            fail("Older Null, expected IllegalArgumentExcepion");
-        } catch (final IllegalArgumentException ignore) {
+            fail("Older Null, expected NullPointerException");
+        } catch (final NullPointerException ignore) {
             // expected result
         }
 
         // Null reference File
         try {
             FileUtils.isFileOlder(oldFile, (File) null);
-            fail("Older Null reference, expected IllegalArgumentExcepion");
-        } catch (final IllegalArgumentException ignore) {
+            fail("Older Null reference, expected NullPointerException");
+        } catch (final NullPointerException ignore) {
             // expected result
         }
 
         // Invalid reference File
         try {
             FileUtils.isFileOlder(oldFile, invalidFile);
-            fail("Older invalid reference, expected IllegalArgumentExcepion");
-        } catch (final IllegalArgumentException ignore) {
+            fail("Older invalid reference, expected NullPointerException");
+        } catch (final NullPointerException ignore) {
             // expected result
         }
 
         // Null reference Date
         try {
             FileUtils.isFileOlder(oldFile, (Date) null);
-            fail("Older Null date, expected IllegalArgumentExcepion");
-        } catch (final IllegalArgumentException ignore) {
+            fail("Older Null date, expected NullPointerException");
+        } catch (final NullPointerException ignore) {
             // expected result
         }
 

--- a/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
@@ -39,6 +39,11 @@ import java.math.BigInteger;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1024,6 +1029,11 @@ public class FileUtilsTestCase {
 
         final Date date = new Date();
         final long now = date.getTime();
+        final Instant instant = date.toInstant();
+        final ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, ZoneId.systemDefault());
+        final LocalDateTime localDateTime = zonedDateTime.toLocalDateTime();
+        final LocalDate localDate = zonedDateTime.toLocalDate();
+        final LocalDate localDatePlusDay = localDate.plusDays(1);
 
         do {
             try {
@@ -1065,9 +1075,27 @@ public class FileUtilsTestCase {
         assertTrue(FileUtils.isFileOlder(oldFile, reference), "Old File - Older - File");
         assertTrue(FileUtils.isFileOlder(oldFile, date), "Old File - Older - Date");
         assertTrue(FileUtils.isFileOlder(oldFile, now), "Old File - Older - Mili");
+        assertTrue(FileUtils.isFileOlder(oldFile, instant), "Old File - Older - Instant");
+        assertTrue(FileUtils.isFileOlder(oldFile, zonedDateTime), "Old File - Older - ZonedDateTime");
+        assertTrue(FileUtils.isFileOlder(oldFile, localDateTime), "Old File - Older - LocalDateTime");
+        assertTrue(FileUtils.isFileOlder(oldFile, localDateTime, ZoneId.systemDefault()), "Old File - Older - LocalDateTime,ZoneId");
+        assertFalse(FileUtils.isFileOlder(oldFile, localDate), "Old File - Older - LocalDate");
+        assertFalse(FileUtils.isFileOlder(oldFile, localDate, ZoneId.systemDefault()), "Old File - Older - LocalDate,ZoneId");
+        assertTrue(FileUtils.isFileOlder(oldFile, localDatePlusDay), "Old File - Older - LocalDate plus one day");
+        assertTrue(FileUtils.isFileOlder(oldFile, localDatePlusDay, ZoneId.systemDefault()), "Old File - Older - LocalDate plus one day,ZoneId");
+
         assertFalse(FileUtils.isFileOlder(newFile, reference), "New File - Older - File");
         assertFalse(FileUtils.isFileOlder(newFile, date), "New File - Older - Date");
         assertFalse(FileUtils.isFileOlder(newFile, now), "New File - Older - Mili");
+        assertFalse(FileUtils.isFileOlder(newFile, instant), "New File - Older - Instant");
+        assertFalse(FileUtils.isFileOlder(newFile, zonedDateTime), "New File - Older - ZonedDateTime");
+        assertFalse(FileUtils.isFileOlder(newFile, localDateTime), "New File - Older - LocalDateTime");
+        assertFalse(FileUtils.isFileOlder(newFile, localDateTime, ZoneId.systemDefault()), "New File - Older - LocalDateTime,ZoneId");
+        assertFalse(FileUtils.isFileOlder(newFile, localDate), "New File - Older - LocalDate");
+        assertFalse(FileUtils.isFileOlder(newFile, localDate, ZoneId.systemDefault()), "New File - Older - LocalDate,ZoneId");
+        assertTrue(FileUtils.isFileOlder(newFile, localDatePlusDay), "New File - Older - LocalDate plus one day");
+        assertTrue(FileUtils.isFileOlder(newFile, localDatePlusDay, ZoneId.systemDefault()), "New File - Older - LocalDate plus one day,ZoneId");
+
         assertFalse(FileUtils.isFileOlder(invalidFile, reference), "Invalid - Older - File");
         try {
             FileUtils.isFileOlder(newFile, invalidFile);
@@ -1693,7 +1721,7 @@ public class FileUtilsTestCase {
         assertEquals(testFile1Size, destination.length(), "Check Full copy");
         assertEquals(testFile1.lastModified(), destination.lastModified(), "Check last modified date preserved");
 
-        assertThrows(IOException.class, 
+        assertThrows(IOException.class,
             () -> FileUtils.copyFileToDirectory(destination, directory),
             "Should not be able to copy a file into the same directory as itself");
     }

--- a/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
@@ -1058,9 +1058,26 @@ public class FileUtilsTestCase {
         assertFalse(FileUtils.isFileNewer(oldFile, reference), "Old File - Newer - File");
         assertFalse(FileUtils.isFileNewer(oldFile, date), "Old File - Newer - Date");
         assertFalse(FileUtils.isFileNewer(oldFile, now), "Old File - Newer - Mili");
+        assertFalse(FileUtils.isFileNewer(oldFile, instant), "Old File - Newer - Instant");
+        assertFalse(FileUtils.isFileNewer(oldFile, zonedDateTime), "Old File - Newer - ZonedDateTime");
+        assertFalse(FileUtils.isFileNewer(oldFile, localDateTime), "Old File - Newer - LocalDateTime");
+        assertFalse(FileUtils.isFileNewer(oldFile, localDateTime, ZoneId.systemDefault()), "Old File - Newer - LocalDateTime,ZoneId");
+        assertTrue(FileUtils.isFileNewer(oldFile, localDate), "Old File - Newer - LocalDate");
+        assertTrue(FileUtils.isFileNewer(oldFile, localDate, ZoneId.systemDefault()), "Old File - Newer - LocalDate,ZoneId");
+        assertFalse(FileUtils.isFileNewer(oldFile, localDatePlusDay), "Old File - Newer - LocalDate plus one day");
+        assertFalse(FileUtils.isFileNewer(oldFile, localDatePlusDay, ZoneId.systemDefault()), "Old File - Newer - LocalDate plus one day,ZoneId");
+
         assertTrue(FileUtils.isFileNewer(newFile, reference), "New File - Newer - File");
         assertTrue(FileUtils.isFileNewer(newFile, date), "New File - Newer - Date");
         assertTrue(FileUtils.isFileNewer(newFile, now), "New File - Newer - Mili");
+        assertTrue(FileUtils.isFileNewer(newFile, instant), "New File - Newer - Instant");
+        assertTrue(FileUtils.isFileNewer(newFile, zonedDateTime), "New File - Newer - ZonedDateTime");
+        assertTrue(FileUtils.isFileNewer(newFile, localDateTime), "New File - Newer - LocalDateTime");
+        assertTrue(FileUtils.isFileNewer(newFile, localDateTime, ZoneId.systemDefault()), "New File - Newer - LocalDateTime,ZoneId");
+        assertTrue(FileUtils.isFileNewer(newFile, localDate), "New File - Newer - LocalDate");
+        assertTrue(FileUtils.isFileNewer(newFile, localDate, ZoneId.systemDefault()), "New File - Newer - LocalDate,ZoneId");
+        assertFalse(FileUtils.isFileNewer(newFile, localDatePlusDay), "New File - Newer - LocalDate plus one day");
+        assertFalse(FileUtils.isFileNewer(newFile, localDatePlusDay, ZoneId.systemDefault()), "New File - Newer - LocalDate plus one day,ZoneId");
         assertFalse(FileUtils.isFileNewer(invalidFile, reference), "Invalid - Newer - File");
         final String invalidFileName = invalidFile.getName();
         try {

--- a/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTestCase.java
@@ -42,6 +42,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -1034,6 +1035,7 @@ public class FileUtilsTestCase {
         final LocalDateTime localDateTime = zonedDateTime.toLocalDateTime();
         final LocalDate localDate = zonedDateTime.toLocalDate();
         final LocalDate localDatePlusDay = localDate.plusDays(1);
+        final LocalTime localTime = LocalTime.ofSecondOfDay(0);
 
         do {
             try {
@@ -1062,10 +1064,10 @@ public class FileUtilsTestCase {
         assertFalse(FileUtils.isFileNewer(oldFile, zonedDateTime), "Old File - Newer - ZonedDateTime");
         assertFalse(FileUtils.isFileNewer(oldFile, localDateTime), "Old File - Newer - LocalDateTime");
         assertFalse(FileUtils.isFileNewer(oldFile, localDateTime, ZoneId.systemDefault()), "Old File - Newer - LocalDateTime,ZoneId");
-        assertTrue(FileUtils.isFileNewer(oldFile, localDate), "Old File - Newer - LocalDate");
-        assertTrue(FileUtils.isFileNewer(oldFile, localDate, ZoneId.systemDefault()), "Old File - Newer - LocalDate,ZoneId");
+        assertFalse(FileUtils.isFileNewer(oldFile, localDate), "Old File - Newer - LocalDate");
+        assertTrue(FileUtils.isFileNewer(oldFile, localDate, localTime), "Old File - Newer - LocalDate,ZoneId");
         assertFalse(FileUtils.isFileNewer(oldFile, localDatePlusDay), "Old File - Newer - LocalDate plus one day");
-        assertFalse(FileUtils.isFileNewer(oldFile, localDatePlusDay, ZoneId.systemDefault()), "Old File - Newer - LocalDate plus one day,ZoneId");
+        assertFalse(FileUtils.isFileNewer(oldFile, localDatePlusDay, localTime), "Old File - Newer - LocalDate plus one day,ZoneId");
 
         assertTrue(FileUtils.isFileNewer(newFile, reference), "New File - Newer - File");
         assertTrue(FileUtils.isFileNewer(newFile, date), "New File - Newer - Date");
@@ -1074,10 +1076,10 @@ public class FileUtilsTestCase {
         assertTrue(FileUtils.isFileNewer(newFile, zonedDateTime), "New File - Newer - ZonedDateTime");
         assertTrue(FileUtils.isFileNewer(newFile, localDateTime), "New File - Newer - LocalDateTime");
         assertTrue(FileUtils.isFileNewer(newFile, localDateTime, ZoneId.systemDefault()), "New File - Newer - LocalDateTime,ZoneId");
-        assertTrue(FileUtils.isFileNewer(newFile, localDate), "New File - Newer - LocalDate");
-        assertTrue(FileUtils.isFileNewer(newFile, localDate, ZoneId.systemDefault()), "New File - Newer - LocalDate,ZoneId");
+        assertFalse(FileUtils.isFileNewer(newFile, localDate), "New File - Newer - LocalDate");
+        assertTrue(FileUtils.isFileNewer(newFile, localDate, localTime), "New File - Newer - LocalDate,ZoneId");
         assertFalse(FileUtils.isFileNewer(newFile, localDatePlusDay), "New File - Newer - LocalDate plus one day");
-        assertFalse(FileUtils.isFileNewer(newFile, localDatePlusDay, ZoneId.systemDefault()), "New File - Newer - LocalDate plus one day,ZoneId");
+        assertFalse(FileUtils.isFileNewer(newFile, localDatePlusDay, localTime), "New File - Newer - LocalDate plus one day,ZoneId");
         assertFalse(FileUtils.isFileNewer(invalidFile, reference), "Invalid - Newer - File");
         final String invalidFileName = invalidFile.getName();
         try {
@@ -1095,11 +1097,11 @@ public class FileUtilsTestCase {
         assertTrue(FileUtils.isFileOlder(oldFile, instant), "Old File - Older - Instant");
         assertTrue(FileUtils.isFileOlder(oldFile, zonedDateTime), "Old File - Older - ZonedDateTime");
         assertTrue(FileUtils.isFileOlder(oldFile, localDateTime), "Old File - Older - LocalDateTime");
-        assertTrue(FileUtils.isFileOlder(oldFile, localDateTime, ZoneId.systemDefault()), "Old File - Older - LocalDateTime,ZoneId");
-        assertFalse(FileUtils.isFileOlder(oldFile, localDate), "Old File - Older - LocalDate");
-        assertFalse(FileUtils.isFileOlder(oldFile, localDate, ZoneId.systemDefault()), "Old File - Older - LocalDate,ZoneId");
+        assertTrue(FileUtils.isFileOlder(oldFile, localDateTime, ZoneId.systemDefault()), "Old File - Older - LocalDateTime,LocalTime");
+        assertTrue(FileUtils.isFileOlder(oldFile, localDate), "Old File - Older - LocalDate");
+        assertFalse(FileUtils.isFileOlder(oldFile, localDate, localTime), "Old File - Older - LocalDate,ZoneId");
         assertTrue(FileUtils.isFileOlder(oldFile, localDatePlusDay), "Old File - Older - LocalDate plus one day");
-        assertTrue(FileUtils.isFileOlder(oldFile, localDatePlusDay, ZoneId.systemDefault()), "Old File - Older - LocalDate plus one day,ZoneId");
+        assertTrue(FileUtils.isFileOlder(oldFile, localDatePlusDay, localTime), "Old File - Older - LocalDate plus one day,LocalTime");
 
         assertFalse(FileUtils.isFileOlder(newFile, reference), "New File - Older - File");
         assertFalse(FileUtils.isFileOlder(newFile, date), "New File - Older - Date");
@@ -1108,10 +1110,10 @@ public class FileUtilsTestCase {
         assertFalse(FileUtils.isFileOlder(newFile, zonedDateTime), "New File - Older - ZonedDateTime");
         assertFalse(FileUtils.isFileOlder(newFile, localDateTime), "New File - Older - LocalDateTime");
         assertFalse(FileUtils.isFileOlder(newFile, localDateTime, ZoneId.systemDefault()), "New File - Older - LocalDateTime,ZoneId");
-        assertFalse(FileUtils.isFileOlder(newFile, localDate), "New File - Older - LocalDate");
-        assertFalse(FileUtils.isFileOlder(newFile, localDate, ZoneId.systemDefault()), "New File - Older - LocalDate,ZoneId");
+        assertTrue(FileUtils.isFileOlder(newFile, localDate), "New File - Older - LocalDate");
+        assertFalse(FileUtils.isFileOlder(newFile, localDate, localTime), "New File - Older - LocalDate,LocalTime");
         assertTrue(FileUtils.isFileOlder(newFile, localDatePlusDay), "New File - Older - LocalDate plus one day");
-        assertTrue(FileUtils.isFileOlder(newFile, localDatePlusDay, ZoneId.systemDefault()), "New File - Older - LocalDate plus one day,ZoneId");
+        assertTrue(FileUtils.isFileOlder(newFile, localDatePlusDay, localTime), "New File - Older - LocalDate plus one day,LocalTime");
 
         assertFalse(FileUtils.isFileOlder(invalidFile, reference), "Invalid - Older - File");
         try {
@@ -1143,8 +1145,8 @@ public class FileUtilsTestCase {
         // Invalid reference File
         try {
             FileUtils.isFileNewer(oldFile, invalidFile);
-            fail("Newer invalid reference, expected NullPointerException");
-        } catch (final NullPointerException ignore) {
+            fail("Newer invalid reference, expected IllegalArgumentException");
+        } catch (final IllegalArgumentException ignore) {
             // expected result
         }
 
@@ -1177,8 +1179,8 @@ public class FileUtilsTestCase {
         // Invalid reference File
         try {
             FileUtils.isFileOlder(oldFile, invalidFile);
-            fail("Older invalid reference, expected NullPointerException");
-        } catch (final NullPointerException ignore) {
+            fail("Older invalid reference, expected IllegalArgumentException");
+        } catch (final IllegalArgumentException ignore) {
             // expected result
         }
 


### PR DESCRIPTION
Add `isFileNewer()` and `isFileOlder()` methods to `FileUtils` that accept the Java 8 Date/Time API classes, such as `Instant`, as parameters.