### PR TITLE
Fix usage of assertNotNull

### DIFF
--- a/src/test/java/org/apache/commons/io/FileSystemUtilsTestCase.java
+++ b/src/test/java/org/apache/commons/io/FileSystemUtilsTestCase.java
@@ -63,7 +63,7 @@ public class FileSystemUtilsTestCase {
             boolean kilobyteBlock = true;
             try (BufferedReader r = new BufferedReader(new InputStreamReader(proc.getInputStream()))){
                 final String line = r.readLine();
-                assertNotNull("Unexpected null line", line);
+                assertNotNull(line, "Unexpected null line");
                 if (line.contains("512")) {
                     kilobyteBlock = false;
                 }


### PR DESCRIPTION
Signature of assertNoNull() is taking "actual" as first parameter:

    public static void assertNotNull(Object actual, String message) {
        AssertNotNull.assertNotNull(actual, message);
    }

Signed-off-by: Davide Angelocola <davide.angelocola@gmail.com>