### PR TITLE
IntPredicateFilterReader

### DIFF
--- a/src/main/java/org/apache/commons/io/input/IntPredicateFilterReader.java
+++ b/src/main/java/org/apache/commons/io/input/IntPredicateFilterReader.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.input;
+
+import java.io.Reader;
+import java.util.function.IntPredicate;
+
+/**
+ * A filter reader that removes characters represented as {@code int} code points that match a predicate,
+ * handy to remove white space characters for example. This class is the most efficient way to filter out
+ * multiple characters using a simple predicate.
+ *
+ * @since 2.9.0
+ */
+public class IntPredicateFilterReader extends AbstractCharacterFilterReader {
+
+    private static final IntPredicate SKIP_NONE = ch -> false;
+
+    private final IntPredicate skip;
+
+    /**
+     * Constructs a new reader.
+     *
+     * @param reader the reader to filter.
+     * @param skip the predicates that determines which characters are filtered out.
+     */
+    public IntPredicateFilterReader(final Reader reader, final IntPredicate skip) {
+        super(reader);
+        this.skip = skip == null ? SKIP_NONE : skip;
+    }
+
+    @Override
+    protected boolean filter(final int ch) {
+        return skip.test(ch);
+    }
+
+}

--- a/src/test/java/org/apache/commons/io/input/IntPredicateFilterReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/IntPredicateFilterReaderTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.input;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.io.StringReader;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.output.StringBuilderWriter;
+import org.junit.jupiter.api.Test;
+
+public class IntPredicateFilterReaderTest {
+
+    @Test
+    public void testInputSize0FilterAll() throws IOException {
+        final StringReader input = new StringReader("");
+        try (IntPredicateFilterReader reader = new IntPredicateFilterReader(input, ch -> true)) {
+            assertEquals(-1, reader.read());
+        }
+    }
+
+    @Test
+    public void testInputSize1FilterAll() throws IOException {
+        try (StringReader input = new StringReader("a");
+                IntPredicateFilterReader reader = new IntPredicateFilterReader(input, ch -> true)) {
+            assertEquals(-1, reader.read());
+        }
+    }
+
+    @Test
+    public void testInputSize2FilterAll() throws IOException {
+        final StringReader input = new StringReader("aa");
+        try (IntPredicateFilterReader reader = new IntPredicateFilterReader(input, ch -> true)) {
+            assertEquals(-1, reader.read());
+        }
+    }
+
+    @Test
+    public void testInputSize2FilterFirst() throws IOException {
+        final StringReader input = new StringReader("ab");
+        try (IntPredicateFilterReader reader = new IntPredicateFilterReader(input, ch -> ch == 'a')) {
+            assertEquals('b', reader.read());
+            assertEquals(-1, reader.read());
+        }
+    }
+
+    @Test
+    public void testInputSize2FilterLast() throws IOException {
+        final StringReader input = new StringReader("ab");
+        try (IntPredicateFilterReader reader = new IntPredicateFilterReader(input, ch -> ch == 'b')) {
+            assertEquals('a', reader.read());
+            assertEquals(-1, reader.read());
+        }
+    }
+
+    @Test
+    public void testInputSize5FilterWhitespace() throws IOException {
+        final StringReader input = new StringReader(" a b ");
+        try (IntPredicateFilterReader reader = new IntPredicateFilterReader(input, Character::isWhitespace)) {
+            assertEquals('a', reader.read());
+            assertEquals('b', reader.read());
+            assertEquals(-1, reader.read());
+        }
+    }
+
+    @Test
+    public void testReadIntoBuffer() throws IOException {
+        final StringReader input = new StringReader("ababcabcd");
+        try (IntPredicateFilterReader reader = new IntPredicateFilterReader(input, ch -> ch == 'b')) {
+            final char[] buff = new char[9];
+            final int charCount = reader.read(buff);
+            assertEquals(6, charCount);
+            assertEquals("aacacd", new String(buff, 0, charCount));
+        }
+    }
+
+    @Test
+    public void testReadIntoBufferFilterWhitespace() throws IOException {
+        final StringReader input = new StringReader(" a b a b c a b c d ");
+        try (IntPredicateFilterReader reader = new IntPredicateFilterReader(input, Character::isWhitespace)) {
+            final char[] buff = new char[19];
+            final int charCount = reader.read(buff);
+            assertEquals(9, charCount);
+            assertEquals("ababcabcd", new String(buff, 0, charCount));
+        }
+    }
+
+    @Test
+    public void testReadUsingReader() throws IOException {
+        final StringReader input = new StringReader("ababcabcd");
+        try (StringBuilderWriter output = new StringBuilderWriter();
+                IntPredicateFilterReader reader = new IntPredicateFilterReader(input, ch -> ch == 'b')) {
+            IOUtils.copy(reader, output);
+            assertEquals("aacacd", output.toString());
+        }
+    }
+
+    @Test
+    public void testReadUsingReaderFilterWhitespace() throws IOException {
+        final StringReader input = new StringReader(" a b a b c a b c d ");
+        try (StringBuilderWriter output = new StringBuilderWriter();
+                IntPredicateFilterReader reader = new IntPredicateFilterReader(input, Character::isWhitespace)) {
+            IOUtils.copy(reader, output);
+            assertEquals("ababcabcd", output.toString());
+        }
+    }
+
+}


### PR DESCRIPTION
When using `AbstractCharacterFilterReader`, there are currently three options:
* Use `CharacterFilterReader`, possibly nested.
* Use `CharacterSetFilterReader`.
* Extend `AbstractCharacterFilterReader` and implement `filter`.

Given that the `filter` method can easily be implemented using an `IntPredicate`, I've created class `IntPredicateFilterReader` that allows one to easily create a filter reader that omits whitespace:

    new IntPredicateFilterReader(reader, Character::isWhitespace);

Note that this PR depends on (and includes the changes for) PR #226, as the unit tests triggered the infinite loop reported in that PR with the "filter all" predicates.