### PR TITLE
[IO-679] input.AbstractCharacterFilterReader passes count of chars read

### DIFF
--- a/src/main/java/org/apache/commons/io/input/AbstractCharacterFilterReader.java
+++ b/src/main/java/org/apache/commons/io/input/AbstractCharacterFilterReader.java
@@ -61,7 +61,7 @@ public abstract class AbstractCharacterFilterReader extends FilterReader {
         }
         int pos = off - 1;
         for (int readPos = off; readPos < off + read; readPos++) {
-            if (filter(read)) {
+            if (filter(cbuf[readPos])) {
                 continue;
             }
             pos++;

--- a/src/test/java/org/apache/commons/io/input/CharacterFilterReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/CharacterFilterReaderTest.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.HashSet;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.StringBuilderWriter;
 import org.junit.jupiter.api.Test;
 
 public class CharacterFilterReaderTest {
@@ -67,6 +69,26 @@ public class CharacterFilterReaderTest {
         try (CharacterFilterReader reader = new CharacterFilterReader(input, 'b')) {
             assertEquals('a', reader.read());
             assertEquals(-1, reader.read());
+        }
+    }
+
+    @Test
+    public void testReadIntoBuffer() throws IOException {
+        final StringReader input = new StringReader("ababcabcd");
+        try (CharacterFilterReader reader = new CharacterFilterReader(input, 'b')) {
+            char[] buff = new char[9];
+            int charCount = reader.read(buff);
+            assertEquals(6, charCount);
+            assertEquals("aacacd", new String(buff, 0, charCount));
+        }
+    }
+
+    @Test
+    public void testReadUsingReader() throws IOException {
+        final StringReader input = new StringReader("ababcabcd");
+        try (StringBuilderWriter output = new StringBuilderWriter(); CharacterFilterReader reader = new CharacterFilterReader(input, 'b')) {
+            IOUtils.copy(reader, output);
+            assertEquals("aacacd", output.toString());
         }
     }
 


### PR DESCRIPTION
A bug in the read(final char[] cbuf, final int off, final int len)
method causes the filter function to receive the count of chars read
instead of iteratively getting each char code point

This affects subclasses CharacterFilterReader and
CharacterSetFilterReader also.

Added to tests to cover the bug