### PR TITLE
Prevent infinite loop with AbstractCharacterFilterReader if EOF is filtered out

### DIFF
--- a/src/main/java/org/apache/commons/io/input/AbstractCharacterFilterReader.java
+++ b/src/main/java/org/apache/commons/io/input/AbstractCharacterFilterReader.java
@@ -42,7 +42,7 @@ public abstract class AbstractCharacterFilterReader extends FilterReader {
         int ch;
         do {
             ch = in.read();
-        } while (filter(ch));
+        } while (ch != EOF && filter(ch));
         return ch;
     }
 

--- a/src/test/java/org/apache/commons/io/input/CharacterFilterReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/CharacterFilterReaderTest.java
@@ -17,9 +17,11 @@
 package org.apache.commons.io.input;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.Duration;
 import java.util.HashSet;
 
 import org.apache.commons.io.IOUtils;
@@ -92,4 +94,17 @@ public class CharacterFilterReaderTest {
         }
     }
 
+    @Test
+    public void testReadFilteringEOF() throws IOException {
+        final StringReader input = new StringReader("ababcabcd");
+        assertTimeoutPreemptively(Duration.ofMillis(500), () -> {
+            try (StringBuilderWriter output = new StringBuilderWriter(); CharacterFilterReader reader = new CharacterFilterReader(input, -1)) {
+                int c;
+                while ((c = reader.read()) != -1) {
+                    output.write(c);
+                }
+                assertEquals("ababcabcd", output.toString());
+            }
+        });
+    }
 }


### PR DESCRIPTION
`AbstractCharacterFilterReader.read()` only aborts its loop if `filter(ch)` returns false. If that method returns `true` for EOF, you'll get an infinite loop if the backing `read()` call keeps returning EOF. That's really easy to achieve with `CharacterFilterReader`.

This small fix aborts the loop not only if `filter(ch)` returns false, but also if the backing `read()` call returns EOF.