### PR TITLE
Fix Typos in JavaDoc, Comments and Tests

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -2192,7 +2192,7 @@ public class FileUtils {
      * @throws IOException if the directory was not created along with all its parent directories.
      * @throws IOException if the given file object is not a directory.
      * @throws SecurityException See {@link File#mkdirs()}.
-     * @see @see File#mkdirs()
+     * @see File#mkdirs()
      */
     private static File mkdirs(final File directory) throws IOException {
         if (directory != null) {
@@ -2625,7 +2625,7 @@ public class FileUtils {
      * Requires that the given {@code File} is a directory.
      *
      * @param directory The {@code File} to check.
-     * @param name
+     * @param name The parameter name to use in the exception message in case of null input or if the file is not a directory.
      * @return the given directory.
      * @throws NullPointerException if the given {@code File} is {@code null}.
      * @throws IllegalArgumentException if the given {@code File} does not exist or is not a directory.
@@ -3052,7 +3052,7 @@ public class FileUtils {
      *
      * @param extensions an array of extensions. Format: {"java", "xml"}
      * @return an array of suffixes. Format: {".java", ".xml"}
-     * @throws NullPointerException
+     * @throws NullPointerException if the parameter is null
      */
     private static String[] toSuffixes(final String... extensions) {
         Objects.requireNonNull(extensions, "extensions");

--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -1430,7 +1430,7 @@ public class FilenameUtils {
                     } else {
                         // matching from current position
                         if (!caseSensitivity.checkRegionMatches(fileName, textIdx, wcs[wcsIdx])) {
-                            // couldnt match token
+                            // couldn't match token
                             break;
                         }
                     }

--- a/src/main/java/org/apache/commons/io/input/XmlStreamReader.java
+++ b/src/main/java/org/apache/commons/io/input/XmlStreamReader.java
@@ -512,7 +512,7 @@ public class XmlStreamReader extends Reader {
      *         the URLConnection.
      */
     public XmlStreamReader(final URLConnection conn, final String defaultEncoding) throws IOException {
-        Objects.requireNonNull(conn, "conm");
+        Objects.requireNonNull(conn, "conn");
         this.defaultEncoding = defaultEncoding;
         final boolean lenient = true;
         final String contentType = conn.getContentType();

--- a/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
@@ -301,7 +301,7 @@ public abstract class AbstractByteArrayOutputStream extends OutputStream {
      * @see #reset()
      * @since 2.7
      */
-    @SuppressWarnings("resource") // The result InputStream MUIST be managed by the call site.
+    @SuppressWarnings("resource") // The result InputStream MUST be managed by the call site.
     protected <T extends InputStream> InputStream toInputStream(
             final InputStreamConstructor<T> isConstructor) {
         int remaining = count;

--- a/src/main/java/org/apache/commons/io/output/WriterOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/WriterOutputStream.java
@@ -333,14 +333,14 @@ public class WriterOutputStream extends OutputStream {
             try {
                 charsetDecoder2.decode(bb2, cb2, i == (len - 1));
             } catch ( final IllegalArgumentException e){
-                throw new UnsupportedOperationException("UTF-16 requested when runninng on an IBM JDK with broken UTF-16 support. " +
+                throw new UnsupportedOperationException("UTF-16 requested when running on an IBM JDK with broken UTF-16 support. " +
                         "Please find a JDK that supports UTF-16 if you intend to use UF-16 with WriterOutputStream");
             }
             bb2.compact();
         }
         cb2.rewind();
         if (!TEST_STRING_2.equals(cb2.toString())){
-            throw new UnsupportedOperationException("UTF-16 requested when runninng on an IBM JDK with broken UTF-16 support. " +
+            throw new UnsupportedOperationException("UTF-16 requested when running on an IBM JDK with broken UTF-16 support. " +
                     "Please find a JDK that supports UTF-16 if you intend to use UF-16 with WriterOutputStream");
         }
 

--- a/src/test/java/org/apache/commons/io/FileSystemUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileSystemUtilsTestCase.java
@@ -72,7 +72,7 @@ public class FileSystemUtilsTestCase {
             final long kb = FileSystemUtils.freeSpaceKb("/");
             // Assume disk space does not fluctuate
             // more than 1% between the above two calls;
-            // this also also small enough to verifiy freeSpaceKb uses
+            // this also also small enough to verify freeSpaceKb uses
             // kibibytes (1024) instead of SI kilobytes (1000)
             final double acceptableDelta = kb * 0.01d;
             if (kilobyteBlock) {

--- a/src/test/java/org/apache/commons/io/FileUtilsDirectoryContainsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsDirectoryContainsTestCase.java
@@ -156,7 +156,7 @@ public class FileUtilsDirectoryContainsTestCase {
         final File file = new File(top, "DOESNOTEXIST");
         assertTrue(top.exists(), "Check directory exists");
         assertFalse(file.exists(), "Check file does not exist");
-        assertFalse(FileUtils.directoryContains(top, file), "Direcory does not contain unrealized file");
+        assertFalse(FileUtils.directoryContains(top, file), "Directory does not contain unrealized file");
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 /**
  * Tests functionality of {@link BufferedFileChannelInputStream}.
  *
- * This class was ported and adapted from Apache Spark commit 933dc6cb7b3de1d8ccaf73d124d6eb95b947ed19 wher it was
+ * This class was ported and adapted from Apache Spark commit 933dc6cb7b3de1d8ccaf73d124d6eb95b947ed19 where it was
  * called {@code BufferedFileChannelInputStreamSuite}.
  */
 public class BufferedFileChannelInputStreamTest extends AbstractInputStreamTest {

--- a/src/test/java/org/apache/commons/io/input/NullInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/NullInputStreamTest.java
@@ -46,7 +46,7 @@ public class NullInputStreamTest {
         }
         assertEquals(0, input.available(), "Available after contents all read");
 
-        // Check availabale is zero after End of file
+        // Check available is zero after End of file
         assertEquals(-1, input.read(), "End of File");
         assertEquals(0, input.available(), "Available after End of File");
 

--- a/src/test/java/org/apache/commons/io/input/XmlStreamReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/XmlStreamReaderTest.java
@@ -481,7 +481,7 @@ public class XmlStreamReaderTest {
         final String xmlDoc = getXML(bomType, xmlType, streamEnc, prologEnc);
         writer.write(xmlDoc);
 
-        // PADDDING TO TEST THINGS WORK BEYOND PUSHBACK_SIZE
+        // PADDING TO TEST THINGS WORK BEYOND PUSHBACK_SIZE
         writer.write("<da>\n");
         for (int i = 0; i < 10000; i++) {
             writer.write("<do/>\n");

--- a/src/test/java/org/apache/commons/io/input/XmlStreamReaderUtilitiesTest.java
+++ b/src/test/java/org/apache/commons/io/input/XmlStreamReaderUtilitiesTest.java
@@ -171,7 +171,7 @@ public class XmlStreamReaderUtilitiesTest {
     }
 
     @Test
-    public void testCalculateRawEncodingAdditonalUTF16() throws IOException {
+    public void testCalculateRawEncodingAdditionalUTF16() throws IOException {
         //                           BOM         Guess       XML         Default
         checkRawError(RAWMGS1,       "UTF-16BE", "UTF-16",   null,       null);
         checkRawEncoding("UTF-16BE", "UTF-16BE", null,       "UTF-16",   null);
@@ -186,7 +186,7 @@ public class XmlStreamReaderUtilitiesTest {
     }
 
     @Test
-    public void testCalculateRawEncodingAdditonalUTF32() throws IOException {
+    public void testCalculateRawEncodingAdditionalUTF32() throws IOException {
         //                           BOM         Guess       XML         Default
         checkRawError(RAWMGS1,       "UTF-32BE", "UTF-32",   null,       null);
         checkRawEncoding("UTF-32BE", "UTF-32BE", null,       "UTF-32",   null);

--- a/src/test/java/org/apache/commons/io/input/buffer/CircularBufferInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/buffer/CircularBufferInputStreamTest.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 
 public class CircularBufferInputStreamTest {
 	private final Random rnd = new Random(1530960934483L); // System.currentTimeMillis(), when this test was written.
-	                                                       // Always using the same seed should ensure a reproducable test.
+	                                                       // Always using the same seed should ensure a reproducible test.
 
 	@Test
 	public void testRandomRead() throws Exception {

--- a/src/test/java/org/apache/commons/io/output/DeferredFileOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/DeferredFileOutputStreamTest.java
@@ -215,7 +215,7 @@ public class DeferredFileOutputStreamTest {
 
             try {
                 dfos.writeTo(baos);
-                fail("Should not have been able to write before closeing");
+                fail("Should not have been able to write before closing");
             } catch (final IOException ioe) {
                 // ok, as expected
             }


### PR DESCRIPTION
This PR fixes a number of smaller typos (none affecting compiled results).