### PR TITLE
IOUtils use TaggedInputStream instead of ProxyInputStream

### DIFF
--- a/src/main/java/org/apache/commons/io/input/AutoCloseInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/AutoCloseInputStream.java
@@ -36,7 +36,7 @@ import java.io.InputStream;
  *
  * @since 1.4
  */
-public class AutoCloseInputStream extends ProxyInputStream {
+public class AutoCloseInputStream extends TaggedInputStream {
 
     /**
      * Creates an automatically closing proxy for the given input stream.
@@ -76,7 +76,7 @@ public class AutoCloseInputStream extends ProxyInputStream {
      */
     @Override
     public void close() throws IOException {
-        in.close();
+        super.close();
         in = ClosedInputStream.INSTANCE;
     }
 

--- a/src/main/java/org/apache/commons/io/input/BOMInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BOMInputStream.java
@@ -87,7 +87,7 @@ import org.apache.commons.io.IOUtils;
  * @see <a href="http://en.wikipedia.org/wiki/Byte_order_mark">Wikipedia - Byte Order Mark</a>
  * @since 2.0
  */
-public class BOMInputStream extends ProxyInputStream {
+public class BOMInputStream extends TaggedInputStream {
     /**
      * Compares ByteOrderMark objects in descending length order.
      */
@@ -195,7 +195,7 @@ public class BOMInputStream extends ProxyInputStream {
             firstBytes = new int[maxBomSize];
             // Read first maxBomSize bytes
             for (int i = 0; i < firstBytes.length; i++) {
-                firstBytes[i] = in.read();
+                firstBytes[i] = super.read();
                 fbLength++;
                 if (firstBytes[i] < 0) {
                     break;
@@ -267,7 +267,7 @@ public class BOMInputStream extends ProxyInputStream {
     public synchronized void mark(final int readlimit) {
         markFbIndex = fbIndex;
         markedAtStart = firstBytes == null;
-        in.mark(readlimit);
+        super.mark(readlimit);
     }
 
     /**
@@ -304,7 +304,7 @@ public class BOMInputStream extends ProxyInputStream {
     @Override
     public int read() throws IOException {
         final int b = readFirstBytes();
-        return b >= 0 ? b : in.read();
+        return b >= 0 ? b : super.read();
     }
 
     /**
@@ -346,7 +346,7 @@ public class BOMInputStream extends ProxyInputStream {
                 firstCount++;
             }
         }
-        final int secondCount = in.read(buf, off, len);
+        final int secondCount = super.read(buf, off, len);
         return secondCount < 0 ? firstCount > 0 ? firstCount : EOF : firstCount + secondCount;
     }
 
@@ -377,7 +377,7 @@ public class BOMInputStream extends ProxyInputStream {
             firstBytes = null;
         }
 
-        in.reset();
+        super.reset();
     }
 
     /**
@@ -395,6 +395,6 @@ public class BOMInputStream extends ProxyInputStream {
         while ((n > skipped) && (readFirstBytes() >= 0)) {
             skipped++;
         }
-        return in.skip(n - skipped) + skipped;
+        return super.skip(n - skipped) + skipped;
     }
 }

--- a/src/main/java/org/apache/commons/io/input/CloseShieldInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/CloseShieldInputStream.java
@@ -28,7 +28,7 @@ import java.io.InputStream;
  *
  * @since 1.4
  */
-public class CloseShieldInputStream extends ProxyInputStream {
+public class CloseShieldInputStream extends TaggedInputStream {
 
     /**
      * Creates a proxy that shields the given input stream from being closed.

--- a/src/main/java/org/apache/commons/io/input/CountingInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/CountingInputStream.java
@@ -29,7 +29,7 @@ import java.io.InputStream;
  * read as expected.
  * </p>
  */
-public class CountingInputStream extends ProxyInputStream {
+public class CountingInputStream extends TaggedInputStream {
 
     /** The count of bytes that have passed. */
     private long count;

--- a/src/main/java/org/apache/commons/io/input/MarkShieldInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/MarkShieldInputStream.java
@@ -33,7 +33,7 @@ import java.io.InputStream;
  *
  * @since 2.8.0
  */
-public class MarkShieldInputStream extends ProxyInputStream {
+public class MarkShieldInputStream extends TaggedInputStream {
 
     /**
      * Creates a proxy that shields the given input stream from being

--- a/src/main/java/org/apache/commons/io/input/SwappedDataInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/SwappedDataInputStream.java
@@ -33,7 +33,7 @@ import org.apache.commons.io.EndianUtils;
  * </p>
  *
  */
-public class SwappedDataInputStream extends ProxyInputStream implements DataInput {
+public class SwappedDataInputStream extends TaggedInputStream implements DataInput {
 
     /**
      * Constructs a SwappedDataInputStream.
@@ -65,7 +65,11 @@ public class SwappedDataInputStream extends ProxyInputStream implements DataInpu
      */
     @Override
     public byte readByte() throws IOException, EOFException {
-        return (byte) in.read();
+        final int returnValue = super.read();
+        if (returnValue == EOF) {
+            handleIOException(new EOFException("Unexpected EOF reached"));
+        }
+        return (byte) returnValue;
     }
 
     /**
@@ -89,7 +93,14 @@ public class SwappedDataInputStream extends ProxyInputStream implements DataInpu
      */
     @Override
     public double readDouble() throws IOException, EOFException {
-        return EndianUtils.readSwappedDouble(in);
+        double returnValue;
+        try {
+            returnValue = EndianUtils.readSwappedDouble(this);
+        } catch (IOException e) {
+            handleIOException(e);
+            returnValue = EOF;
+        }
+        return returnValue;
     }
 
     /**
@@ -101,7 +112,14 @@ public class SwappedDataInputStream extends ProxyInputStream implements DataInpu
      */
     @Override
     public float readFloat() throws IOException, EOFException {
-        return EndianUtils.readSwappedFloat(in);
+        float returnValue;
+        try {
+            returnValue = EndianUtils.readSwappedFloat(this);
+        } catch (IOException e) {
+            handleIOException(e);
+            returnValue = EOF;
+        }
+        return returnValue;
     }
 
     /**
@@ -134,7 +152,8 @@ public class SwappedDataInputStream extends ProxyInputStream implements DataInpu
             final int count = read(data, location, remaining);
 
             if (EOF == count) {
-                throw new EOFException();
+                handleIOException(new EOFException("Unexpected EOF reached"));
+                break; // Never reached, exception is thrown.
             }
 
             remaining -= count;
@@ -150,7 +169,14 @@ public class SwappedDataInputStream extends ProxyInputStream implements DataInpu
      */
     @Override
     public int readInt() throws IOException, EOFException {
-        return EndianUtils.readSwappedInteger(in);
+        int returnValue;
+        try {
+            returnValue = EndianUtils.readSwappedInteger(this);
+        } catch (IOException e) {
+            handleIOException(e);
+            returnValue = EOF;
+        }
+        return returnValue;
     }
 
     /**
@@ -174,7 +200,14 @@ public class SwappedDataInputStream extends ProxyInputStream implements DataInpu
      */
     @Override
     public long readLong() throws IOException, EOFException {
-        return EndianUtils.readSwappedLong(in);
+        long returnValue;
+        try {
+            returnValue = EndianUtils.readSwappedLong(this);
+        } catch (IOException e) {
+            handleIOException(e);
+            returnValue = EOF;
+        }
+        return returnValue;
     }
 
     /**
@@ -186,7 +219,14 @@ public class SwappedDataInputStream extends ProxyInputStream implements DataInpu
      */
     @Override
     public short readShort() throws IOException, EOFException {
-        return EndianUtils.readSwappedShort(in);
+        short returnValue;
+        try {
+            returnValue = EndianUtils.readSwappedShort(this);
+        } catch (IOException e) {
+            handleIOException(e);
+            returnValue = EOF;
+        }
+        return returnValue;
     }
 
     /**
@@ -198,7 +238,11 @@ public class SwappedDataInputStream extends ProxyInputStream implements DataInpu
      */
     @Override
     public int readUnsignedByte() throws IOException, EOFException {
-        return in.read();
+        final int returnValue = super.read();
+        if (returnValue == EOF) {
+            handleIOException(new EOFException("Unexpected EOF reached"));
+        }
+        return returnValue;
     }
 
     /**
@@ -210,7 +254,14 @@ public class SwappedDataInputStream extends ProxyInputStream implements DataInpu
      */
     @Override
     public int readUnsignedShort() throws IOException, EOFException {
-        return EndianUtils.readSwappedUnsignedShort(in);
+        int returnValue;
+        try {
+            returnValue = EndianUtils.readSwappedUnsignedShort(this);
+        } catch (IOException e) {
+            handleIOException(e);
+            returnValue = EOF;
+        }
+        return returnValue;
     }
 
     /**
@@ -235,7 +286,7 @@ public class SwappedDataInputStream extends ProxyInputStream implements DataInpu
      */
     @Override
     public int skipBytes(final int count) throws IOException, EOFException {
-        return (int) in.skip(count);
+        return (int) super.skip(count);
     }
 
 }

--- a/src/main/java/org/apache/commons/io/input/TeeInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/TeeInputStream.java
@@ -37,7 +37,7 @@ import java.io.OutputStream;
  * @since 1.4
  * @see ObservableInputStream
  */
-public class TeeInputStream extends ProxyInputStream {
+public class TeeInputStream extends TaggedInputStream {
 
     /**
      * The output stream that will receive a copy of all bytes read from the
@@ -93,7 +93,11 @@ public class TeeInputStream extends ProxyInputStream {
             super.close();
         } finally {
             if (closeBranch) {
-                branch.close();
+                try {
+                    branch.close();
+                } catch (IOException e) {
+                    handleIOException(e);
+                }
             }
         }
     }
@@ -109,7 +113,11 @@ public class TeeInputStream extends ProxyInputStream {
     public int read() throws IOException {
         final int ch = super.read();
         if (ch != EOF) {
-            branch.write(ch);
+            try {
+                branch.write(ch);
+            } catch (IOException e) {
+                handleIOException(e);
+            }
         }
         return ch;
     }
@@ -126,7 +134,11 @@ public class TeeInputStream extends ProxyInputStream {
     public int read(final byte[] bts) throws IOException {
         final int n = super.read(bts);
         if (n != EOF) {
-            branch.write(bts, 0, n);
+            try {
+                branch.write(bts, 0, n);
+            } catch (IOException e) {
+                handleIOException(e);
+            }
         }
         return n;
     }
@@ -145,7 +157,11 @@ public class TeeInputStream extends ProxyInputStream {
     public int read(final byte[] bts, final int st, final int end) throws IOException {
         final int n = super.read(bts, st, end);
         if (n != EOF) {
-            branch.write(bts, st, n);
+            try {
+                branch.write(bts, st, n);
+            } catch (IOException e) {
+                handleIOException(e);
+            }
         }
         return n;
     }

--- a/src/test/java/org/apache/commons/io/test/ThrowOnCloseInputStream.java
+++ b/src/test/java/org/apache/commons/io/test/ThrowOnCloseInputStream.java
@@ -20,12 +20,12 @@ import java.io.IOException;
 import java.io.InputStream;
 
 import org.apache.commons.io.input.NullInputStream;
-import org.apache.commons.io.input.ProxyInputStream;
+import org.apache.commons.io.input.TaggedInputStream;
 
 /**
  * Helper class for checking behavior of IO classes.
  */
-public class ThrowOnCloseInputStream extends ProxyInputStream {
+public class ThrowOnCloseInputStream extends TaggedInputStream {
 
     /**
      * Defaultconstructor.
@@ -44,7 +44,7 @@ public class ThrowOnCloseInputStream extends ProxyInputStream {
     /** @see java.io.InputStream#close() */
     @Override
     public void close() throws IOException {
-        throw new IOException(getClass().getSimpleName() + ".close() called.");
+        handleIOException(new IOException(getClass().getSimpleName() + ".close() called."));
     }
 
 }


### PR DESCRIPTION
This pull request is to use `TaggedInputStream` as a superclass where possible, in place of `ProxyInputStream`, to allow access to the methods `isCauseOf` and `throwIfCauseOf`.