### PR TITLE
IO-429: Check for long streams in IOUtils.toByteArray

### DIFF
--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -2394,10 +2394,13 @@ public class IOUtils {
      * @return the requested byte array.
      * @throws NullPointerException if the InputStream is {@code null}.
      * @throws IOException if an I/O error occurs.
+     * @throws IllegalArgumentException if input is longer than the maximum Java array length.
      */
     public static byte[] toByteArray(final InputStream inputStream) throws IOException {
         try (final ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-            copy(inputStream, output);
+            if (copy(inputStream, output) == -1) {
+                throw new IllegalArgumentException("Stream cannot be longer than Integer max value bytes");
+            }
             return output.toByteArray();
         }
     }

--- a/src/test/java/org/apache/commons/io/IOUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTestCase.java
@@ -62,6 +62,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.io.function.IOConsumer;
+import org.apache.commons.io.input.CircularInputStream;
 import org.apache.commons.io.input.NullInputStream;
 import org.apache.commons.io.output.AppendableWriter;
 import org.apache.commons.io.output.NullOutputStream;
@@ -1435,9 +1436,13 @@ public class IOUtilsTestCase {
         }
     }
 
+    @Test public void testToByteArray_InputStreamTooLong() throws Exception {
+        CircularInputStream cin = new CircularInputStream(new byte[]{65, 65, 65}, ((long)Integer.MAX_VALUE) + 1L);
+        assertThrows(IllegalArgumentException.class, () -> IOUtils.toByteArray(cin));
+    }
+
     @Test
     public void testToByteArray_InputStream_NegativeSize() throws Exception {
-
         try (FileInputStream fin = new FileInputStream(testFile)) {
             IOUtils.toByteArray(fin, -1);
             fail("IllegalArgumentException expected");


### PR DESCRIPTION
Throw an `IllegalArgumentException` when an `InputStream` provided to `IOUtils.toByteArray()` is longer than `Integer.MAX_VALUE` bytes. Processing of such long arrays is not possible, as arrays with `long` indices are [forbidden](https://docs.oracle.com/javase/specs/jls/se14/html/jls-10.html#jls-10.4) by Java language specification.