### PR TITLE
IO-727: FilenameUtils directoryContains() should handle files with the same prefix

### DIFF
--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -519,7 +519,7 @@ public class FilenameUtils {
     /**
      * Determines whether the {@code parent} directory contains the {@code child} element (a file or directory).
      * <p>
-     * The files names are expected to be normalized.
+     * The files names are expected to be canonical.
      * </p>
      *
      * Edge cases:

--- a/src/test/java/org/apache/commons/io/FileUtilsDirectoryContainsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsDirectoryContainsTestCase.java
@@ -147,6 +147,12 @@ public class FileUtilsDirectoryContainsTestCase {
     }
 
     @Test
+    public void testIO466() throws IOException {
+        final File fooFile = new File(directory1.getParent(), "directory1.txt");
+        assertFalse(FileUtils.directoryContains(directory1, fooFile));
+    }
+
+    @Test
     public void testFileHavingSamePrefixBug() throws IOException {
         final File foo = new File(top, "foo");
         final File foobar = new File(top, "foobar");

--- a/src/test/java/org/apache/commons/io/FileUtilsDirectoryContainsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsDirectoryContainsTestCase.java
@@ -134,9 +134,16 @@ public class FileUtilsDirectoryContainsTestCase {
     }
 
     @Test
-    public void testIO466() throws IOException {
-            final File fooFile = new File(directory1.getParent(), "directory1.txt");
-            assertFalse(FileUtils.directoryContains(directory1, fooFile));
+    public void testFileHavingSamePrefixBug() throws IOException {
+        final File foo = new File(top, "foo");
+        final File foobar = new File(top, "foobar");
+        final File fooTxt = new File(top, "foo.txt");
+        foo.mkdir();
+        foobar.mkdir();
+        FileUtils.touch(fooTxt);
+
+        assertFalse(FileUtils.directoryContains(foo, foobar));
+        assertFalse(FileUtils.directoryContains(foo, fooTxt));
     }
 
     @Test


### PR DESCRIPTION
- Fix `FilenameUtils.directoryContains`. Add a file separator to the end of the parent directory to avoid treating files having the same prefix as subdirectories. `directoryContains` will return false when either parent or child is empty.
- Explicitly state in the docs that the input paths are expected to be canonical.
- Add a new test case for FilenameUtils.directoryContains.
- Replace `testIO466` with a new test case to demonstrate the bug (the current `testIO466` will always pass because fooFile doesn't exist)

Jira: https://issues.apache.org/jira/browse/IO-727