### PR TITLE
(doc) Fix Maven Central badge version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Apache Commons IO
 [![Travis-CI Status](https://travis-ci.org/apache/commons-io.svg)](https://travis-ci.org/apache/commons-io)
 [![GitHub Actions Status](https://github.com/apache/commons-io/workflows/Java%20CI/badge.svg)](https://github.com/apache/commons-io/actions)
 [![Coverage Status](https://coveralls.io/repos/apache/commons-io/badge.svg)](https://coveralls.io/r/apache/commons-io)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/commons-io/commons-io/badge.svg)](https://maven-badges.herokuapp.com/maven-central/commons-io/commons-io/)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/commons-io/commons-io/badge.svg?gav=true)](https://maven-badges.herokuapp.com/maven-central/commons-io/commons-io/)
 [![Javadocs](https://javadoc.io/badge/commons-io/commons-io/2.11.0.svg)](https://javadoc.io/doc/commons-io/commons-io/2.11.0)
 
 The Apache Commons IO library contains utility classes, stream implementations, file filters,


### PR DESCRIPTION
Fixes the [badge](https://github.com/softwaremill/maven-badges) in the README.md to display the correct latest version, ignoring the non-semver-compatible [`20030203.000550`](https://mvnrepository.com/artifact/commons-io/commons-io/20030203.000550) version.