### PR TITLE
Update cleanDirectory(final File) method in org.apache.commons.io.FileUtils.

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -339,19 +339,26 @@ public class FileUtils {
      * @throws IOException if an I/O error occurs.
      * @see #forceDelete(File)
      */
-    public static void cleanDirectory(final File directory) {
+    public static void cleanDirectory(final File directory) throws IOException {
+        if (directory == null) {
+            return;
+        }
         if (directory.exists()) {
             if (directory.isDirectory()) {
                 if (Objects.requireNonNull(directory.listFiles(), "File is not directory").length != 0) {
                     Arrays.stream(Objects.requireNonNull(directory.listFiles(), "File is not directory")).forEach(file -> {
-                        if (file.isDirectory() && Objects.requireNonNull(file.listFiles()).length != 0) {
-                            cleanDirectory(file);
+                        try {
+                            if (file.isDirectory() && Objects.requireNonNull(file.listFiles()).length != 0) {
+                                cleanDirectory(file);
+                            }
+                            Files.delete(directory.toPath());
+                        } catch (IOException e) {
+                            e.printStackTrace();
                         }
-                        file.delete();
                     });
                 }
             } else {
-                directory.delete();
+                Files.delete(directory.toPath());
             }
         }
     }

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -339,20 +339,20 @@ public class FileUtils {
      * @throws IOException if an I/O error occurs.
      * @see #forceDelete(File)
      */
-    public static void cleanDirectory(final File directory) throws IOException {
-        final File[] files = listFiles(directory, null);
-
-        final List<Exception> causeList = new ArrayList<>();
-        for (final File file : files) {
-            try {
-                forceDelete(file);
-            } catch (final IOException ioe) {
-                causeList.add(ioe);
+    public static void cleanDirectory(final File directory) {
+        if (directory.exists()) {
+            if (directory.isDirectory()) {
+                if (Objects.requireNonNull(directory.listFiles(), "File is not directory").length != 0) {
+                    Arrays.stream(Objects.requireNonNull(directory.listFiles(), "File is not directory")).forEach(file -> {
+                        if (file.isDirectory() && Objects.requireNonNull(file.listFiles()).length != 0) {
+                            cleanDirectory(file);
+                        }
+                        file.delete();
+                    });
+                }
+            } else {
+                directory.delete();
             }
-        }
-
-        if (!causeList.isEmpty()) {
-            throw new IOExceptionList(directory.toString(), causeList);
         }
     }
 


### PR DESCRIPTION
I have made a change to the method cleanDirectory(final File) in class org.apache.commons.io.FileUtils.

It first checks if the directory exists, then it cleans the directory by iterating though the files and deleting them. If the
given File is a simple file, it deletes it.