### PR TITLE
Fixes regression on copyURLToFile with partial regression tests

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1060,7 +1060,7 @@ public class FileUtils {
      */
     public static void copyURLToFile(final URL source, final File destination) throws IOException {
         try (final InputStream stream = source.openStream()) {
-            Files.copy(stream, destination.toPath());
+            copyInputStreamToFile(stream, destination);
         }
     }
 

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -1244,16 +1244,36 @@ public class FileUtilsTest extends AbstractTempDirTest {
         final File file = new File(tempDirFile, getName());
         file.deleteOnExit();
 
-        // Loads resource
-        final String resourceName = "/java/lang/Object.class";
-        FileUtils.copyURLToFile(getClass().getResource(resourceName), file);
+        assertContentMatchesAfterCopyURLToFileFor("/java/lang/Object.class", file);
+        //TODO Maybe test copy to itself like for copyFile()
+    }
 
-        // Tests that resuorce was copied correctly
-        try (InputStream fis = Files.newInputStream(file.toPath())) {
+    private void assertContentMatchesAfterCopyURLToFileFor(String resourceName, File destination) throws IOException {
+        FileUtils.copyURLToFile(getClass().getResource(resourceName), destination);
+
+        try (InputStream fis = Files.newInputStream(destination.toPath())) {
             assertTrue(IOUtils.contentEquals(getClass().getResourceAsStream(resourceName), fis),
                     "Content is not equal.");
         }
-        //TODO Maybe test copy to itself like for copyFile()
+    }
+
+    @Test
+    public void testCopyURLToFileCreatesParentDirs() throws Exception {
+
+        final File file = managedTempDirPath.resolve("subdir").resolve(getName()).toFile();
+        file.deleteOnExit();
+
+        assertContentMatchesAfterCopyURLToFileFor("/java/lang/Object.class", file);
+    }
+
+    @Test
+    public void testCopyURLToFileReplacesExisting() throws Exception {
+
+        final File file = new File(tempDirFile, getName());
+        file.deleteOnExit();
+
+        assertContentMatchesAfterCopyURLToFileFor("/java/lang/Object.class", file);
+        assertContentMatchesAfterCopyURLToFileFor("/java/lang/String.class", file);
     }
 
     @Test


### PR DESCRIPTION
The change in https://github.com/apache/commons-io/commit/f22b42618d704a09aac21db143bd7ee8d957e13a#r63142538 seemed to accidentally break the contract on `copyURLToFile` in the Javadoc

https://github.com/apache/commons-io/blob/ae2f2cd88c0df5276ebbcfba0bdcac5b16d003dc/src/main/java/org/apache/commons/io/FileUtils.java#L1042-L1045

This 
- reverts the change at fault to restore master to a state compatible with the contract
- adds a couple of tests which passed prior to this commit (with some minor tweaks to deal with test tidy up done between then and now).

I'm not sure of the intent of the original change, so this does not attempt to address that. Feel free to update this PR to do so if it makes sense.