### PR TITLE
(doc) [IO-484] Fix incorrect FilenameUtils documentation for null bytes

### DIFF
--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -194,7 +194,8 @@ public class FilenameUtils {
      *
      * @param basePath  the base path to attach to, always treated as a path
      * @param fullFileNameToAdd  the fileName (or path) to attach to the base
-     * @return the concatenated path, or null if invalid.  Null bytes inside string will be removed
+     * @return the concatenated path, or null if invalid
+     * @throws IllegalArgumentException if the result path contains null bytes
      */
     public static String concat(final String basePath, final String fullFileNameToAdd) {
         final int prefix = getPrefixLength(fullFileNameToAdd);
@@ -260,8 +261,10 @@ public class FilenameUtils {
      * @param fileName  the fileName
      * @param includeSeparator  true to include the end separator
      * @return the path
+     * @throws IllegalArgumentException if the result path contains null bytes
      */
     private static String doGetFullPath(final String fileName, final boolean includeSeparator) {
+        // TODO: Does not (indirectly) call requireNonNullChars in all cases for result
         if (fileName == null) {
             return null;
         }
@@ -291,7 +294,8 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName
      * @param separatorAdd  0 to omit the end separator, 1 to return it
-     * @return the path. Null bytes inside string will be removed
+     * @return the path
+     * @throws IllegalArgumentException if the result path contains null bytes
      */
     private static String doGetPath(final String fileName, final int separatorAdd) {
         if (fileName == null) {
@@ -315,7 +319,8 @@ public class FilenameUtils {
      * @param fileName  the fileName
      * @param separator The separator character to use
      * @param keepSeparator  true to keep the final separator
-     * @return the normalized fileName. Null bytes inside string will be removed.
+     * @return the normalized fileName
+     * @throws IllegalArgumentException if the fileName contains null bytes
      */
     private static String doNormalize(final String fileName, final char separator, final boolean keepSeparator) {
         if (fileName == null) {
@@ -447,6 +452,9 @@ public class FilenameUtils {
         if (fileName1 == null || fileName2 == null) {
             return fileName1 == null && fileName2 == null;
         }
+        // TODO: Should IllegalArgumentException thrown by `normalize` for null bytes be
+        // handled? (and for example `false` be returned instead); If not, have to mention it
+        // in javadoc of this method and callers
         if (normalized) {
             fileName1 = normalize(fileName1);
             if (fileName1 == null) {
@@ -565,8 +573,8 @@ public class FilenameUtils {
      * </p>
      *
      * @param fileName  the fileName to query, null returns null
-     * @return the name of the file without the path, or an empty string if none exists. Null bytes inside string
-     * will be removed
+     * @return the name of the file without the path, or an empty string if none exists
+     * @throws IllegalArgumentException if the fileName contains null bytes
      */
     public static String getBaseName(final String fileName) {
         return removeExtension(getName(fileName));
@@ -610,6 +618,7 @@ public class FilenameUtils {
         if (index == NOT_FOUND) {
             return EMPTY_STRING;
         }
+        // TODO: Should check for null bytes?
         return fileName.substring(index + 1);
     }
 
@@ -639,6 +648,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to query, null returns null
      * @return the path of the file, an empty string if none exists, null if invalid
+     * @throws IllegalArgumentException if the result path contains null bytes
      */
     public static String getFullPath(final String fileName) {
         return doGetFullPath(fileName, true);
@@ -671,6 +681,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to query, null returns null
      * @return the path of the file, an empty string if none exists, null if invalid
+     * @throws IllegalArgumentException if the result path contains null bytes
      */
     public static String getFullPathNoEndSeparator(final String fileName) {
         return doGetFullPath(fileName, false);
@@ -693,8 +704,8 @@ public class FilenameUtils {
      * </p>
      *
      * @param fileName  the fileName to query, null returns null
-     * @return the name of the file without the path, or an empty string if none exists.
-     * Null bytes inside string will be removed
+     * @return the name of the file without the path, or an empty string if none exists
+     * @throws IllegalArgumentException if the fileName contains null bytes
      */
     public static String getName(final String fileName) {
         if (fileName == null) {
@@ -726,8 +737,8 @@ public class FilenameUtils {
      * </p>
      *
      * @param fileName  the fileName to query, null returns null
-     * @return the path of the file, an empty string if none exists, null if invalid.
-     * Null bytes inside string will be removed
+     * @return the path of the file, an empty string if none exists, null if invalid
+     * @throws IllegalArgumentException if the result path contains null bytes
      */
     public static String getPath(final String fileName) {
         return doGetPath(fileName, 1);
@@ -757,8 +768,8 @@ public class FilenameUtils {
      * </p>
      *
      * @param fileName  the fileName to query, null returns null
-     * @return the path of the file, an empty string if none exists, null if invalid.
-     * Null bytes inside string will be removed
+     * @return the path of the file, an empty string if none exists, null if invalid
+     * @throws IllegalArgumentException if the result path contains null bytes
      */
     public static String getPathNoEndSeparator(final String fileName) {
         return doGetPath(fileName, 0);
@@ -793,7 +804,8 @@ public class FilenameUtils {
      * </p>
      *
      * @param fileName  the fileName to query, null returns null
-     * @return the prefix of the file, null if invalid. Null bytes inside string will be removed
+     * @return the prefix of the file, null if invalid
+     * @throws IllegalArgumentException if the result contains null bytes
      */
     public static String getPrefix(final String fileName) {
         if (fileName == null) {
@@ -987,7 +999,7 @@ public class FilenameUtils {
      * @param fileName  the fileName to query, null returns false
      * @param extensions  the extensions to check for, null checks for no extension
      * @return true if the fileName is one of the extensions
-     * @throws java.lang.IllegalArgumentException if the supplied fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains null bytes
      */
     public static boolean isExtension(final String fileName, final Collection<String> extensions) {
         if (fileName == null) {
@@ -1017,7 +1029,7 @@ public class FilenameUtils {
      * @param fileName  the fileName to query, null returns false
      * @param extension  the extension to check for, null or empty checks for no extension
      * @return true if the fileName has the specified extension
-     * @throws java.lang.IllegalArgumentException if the supplied fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains null bytes
      */
     public static boolean isExtension(final String fileName, final String extension) {
         if (fileName == null) {
@@ -1041,7 +1053,7 @@ public class FilenameUtils {
      * @param fileName  the fileName to query, null returns false
      * @param extensions  the extensions to check for, null checks for no extension
      * @return true if the fileName is one of the extensions
-     * @throws java.lang.IllegalArgumentException if the supplied fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains null bytes
      */
     public static boolean isExtension(final String fileName, final String... extensions) {
         if (fileName == null) {
@@ -1253,7 +1265,8 @@ public class FilenameUtils {
      * (Note the file separator returned will be correct for Windows/Unix)
      *
      * @param fileName  the fileName to normalize, null returns null
-     * @return the normalized fileName, or null if invalid. Null bytes inside string will be removed
+     * @return the normalized fileName, or null if invalid
+     * @throws IllegalArgumentException if the fileName contains null bytes
      */
     public static String normalize(final String fileName) {
         return doNormalize(fileName, SYSTEM_NAME_SEPARATOR, true);
@@ -1300,7 +1313,8 @@ public class FilenameUtils {
      * @param fileName  the fileName to normalize, null returns null
      * @param unixSeparator {@code true} if a unix separator should
      * be used or {@code false} if a windows separator should be used.
-     * @return the normalized fileName, or null if invalid. Null bytes inside string will be removed
+     * @return the normalized fileName, or null if invalid
+     * @throws IllegalArgumentException if the fileName contains null bytes
      * @since 2.0
      */
     public static String normalize(final String fileName, final boolean unixSeparator) {
@@ -1346,7 +1360,8 @@ public class FilenameUtils {
      * (Note the file separator returned will be correct for Windows/Unix)
      *
      * @param fileName  the fileName to normalize, null returns null
-     * @return the normalized fileName, or null if invalid. Null bytes inside string will be removed
+     * @return the normalized fileName, or null if invalid
+     * @throws IllegalArgumentException if the fileName contains null bytes
      */
     public static String normalizeNoEndSeparator(final String fileName) {
         return doNormalize(fileName, SYSTEM_NAME_SEPARATOR, false);
@@ -1392,7 +1407,8 @@ public class FilenameUtils {
      * @param fileName  the fileName to normalize, null returns null
      * @param unixSeparator {@code true} if a unix separator should
      * be used or {@code false} if a windows separator should be used.
-     * @return the normalized fileName, or null if invalid. Null bytes inside string will be removed
+     * @return the normalized fileName, or null if invalid
+     * @throws IllegalArgumentException if the fileName contains null bytes
      * @since 2.0
      */
     public static String normalizeNoEndSeparator(final String fileName, final boolean unixSeparator) {
@@ -1415,6 +1431,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to query, null returns null
      * @return the fileName minus the extension
+     * @throws IllegalArgumentException if the fileName contains null bytes
      */
     public static String removeExtension(final String fileName) {
         if (fileName == null) {
@@ -1436,6 +1453,7 @@ public class FilenameUtils {
      *
      * @param path the path to check
      * @return The input
+     * @throws IllegalArgumentException if path contains null bytes
      */
     private static String requireNonNullChars(final String path) {
         if (path.indexOf(0) >= 0) {

--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -264,7 +264,6 @@ public class FilenameUtils {
      * @throws IllegalArgumentException if the result path contains the null character ({@code U+0000})
      */
     private static String doGetFullPath(final String fileName, final boolean includeSeparator) {
-        // TODO: Does not (indirectly) call requireNonNullChars in all cases for result
         if (fileName == null) {
             return null;
         }
@@ -452,9 +451,6 @@ public class FilenameUtils {
         if (fileName1 == null || fileName2 == null) {
             return fileName1 == null && fileName2 == null;
         }
-        // TODO: Should IllegalArgumentException thrown by `normalize` for null characters be
-        // handled? (and for example `false` be returned instead); If not, have to mention it
-        // in javadoc of this method and callers
         if (normalized) {
             fileName1 = normalize(fileName1);
             if (fileName1 == null) {
@@ -618,7 +614,6 @@ public class FilenameUtils {
         if (index == NOT_FOUND) {
             return EMPTY_STRING;
         }
-        // TODO: Should check for null characters?
         return fileName.substring(index + 1);
     }
 

--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -195,7 +195,7 @@ public class FilenameUtils {
      * @param basePath  the base path to attach to, always treated as a path
      * @param fullFileNameToAdd  the fileName (or path) to attach to the base
      * @return the concatenated path, or null if invalid
-     * @throws IllegalArgumentException if the result path contains null bytes
+     * @throws IllegalArgumentException if the result path contains the null character ({@code U+0000})
      */
     public static String concat(final String basePath, final String fullFileNameToAdd) {
         final int prefix = getPrefixLength(fullFileNameToAdd);
@@ -261,7 +261,7 @@ public class FilenameUtils {
      * @param fileName  the fileName
      * @param includeSeparator  true to include the end separator
      * @return the path
-     * @throws IllegalArgumentException if the result path contains null bytes
+     * @throws IllegalArgumentException if the result path contains the null character ({@code U+0000})
      */
     private static String doGetFullPath(final String fileName, final boolean includeSeparator) {
         // TODO: Does not (indirectly) call requireNonNullChars in all cases for result
@@ -295,7 +295,7 @@ public class FilenameUtils {
      * @param fileName  the fileName
      * @param separatorAdd  0 to omit the end separator, 1 to return it
      * @return the path
-     * @throws IllegalArgumentException if the result path contains null bytes
+     * @throws IllegalArgumentException if the result path contains the null character ({@code U+0000})
      */
     private static String doGetPath(final String fileName, final int separatorAdd) {
         if (fileName == null) {
@@ -320,7 +320,7 @@ public class FilenameUtils {
      * @param separator The separator character to use
      * @param keepSeparator  true to keep the final separator
      * @return the normalized fileName
-     * @throws IllegalArgumentException if the fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains the null character ({@code U+0000})
      */
     private static String doNormalize(final String fileName, final char separator, final boolean keepSeparator) {
         if (fileName == null) {
@@ -452,7 +452,7 @@ public class FilenameUtils {
         if (fileName1 == null || fileName2 == null) {
             return fileName1 == null && fileName2 == null;
         }
-        // TODO: Should IllegalArgumentException thrown by `normalize` for null bytes be
+        // TODO: Should IllegalArgumentException thrown by `normalize` for null characters be
         // handled? (and for example `false` be returned instead); If not, have to mention it
         // in javadoc of this method and callers
         if (normalized) {
@@ -574,7 +574,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to query, null returns null
      * @return the name of the file without the path, or an empty string if none exists
-     * @throws IllegalArgumentException if the fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains the null character ({@code U+0000})
      */
     public static String getBaseName(final String fileName) {
         return removeExtension(getName(fileName));
@@ -618,7 +618,7 @@ public class FilenameUtils {
         if (index == NOT_FOUND) {
             return EMPTY_STRING;
         }
-        // TODO: Should check for null bytes?
+        // TODO: Should check for null characters?
         return fileName.substring(index + 1);
     }
 
@@ -648,7 +648,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to query, null returns null
      * @return the path of the file, an empty string if none exists, null if invalid
-     * @throws IllegalArgumentException if the result path contains null bytes
+     * @throws IllegalArgumentException if the result path contains the null character ({@code U+0000})
      */
     public static String getFullPath(final String fileName) {
         return doGetFullPath(fileName, true);
@@ -681,7 +681,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to query, null returns null
      * @return the path of the file, an empty string if none exists, null if invalid
-     * @throws IllegalArgumentException if the result path contains null bytes
+     * @throws IllegalArgumentException if the result path contains the null character ({@code U+0000})
      */
     public static String getFullPathNoEndSeparator(final String fileName) {
         return doGetFullPath(fileName, false);
@@ -705,7 +705,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to query, null returns null
      * @return the name of the file without the path, or an empty string if none exists
-     * @throws IllegalArgumentException if the fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains the null character ({@code U+0000})
      */
     public static String getName(final String fileName) {
         if (fileName == null) {
@@ -738,7 +738,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to query, null returns null
      * @return the path of the file, an empty string if none exists, null if invalid
-     * @throws IllegalArgumentException if the result path contains null bytes
+     * @throws IllegalArgumentException if the result path contains the null character ({@code U+0000})
      */
     public static String getPath(final String fileName) {
         return doGetPath(fileName, 1);
@@ -769,7 +769,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to query, null returns null
      * @return the path of the file, an empty string if none exists, null if invalid
-     * @throws IllegalArgumentException if the result path contains null bytes
+     * @throws IllegalArgumentException if the result path contains the null character ({@code U+0000})
      */
     public static String getPathNoEndSeparator(final String fileName) {
         return doGetPath(fileName, 0);
@@ -805,7 +805,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to query, null returns null
      * @return the prefix of the file, null if invalid
-     * @throws IllegalArgumentException if the result contains null bytes
+     * @throws IllegalArgumentException if the result contains the null character ({@code U+0000})
      */
     public static String getPrefix(final String fileName) {
         if (fileName == null) {
@@ -850,7 +850,7 @@ public class FilenameUtils {
      * ~user               --&gt; 6           --&gt; named user (slash added)
      * //server/a/b/c.txt  --&gt; 9
      * ///a/b/c.txt        --&gt; -1          --&gt; error
-     * C:                  --&gt; 0           --&gt; valid filename as only null byte and / are reserved characters
+     * C:                  --&gt; 0           --&gt; valid filename as only null character and / are reserved characters
      * </pre>
      * <p>
      * The output will be the same irrespective of the machine that the code is running on.
@@ -999,7 +999,7 @@ public class FilenameUtils {
      * @param fileName  the fileName to query, null returns false
      * @param extensions  the extensions to check for, null checks for no extension
      * @return true if the fileName is one of the extensions
-     * @throws IllegalArgumentException if the fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains the null character ({@code U+0000})
      */
     public static boolean isExtension(final String fileName, final Collection<String> extensions) {
         if (fileName == null) {
@@ -1029,7 +1029,7 @@ public class FilenameUtils {
      * @param fileName  the fileName to query, null returns false
      * @param extension  the extension to check for, null or empty checks for no extension
      * @return true if the fileName has the specified extension
-     * @throws IllegalArgumentException if the fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains the null character ({@code U+0000})
      */
     public static boolean isExtension(final String fileName, final String extension) {
         if (fileName == null) {
@@ -1053,7 +1053,7 @@ public class FilenameUtils {
      * @param fileName  the fileName to query, null returns false
      * @param extensions  the extensions to check for, null checks for no extension
      * @return true if the fileName is one of the extensions
-     * @throws IllegalArgumentException if the fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains the null character ({@code U+0000})
      */
     public static boolean isExtension(final String fileName, final String... extensions) {
         if (fileName == null) {
@@ -1266,7 +1266,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to normalize, null returns null
      * @return the normalized fileName, or null if invalid
-     * @throws IllegalArgumentException if the fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains the null character ({@code U+0000})
      */
     public static String normalize(final String fileName) {
         return doNormalize(fileName, SYSTEM_NAME_SEPARATOR, true);
@@ -1314,7 +1314,7 @@ public class FilenameUtils {
      * @param unixSeparator {@code true} if a unix separator should
      * be used or {@code false} if a windows separator should be used.
      * @return the normalized fileName, or null if invalid
-     * @throws IllegalArgumentException if the fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains the null character ({@code U+0000})
      * @since 2.0
      */
     public static String normalize(final String fileName, final boolean unixSeparator) {
@@ -1361,7 +1361,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to normalize, null returns null
      * @return the normalized fileName, or null if invalid
-     * @throws IllegalArgumentException if the fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains the null character ({@code U+0000})
      */
     public static String normalizeNoEndSeparator(final String fileName) {
         return doNormalize(fileName, SYSTEM_NAME_SEPARATOR, false);
@@ -1408,7 +1408,7 @@ public class FilenameUtils {
      * @param unixSeparator {@code true} if a unix separator should
      * be used or {@code false} if a windows separator should be used.
      * @return the normalized fileName, or null if invalid
-     * @throws IllegalArgumentException if the fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains the null character ({@code U+0000})
      * @since 2.0
      */
     public static String normalizeNoEndSeparator(final String fileName, final boolean unixSeparator) {
@@ -1431,7 +1431,7 @@ public class FilenameUtils {
      *
      * @param fileName  the fileName to query, null returns null
      * @return the fileName minus the extension
-     * @throws IllegalArgumentException if the fileName contains null bytes
+     * @throws IllegalArgumentException if the fileName contains the null character ({@code U+0000})
      */
     public static String removeExtension(final String fileName) {
         if (fileName == null) {
@@ -1447,18 +1447,18 @@ public class FilenameUtils {
     }
 
     /**
-     * Checks the input for null bytes, a sign of unsanitized data being passed to to file level functions.
+     * Checks the input for null characters ({@code U+0000}), a sign of unsanitized data being passed to to file level functions.
      *
      * This may be used for poison byte attacks.
      *
      * @param path the path to check
      * @return The input
-     * @throws IllegalArgumentException if path contains null bytes
+     * @throws IllegalArgumentException if path contains the null character ({@code U+0000})
      */
     private static String requireNonNullChars(final String path) {
         if (path.indexOf(0) >= 0) {
             throw new IllegalArgumentException(
-                "Null byte present in file/path name. There are no known legitimate use cases for such data, but several injection attacks may use it");
+                "Null character present in file/path name. There are no known legitimate use cases for such data, but several injection attacks may use it");
         }
         return path;
     }

--- a/src/test/java/org/apache/commons/io/FilenameUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FilenameUtilsTest.java
@@ -229,7 +229,7 @@ public class FilenameUtilsTest {
     }
 
     @Test
-    public void testGetBaseName_with_nullByte() {
+    public void testGetBaseName_with_null_character() {
         try {
             assertEquals("file.txt", FilenameUtils.getBaseName("fil\u0000e.txt.bak"));
         } catch (final IllegalArgumentException ignore) {
@@ -419,7 +419,7 @@ public class FilenameUtilsTest {
 
 
     @Test
-    public void testGetPath_with_nullbyte() {
+    public void testGetPath_with_null_character() {
         assertThrows(IllegalArgumentException.class, () -> FilenameUtils.getPath("~user/a/\u0000b/c.txt"));
     }
 
@@ -461,7 +461,7 @@ public class FilenameUtilsTest {
     }
 
     @Test
-    public void testGetPathNoEndSeparator_with_null_byte() {
+    public void testGetPathNoEndSeparator_with_null_character() {
         try {
             assertEquals("a/b", FilenameUtils.getPathNoEndSeparator("~user/a\u0000/b/c.txt"));
         } catch (final IllegalArgumentException ignore) {
@@ -515,7 +515,7 @@ public class FilenameUtilsTest {
     }
 
     @Test
-    public void testGetPrefix_with_nullbyte() {
+    public void testGetPrefix_with_null_character() {
         try {
             assertEquals("~user\\", FilenameUtils.getPrefix("~u\u0000ser\\a\\b\\c.txt"));
         } catch (final IllegalArgumentException ignore) {
@@ -957,7 +957,7 @@ public class FilenameUtilsTest {
     /**
      */
     @Test
-    public void testNormalize_with_nullbytes() {
+    public void testNormalize_with_null_character() {
         try {
             assertEquals("a" + SEP + "b" + SEP + "c.txt", FilenameUtils.normalize("a\\b/c\u0000.txt"));
         } catch (final IllegalArgumentException ignore) {


### PR DESCRIPTION
During the development of [IO-484](https://issues.apache.org/jira/browse/IO-484) the behavior was first to remove null bytes (afe78a030b57e3f74825e134d6615ef4878778cc) but then later the implementation was changed to throw an exception instead (5d072ef89fbc2532f621a5a0b4d6791cb926a997).
However, not the complete documentation was adjusted.

This pull request corrects the documentation by mentioning that an `IllegalArgumentException` will be thrown for null bytes.

However, there are cases where the null bytes check is missing, or might be undesired. I have added TODO comments at these locations. Please let me know if you want any additional changes there.