### PR TITLE
IO-748 Documentation correction in FileUtils

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -2373,6 +2373,8 @@ public class FileUtils {
      *        IOException.
      * @throws NullPointerException if any of the given {@code File}s are {@code null}.
      * @throws FileExistsException if the directory or file exists in the destination directory.
+     * @throws FileNotFoundException if the file does not exist, is a directory rather than a regular file, or for some
+     *         other reason cannot be opened for reading.
      * @throws IOException if source or destination is invalid.
      * @throws IOException if an error occurs or setting the last-modified time didn't succeeded.
      * @since 1.4


### PR DESCRIPTION
FileNotFoundException included in FileUtils.moveToDirectory() Javadoc as per comments in IO-748.