### PR TITLE
IO-756: Update FileWriterWithEncoding to extend ProxyWriter

### DIFF
--- a/src/main/java/org/apache/commons/io/output/FileWriterWithEncoding.java
+++ b/src/main/java/org/apache/commons/io/output/FileWriterWithEncoding.java
@@ -46,9 +46,7 @@ import org.apache.commons.io.IOUtils;
  *
  * @since 1.4
  */
-public class FileWriterWithEncoding extends Writer {
-    // Cannot extend ProxyWriter, as requires writer to be
-    // known when super() is called
+public class FileWriterWithEncoding extends ProxyWriter {
 
     /**
      * Initializes the wrapped file writer. Ensure that a cleanup occurs if the writer creation fails.
@@ -85,9 +83,6 @@ public class FileWriterWithEncoding extends Writer {
         }
     }
 
-    /** The writer to decorate. */
-    private final Writer out;
-
     /**
      * Constructs a FileWriterWithEncoding with a file encoding.
      *
@@ -110,7 +105,7 @@ public class FileWriterWithEncoding extends Writer {
      * @throws IOException in case of an I/O error.
      */
     public FileWriterWithEncoding(final File file, final Charset encoding, final boolean append) throws IOException {
-        this.out = initWriter(file, encoding, append);
+        super(initWriter(file, encoding, append));
     }
 
     /**
@@ -135,7 +130,7 @@ public class FileWriterWithEncoding extends Writer {
      * @throws IOException in case of an I/O error.
      */
     public FileWriterWithEncoding(final File file, final CharsetEncoder charsetEncoder, final boolean append) throws IOException {
-        this.out = initWriter(file, charsetEncoder, append);
+        super(initWriter(file, charsetEncoder, append));
     }
 
     /**
@@ -160,7 +155,7 @@ public class FileWriterWithEncoding extends Writer {
      * @throws IOException in case of an I/O error.
      */
     public FileWriterWithEncoding(final File file, final String charsetName, final boolean append) throws IOException {
-        this.out = initWriter(file, charsetName, append);
+        super(initWriter(file, charsetName, append));
     }
 
     /**
@@ -236,84 +231,5 @@ public class FileWriterWithEncoding extends Writer {
      */
     public FileWriterWithEncoding(final String fileName, final String charsetName, final boolean append) throws IOException {
         this(new File(fileName), charsetName, append);
-    }
-
-    /**
-     * Closes the stream.
-     *
-     * @throws IOException if an I/O error occurs.
-     */
-    @Override
-    public void close() throws IOException {
-        out.close();
-    }
-
-    /**
-     * Flushes the stream.
-     *
-     * @throws IOException if an I/O error occurs.
-     */
-    @Override
-    public void flush() throws IOException {
-        out.flush();
-    }
-
-    /**
-     * Writes the characters from an array.
-     *
-     * @param chr the characters to write
-     * @throws IOException if an I/O error occurs.
-     */
-    @Override
-    public void write(final char[] chr) throws IOException {
-        out.write(chr);
-    }
-
-    /**
-     * Writes the specified characters from an array.
-     *
-     * @param chr the characters to write
-     * @param st The start offset
-     * @param end The number of characters to write
-     * @throws IOException if an I/O error occurs.
-     */
-    @Override
-    public void write(final char[] chr, final int st, final int end) throws IOException {
-        out.write(chr, st, end);
-    }
-
-    /**
-     * Writes a character.
-     *
-     * @param idx the character to write
-     * @throws IOException if an I/O error occurs.
-     */
-    @Override
-    public void write(final int idx) throws IOException {
-        out.write(idx);
-    }
-
-    /**
-     * Writes the characters from a string.
-     *
-     * @param str the string to write
-     * @throws IOException if an I/O error occurs.
-     */
-    @Override
-    public void write(final String str) throws IOException {
-        out.write(str);
-    }
-
-    /**
-     * Writes the specified characters from a string.
-     *
-     * @param str the string to write
-     * @param st The start offset
-     * @param end The number of characters to write
-     * @throws IOException if an I/O error occurs.
-     */
-    @Override
-    public void write(final String str, final int st, final int end) throws IOException {
-        out.write(str, st, end);
     }
 }


### PR DESCRIPTION
This pull request simplifies org.apache.commons.io.output.FileWriterWithEncoding by removing the decorated object and extending org.apache.commons.io.output.ProxyWriter directly.
Update: Ticket is here https://issues.apache.org/jira/browse/IO-756