### PR TITLE
Add tests to demonstrate issue with writing files into symlinked directories

### DIFF
--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -352,6 +352,17 @@ public class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
+    public void test_openOutputStream_intoExistingSymlinkedDir() throws Exception {
+        Path symlinkedDir = createTempSymlinkedRelativeDir();
+
+        final File file = symlinkedDir.resolve("test.txt").toFile();
+        try (FileOutputStream out = FileUtils.openOutputStream(file)) {
+            out.write(0);
+        }
+        assertTrue(file.exists());
+    }
+
+    @Test
     public void test_openInputStream_exists() throws Exception {
         final File file = new File(tempDirFile, "test.txt");
         TestUtils.createLineBasedFile(file, new String[]{"Hello"});
@@ -3046,7 +3057,7 @@ public class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
-    public void testWriteStringToFile1() throws Exception {
+    public void testWriteStringToFileWithCharset() throws Exception {
         final File file = new File(tempDirFile, "write.txt");
         FileUtils.writeStringToFile(file, "Hello /u1234", "UTF8");
         final byte[] text = "Hello /u1234".getBytes(StandardCharsets.UTF_8);
@@ -3054,7 +3065,7 @@ public class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
-    public void testWriteStringToFile2() throws Exception {
+    public void testWriteStringToFileWithNullStringCharset() throws Exception {
         final File file = new File(tempDirFile, "write.txt");
         FileUtils.writeStringToFile(file, "Hello /u1234", (String) null);
         final byte[] text = "Hello /u1234".getBytes();
@@ -3062,7 +3073,7 @@ public class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
-    public void testWriteStringToFile3() throws Exception {
+    public void testWriteStringToFileWithNullCharset() throws Exception {
         final File file = new File(tempDirFile, "write.txt");
         FileUtils.writeStringToFile(file, "Hello /u1234", (Charset) null);
         final byte[] text = "Hello /u1234".getBytes();
@@ -3070,11 +3081,30 @@ public class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
-    public void testWriteStringToFile4() throws Exception {
+    public void testWriteStringToFileIntoNonExistentSubdir() throws Exception {
         final File file = new File(tempDirFile, "subdir/write.txt");
         FileUtils.writeStringToFile(file, "Hello /u1234", (Charset) null);
         final byte[] text = "Hello /u1234".getBytes();
         TestUtils.assertEqualContent(text, file);
+    }
+
+    @Test
+    public void testWriteStringToFileIntoSymlinkedDir() throws Exception {
+        Path symlinkDir = createTempSymlinkedRelativeDir();
+
+        File file = symlinkDir.resolve("file").toFile();
+        FileUtils.writeStringToFile(file, "Hello /u1234", StandardCharsets.UTF_8);
+
+        final byte[] text = "Hello /u1234".getBytes();
+        TestUtils.assertEqualContent(text, file);
+    }
+
+    private Path createTempSymlinkedRelativeDir() throws IOException {
+        Path targetDir = tempDirPath.resolve("subdir");
+        Path symlinkDir = tempDirPath.resolve("symlinked-dir");
+        Files.createDirectory(targetDir);
+        Files.createSymbolicLink(symlinkDir, targetDir);
+        return symlinkDir;
     }
 
     @Test


### PR DESCRIPTION
Current master has some regressions when trying to write files into symlinked dirs, e.g

```java
FileUtils.writeStringToFile(new File("symlink-dir/target-file.txt"), "content", "UTF-8")
```
with
```
.
├── symlink-dir -> target-dir
└── target-dir
    └── target-file.txt
```

- `FileUtils.openOutputStream` (used by 2.11 implementation) allows this (per the test - which passes)
- `PathUtils.newOutputStream` and `PathUtils.createParentDirectories` do **not** allow this currently (per added tests)
- The switch from the former to the latter inside `FileUtils` seems to have broken `copyToFile`, `copyInputStreamToFile`, `copyURLToFile`, `write`, `writeStringToFile`, `writeLines`, `touch` compared to `2.11` when working with a target file that would be written inside an existing symlinked dir

As discussed at https://github.com/apache/commons-io/pull/319#issuecomment-1025934935 writing will currently fail with errors like

```
java.nio.file.FileAlreadyExistsException: /var/folders/3s/x7hkyjrd0y76fsw7417x7j1h0000gn/T/junit1985630074694639589/FileUtilsTest8511279228626771736/symlinked-dir
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:94)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:388)
	at java.base/java.nio.file.Files.createDirectory(Files.java:694)
	at java.base/java.nio.file.Files.createAndCheckIsDirectory(Files.java:801)
	at java.base/java.nio.file.Files.createDirectories(Files.java:747)
	at org.apache.commons.io.file.PathUtils.createParentDirectories(PathUtils.java:339)
	at org.apache.commons.io.file.PathUtils.newOutputStream(PathUtils.java:1066)
	at org.apache.commons.io.FileUtils.newOutputStream(FileUtils.java:2454)
	at org.apache.commons.io.FileUtils.writeStringToFile(FileUtils.java:3543)
	at org.apache.commons.io.FileUtils.writeStringToFile(FileUtils.java:3528)
	at org.apache.commons.io.FileUtilsTest.testWriteStringToFileIntoSymlinkedDir(FileUtilsTest.java:3096)
```

I don't know how to address this while still using NIO-based `PathUtils.createParentDirectories` and not breaking the contract. Users possibly expect `PathUtils.createParentDirectories` to fail if there is already a symlink to another directory there as this is existing behaviour since `2.9.0`.

The current implementation uses `Files.createDirectories(dir)` underneath which does not seem to allow treating the symlinked dir as a valid dir, as when it checks directories it uses `LinkOption.NOFOLLOW_LINKS` which is not parameterised to allow user to control it. If we want to keep using NIO for this, I suspect we would need our own version of `Files.createDirectories`

```java
    private static void createAndCheckIsDirectory(Path dir,
                                                  FileAttribute<?>... attrs)
        throws IOException
    {
        try {
            createDirectory(dir, attrs);
        } catch (FileAlreadyExistsException x) {
            if (!isDirectory(dir, LinkOption.NOFOLLOW_LINKS))
                throw x;
        }
    }
```

Marking as draft, because it deliberately has failing tests.