### PR TITLE
Make `FilenameUtils.equals()` not throw an exception

### DIFF
--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -1193,12 +1193,11 @@ public class FilenameUtils {
      * Checks whether two fileNames are equal, optionally normalizing and providing
      * control over the case-sensitivity.
      *
-     * @param fileName1  the first fileName to query, may be null, otherwise must be valid
-     * @param fileName2  the second fileName to query, may be null, otherwise must be valid
+     * @param fileName1  the first fileName to query, may be null
+     * @param fileName2  the second fileName to query, may be null
      * @param normalized  whether to normalize the fileNames
      * @param caseSensitivity  what case sensitivity rule to use, null means case-sensitive
      * @return true if the fileNames are equal, null equals null
-     * @throws IllegalArgumentException if fileName1 or fileName2 is invalid
      * @since 1.3
      */
     public static boolean equals(
@@ -1209,15 +1208,13 @@ public class FilenameUtils {
             return fileName1 == null && fileName2 == null;
         }
         if (normalized) {
-            String originalFileName1 = fileName1;
-            String originalFileName2 = fileName2;
             fileName1 = normalize(fileName1);
-            fileName2 = normalize(fileName2);
             if (fileName1 == null) {
-                throw new IllegalArgumentException("Error normalizing " + originalFileName1);
+                return false;
             }
+            fileName2 = normalize(fileName2);
             if (fileName2 == null) {
-                throw new IllegalArgumentException("Error normalizing " + originalFileName2);
+                return false;
             }
         }
         if (caseSensitivity == null) {

--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -1194,11 +1194,12 @@ public class FilenameUtils {
      * Checks whether two fileNames are equal, optionally normalizing and providing
      * control over the case-sensitivity.
      *
-     * @param fileName1  the first fileName to query, may be null
-     * @param fileName2  the second fileName to query, may be null
+     * @param fileName1  the first fileName to query, may be null, otherwise must be valid
+     * @param fileName2  the second fileName to query, may be null, otherwise must be valid
      * @param normalized  whether to normalize the fileNames
      * @param caseSensitivity  what case sensitivity rule to use, null means case-sensitive
      * @return true if the fileNames are equal, null equals null
+     * @throws IllegalArgumentException if fileName1 or fileName2 is invalid
      * @since 1.3
      */
     public static boolean equals(
@@ -1209,10 +1210,16 @@ public class FilenameUtils {
             return fileName1 == null && fileName2 == null;
         }
         if (normalized) {
+            String originalFileName1 = fileName1;
+            String originalFileName2 = fileName2;
             fileName1 = normalize(fileName1);
             fileName2 = normalize(fileName2);
-            Objects.requireNonNull(fileName1, "Error normalizing one or both of the file names");
-            Objects.requireNonNull(fileName2, "Error normalizing one or both of the file names");
+            if (fileName1 == null) {
+                throw new IllegalArgumentException("Error normalizing " + originalFileName1);
+            }
+            if (fileName2 == null) {
+                throw new IllegalArgumentException("Error normalizing " + originalFileName2);
+            }
         }
         if (caseSensitivity == null) {
             caseSensitivity = IOCase.SENSITIVE;

--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -24,7 +24,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Deque;
 import java.util.List;
-import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/test/java/org/apache/commons/io/FilenameUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FilenameUtilsTestCase.java
@@ -997,24 +997,9 @@ public class FilenameUtilsTestCase {
      */
     @Test
     public void testEqualsNormalizedError_IO_128() {
-        try {
-            FilenameUtils.equalsNormalizedOnSystem("//file.txt", "file.txt");
-            fail("Invalid normalized first file");
-        } catch (final IllegalArgumentException e) {
-            // expected result
-        }
-        try {
-            FilenameUtils.equalsNormalizedOnSystem("file.txt", "//file.txt");
-            fail("Invalid normalized second file");
-        } catch (final IllegalArgumentException e) {
-            // expected result
-        }
-        try {
-            FilenameUtils.equalsNormalizedOnSystem("//file.txt", "//file.txt");
-            fail("Invalid normalized both filse");
-        } catch (final IllegalArgumentException e) {
-            // expected result
-        }
+        assertFalse(FilenameUtils.equalsNormalizedOnSystem("//file.txt", "file.txt"));
+        assertFalse(FilenameUtils.equalsNormalizedOnSystem("file.txt", "//file.txt"));
+        assertFalse(FilenameUtils.equalsNormalizedOnSystem("//file.txt", "//file.txt"));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/FilenameUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FilenameUtilsTestCase.java
@@ -1000,19 +1000,19 @@ public class FilenameUtilsTestCase {
         try {
             FilenameUtils.equalsNormalizedOnSystem("//file.txt", "file.txt");
             fail("Invalid normalized first file");
-        } catch (final NullPointerException e) {
+        } catch (final IllegalArgumentException e) {
             // expected result
         }
         try {
             FilenameUtils.equalsNormalizedOnSystem("file.txt", "//file.txt");
             fail("Invalid normalized second file");
-        } catch (final NullPointerException e) {
+        } catch (final IllegalArgumentException e) {
             // expected result
         }
         try {
             FilenameUtils.equalsNormalizedOnSystem("//file.txt", "//file.txt");
             fail("Invalid normalized both filse");
-        } catch (final NullPointerException e) {
+        } catch (final IllegalArgumentException e) {
             // expected result
         }
     }


### PR DESCRIPTION
It is surprising that `FilenameUtils.equals` can throw `NullPointerException`, because:
 * such behavior is outside the ordinary contract of `equals()`, and
 * `FilenameUtils.equals` throws NullPointerExceptioneven if the client did not pass `null` as an argument.  It throws NullPointerExceptioneven if one of the arguments is not a valid, normalizable filename.  However, this behavior is not documented.

This pull request:
 * documents the requirement that the arguments must be valid,
 * makes the exception message more specific, indicating the filename that was invalid, and
 * throws `IllegalArgumentException` instead of `NullPointerException`.
