### PR TITLE
Refactor `ReaderInputStream` implementation

### DIFF
--- a/src/main/java/org/apache/commons/io/input/ReaderInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/ReaderInputStream.java
@@ -182,6 +182,18 @@ public class ReaderInputStream extends InputStream {
     }
 
     /**
+     * Internal constructor for use by {@link CharSequenceInputStream}.
+     */
+    ReaderInputStream(final CharSequence charSeq, final CharsetEncoder charsetEncoder) {
+        this.reader = NullReader.INSTANCE;
+        this.charsetEncoder = charsetEncoder;
+        this.encoderIn = CharBuffer.wrap(charSeq);
+        this.endOfInput = true; // reader has no chars
+        this.encoderOut = ByteBuffer.allocate(128);
+        this.encoderOut.flip();
+    }
+
+    /**
      * Constructs a new {@link ReaderInputStream} with a default input buffer size of {@value #DEFAULT_BUFFER_SIZE}
      * characters.
      *

--- a/src/test/java/org/apache/commons/io/input/ReaderInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/ReaderInputStreamTest.java
@@ -79,14 +79,13 @@ public class ReaderInputStreamTest {
     public void testBufferTooSmall() throws IOException {
         assertThrows(IllegalArgumentException.class, () -> new ReaderInputStream(new StringReader("\uD800"), StandardCharsets.UTF_8, -1));
         assertThrows(IllegalArgumentException.class, () -> new ReaderInputStream(new StringReader("\uD800"), StandardCharsets.UTF_8, 0));
-        assertThrows(IllegalArgumentException.class, () -> new ReaderInputStream(new StringReader("\uD800"), StandardCharsets.UTF_8, 1));
     }
 
     @Test
     @Timeout(value = 500, unit = TimeUnit.MILLISECONDS)
     public void testBufferSmallest() throws IOException {
         final Charset charset = StandardCharsets.UTF_8;
-        try (InputStream in = new ReaderInputStream(new StringReader("\uD800"), charset, (int) ReaderInputStream.minBufferSize(charset.newEncoder()))) {
+        try (InputStream in = new ReaderInputStream(new StringReader("\uD800"), charset, 1)) {
             in.read();
         }
     }
@@ -115,7 +114,7 @@ public class ReaderInputStreamTest {
     public void testCodingErrorAction() throws IOException {
         final Charset charset = StandardCharsets.UTF_8;
         final CharsetEncoder encoder = charset.newEncoder().onMalformedInput(CodingErrorAction.REPORT);
-        try (InputStream in = new ReaderInputStream(new StringReader("\uD800aa"), encoder, (int) ReaderInputStream.minBufferSize(charset.newEncoder()))) {
+        try (InputStream in = new ReaderInputStream(new StringReader("\uD800aa"), encoder, 1)) {
             assertThrows(CharacterCodingException.class, in::read);
         }
     }


### PR DESCRIPTION
The new implementation follows more closely the required behavior defined by `CharsetEncoder`, instead of assuming that buffers of certain size will work without having to resize them.

Relates to:
- https://issues.apache.org/jira/browse/IO-714
- https://issues.apache.org/jira/browse/IO-716

Sorry for creating this pull request so late and not participating in the review of the previous pull requests for these issues.
If you don't think this pull request is worth it, feel free to close it. The current implementation will probably work in most situations correctly, but [here](https://github.com/apache/commons-io/blob/d47d625275b05643459d47ea9862e827bd672653/src/main/java/org/apache/commons/io/input/ReaderInputStream.java#L239) it overwrites the `lastCoderResult`, even when the previous `encode` was unsuccessful, e.g. OVERFLOW or ERROR.

I also tried refactoring `org.apache.commons.io.input.CharSequenceInputStream` to use `ReaderInputStream` to reduce error-prone usage of `CharsetEncoder` there. However, this causes some behavior changes:
- `available()` will in most cases return 0
- `readLimit` parameter of `mark` is now actually considered, so code calling `mark(0)` will not work anymore

I have marked this pull request as draft for now because I have not extensively tested it. Please let me know what you think.