### PR TITLE
Fix incollect value in field currentBufferIndex when creating new buffer first time.

### DIFF
--- a/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
@@ -129,9 +129,9 @@ public abstract class AbstractByteArrayOutputStream extends OutputStream {
             } else {
                 newBufferSize = Math.max(currentBuffer.length << 1, newcount - filledBufferSum);
                 filledBufferSum += currentBuffer.length;
+                currentBufferIndex++;
             }
 
-            currentBufferIndex++;
             currentBuffer = IOUtils.byteArray(newBufferSize);
             buffers.add(currentBuffer);
         }

--- a/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTest.java
@@ -357,10 +357,10 @@ public class ByteArrayOutputStreamTest {
     @ValueSource(ints = {1024, 64})
     public void testPrivateFieldOfCurrentBufferIndex(int size) throws NoSuchFieldException, IllegalAccessException {
         // Use the default size and custom size.
-        ByteArrayOutputStream os = new ByteArrayOutputStream(size);
+        final ByteArrayOutputStream os = new ByteArrayOutputStream(size);
 
         // Get private field object.
-        Field field = AbstractByteArrayOutputStream.class.getDeclaredField("currentBufferIndex");
+        final Field field = AbstractByteArrayOutputStream.class.getDeclaredField("currentBufferIndex");
         field.setAccessible(true);
 
         // Data for writing


### PR DESCRIPTION
The currentBufferIndex means the index of the current buffer in the class AbstractByteArrayOutputStream. 
when creating new buffer first time and the write size , currentBufferIndex should not change.

Luckily, this mistable does not affect any public methods and the result. After my modification, all the unit tests also pass.

```
    @Test
    public void testCurrentBufferIndex() throws IOException, IllegalAccessException, InstantiationException, NoSuchFieldException {
        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
        outputStream.write(new byte[]{0x31, 0x32});

        // Get Field currentBufferIndex
        Field field = ByteArrayOutputStream.class.getSuperclass().getDeclaredField("currentBufferIndex");
        field.setAccessible(true);
        int currentBufferIndex = (int) field.get(outputStream);

        // print 1. I think the right value is 0.
        //
        // Only 2 bytes are written, less than the default value 1024.
        // The size of array buffers is only 1, and currentBufferIndex should be 0.
        System.out.println(currentBufferIndex);
    }
```