### PR TITLE
IOCase.isCaseSensitive(IOCase) result is backward

### DIFF
--- a/src/main/java/org/apache/commons/io/IOCase.java
+++ b/src/main/java/org/apache/commons/io/IOCase.java
@@ -91,7 +91,7 @@ public enum IOCase {
      * @since 2.10.0
      */
     public static boolean isCaseSensitive(final IOCase ioCase) {
-        return ioCase != null && !ioCase.isCaseSensitive();
+        return ioCase != null && ioCase.isCaseSensitive();
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/filefilter/RegexFileFilter.java
+++ b/src/main/java/org/apache/commons/io/filefilter/RegexFileFilter.java
@@ -16,6 +16,8 @@
  */
 package org.apache.commons.io.filefilter;
 
+import org.apache.commons.io.IOCase;
+
 import java.io.File;
 import java.io.Serializable;
 import java.nio.file.FileVisitResult;
@@ -23,8 +25,6 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.function.Function;
 import java.util.regex.Pattern;
-
-import org.apache.commons.io.IOCase;
 
 /**
  * Filters files using supplied regular expression(s).
@@ -89,7 +89,7 @@ public class RegexFileFilter extends AbstractFileFilter implements Serializable 
      * @return Pattern compilation flags.
      */
     private static int toFlags(final IOCase ioCase) {
-        return IOCase.isCaseSensitive(ioCase) ? Pattern.CASE_INSENSITIVE : 0;
+        return IOCase.isCaseSensitive(ioCase) ? 0 : Pattern.CASE_INSENSITIVE;
     }
 
     /** The regular expression pattern that will be used to match file names. */

--- a/src/main/java/org/apache/commons/io/filefilter/RegexFileFilter.java
+++ b/src/main/java/org/apache/commons/io/filefilter/RegexFileFilter.java
@@ -16,8 +16,6 @@
  */
 package org.apache.commons.io.filefilter;
 
-import org.apache.commons.io.IOCase;
-
 import java.io.File;
 import java.io.Serializable;
 import java.nio.file.FileVisitResult;
@@ -25,6 +23,8 @@ import java.nio.file.Path;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.function.Function;
 import java.util.regex.Pattern;
+
+import org.apache.commons.io.IOCase;
 
 /**
  * Filters files using supplied regular expression(s).

--- a/src/test/java/org/apache/commons/io/IOCaseTest.java
+++ b/src/test/java/org/apache/commons/io/IOCaseTest.java
@@ -301,4 +301,10 @@ public class IOCaseTest {
         assertEquals("System", IOCase.SYSTEM.toString());
     }
 
+    @Test
+    public void test_isCaseSensitive_static() {
+        assertTrue(IOCase.isCaseSensitive(IOCase.SENSITIVE));
+        assertFalse(IOCase.isCaseSensitive(IOCase.INSENSITIVE));
+        assertEquals(!WINDOWS, IOCase.isCaseSensitive(IOCase.SYSTEM));
+    }
 }


### PR DESCRIPTION
When the argument is IOCase.SENSITIVE, I think the static method isCaseSensitive should return true.

I did the following test with the code.

```
public void testIsCaseSensitive() {
  // return true. I think it is right.
  boolean b1 = IOCase.SENSITIVE.isCaseSensitive();
  System.out.println(b1);

  // but invoke static method and return false.
  boolean b2 = IOCase.isCaseSensitive(IOCase.SENSITIVE);
  System.out.println(b2);
}
```