### PR TITLE
IOUtilsTest - use assertThrows

### DIFF
--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1386,7 +1386,7 @@ public class IOUtilsTest {
     public void testToByteArray_InputStream_NegativeSize() throws Exception {
 
         try (InputStream fin = Files.newInputStream(testFilePath)) {
-           IllegalArgumentException exc = assertThrows(IllegalArgumentException.class,
+           final IllegalArgumentException exc = assertThrows(IllegalArgumentException.class,
                    ()->IOUtils.toByteArray(fin, -1), "Should have failed with IllegalArgumentException" );
             assertTrue(exc.getMessage().startsWith("Size must be equal or greater than zero"),
                 "Exception message does not start with \"Size must be equal or greater than zero\"");
@@ -1408,7 +1408,7 @@ public class IOUtilsTest {
     public void testToByteArray_InputStream_SizeIllegal() throws Exception {
 
         try (InputStream fin = Files.newInputStream(testFilePath)) {
-            IOException exc = assertThrows(IOException.class,
+            final IOException exc = assertThrows(IOException.class,
                     ()->IOUtils.toByteArray(fin, testFile.length() + 1), "Should have failed with IOException" );
             assertTrue(exc.getMessage().startsWith("Unexpected read size"),
                 "Exception message does not start with \"Unexpected read size\"");
@@ -1419,7 +1419,7 @@ public class IOUtilsTest {
     public void testToByteArray_InputStream_SizeLong() throws Exception {
 
         try (InputStream fin = Files.newInputStream(testFilePath)) {
-            IllegalArgumentException exc = assertThrows(IllegalArgumentException.class,
+            final IllegalArgumentException exc = assertThrows(IllegalArgumentException.class,
                     ()-> IOUtils.toByteArray(fin, (long) Integer.MAX_VALUE + 1),
                     "Should have failed with IllegalArgumentException" );
             assertTrue(exc.getMessage().startsWith("Size cannot be greater than Integer max value"),

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -935,26 +935,17 @@ public class IOUtilsTest {
     @Test
     public void testReadFully_InputStream_ByteArray() throws Exception {
         final int size = 1027;
-
         final byte[] buffer = new byte[size];
-
         final InputStream input = new ByteArrayInputStream(new byte[size]);
-        try {
-            IOUtils.readFully(input, buffer, 0, -1);
-            fail("Should have failed with IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-            // expected
-        }
+
+        assertThrows(IllegalArgumentException.class, ()-> IOUtils.readFully(input, buffer, 0, -1),
+                "Should have failed with IllegalArgumentException");
+
         IOUtils.readFully(input, buffer, 0, 0);
         IOUtils.readFully(input, buffer, 0, size - 1);
-        try {
-            IOUtils.readFully(input, buffer, 0, 2);
-            fail("Should have failed with EOFxception");
-        } catch (final EOFException expected) {
-            // expected
-        }
+        assertThrows(EOFException.class, ()-> IOUtils.readFully(input, buffer, 0, 2),
+                "Should have failed with EOFException");
         IOUtils.closeQuietly(input);
-
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -72,6 +72,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * This is used to test IOUtils for correctness. The following checks are performed:
@@ -177,30 +179,15 @@ public class IOUtilsTest {
 
     @Test
     public void testAsBufferedNull() {
-        try {
-            IOUtils.buffer((InputStream) null);
-            fail("Expected NullPointerException");
-        } catch (final NullPointerException npe) {
-            // expected
-        }
-        try {
-            IOUtils.buffer((OutputStream) null);
-            fail("Expected NullPointerException");
-        } catch (final NullPointerException npe) {
-            // expected
-        }
-        try {
-            IOUtils.buffer((Reader) null);
-            fail("Expected NullPointerException");
-        } catch (final NullPointerException npe) {
-            // expected
-        }
-        try {
-            IOUtils.buffer((Writer) null);
-            fail("Expected NullPointerException");
-        } catch (final NullPointerException npe) {
-            // expected
-        }
+        final String npeExpectedMessage = "Expected NullPointerException";
+        assertThrows(NullPointerException.class, ()->IOUtils.buffer((InputStream) null),
+                npeExpectedMessage );
+        assertThrows(NullPointerException.class, ()->IOUtils.buffer((OutputStream) null),
+                npeExpectedMessage);
+        assertThrows(NullPointerException.class, ()->IOUtils.buffer((Reader) null),
+                npeExpectedMessage);
+        assertThrows(NullPointerException.class, ()->IOUtils.buffer((Writer) null),
+                npeExpectedMessage);
     }
 
     @Test
@@ -1458,6 +1445,7 @@ public class IOUtilsTest {
             assertTrue(exc.getMessage().startsWith("Size must be equal or greater than zero"),
                 "Exception message does not start with \"Size must be equal or greater than zero\"");
         }
+
 
     }
 

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -913,12 +913,8 @@ public class IOUtilsTest {
             assertEquals(0, buffer.remaining());
             assertEquals(0, input.read(buffer));
             buffer.clear();
-            try {
-                IOUtils.readFully(input, buffer);
-                fail("Should have failed with EOFxception");
-            } catch (final EOFException expected) {
-                // expected
-            }
+            assertThrows(EOFException.class, ()->IOUtils.readFully(input, buffer),
+                    "Should have failed with EOFException");
         } finally {
             IOUtils.closeQuietly(input, fileInputStream);
         }

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -973,12 +973,8 @@ public class IOUtilsTest {
             assertEquals(0, input.read(buffer));
             IOUtils.readFully(input, buffer);
             buffer.clear();
-            try {
-                IOUtils.readFully(input, buffer);
-                fail("Should have failed with EOFxception");
-            } catch (final EOFException expected) {
-                // expected
-            }
+            assertThrows(EOFException.class, ()->IOUtils.readFully(input, buffer),
+                    "Should have failed with EOFxception");
         } finally {
             IOUtils.closeQuietly(input, fileInputStream);
         }
@@ -987,24 +983,15 @@ public class IOUtilsTest {
     @Test
     public void testReadFully_Reader() throws Exception {
         final int size = 1027;
-
         final char[] buffer = new char[size];
-
         final Reader input = new CharArrayReader(new char[size]);
+
         IOUtils.readFully(input, buffer, 0, 0);
         IOUtils.readFully(input, buffer, 0, size - 3);
-        try {
-            IOUtils.readFully(input, buffer, 0, -1);
-            fail("Should have failed with IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-            // expected
-        }
-        try {
-            IOUtils.readFully(input, buffer, 0, 5);
-            fail("Should have failed with EOFException");
-        } catch (final EOFException expected) {
-            // expected
-        }
+        assertThrows(IllegalArgumentException.class, ()->IOUtils.readFully(input, buffer, 0, -1),
+                "Should have failed with IllegalArgumentException" );
+        assertThrows(EOFException.class, ()->IOUtils.readFully(input, buffer, 0, 5),
+                "Should have failed with EOFException" );
         IOUtils.closeQuietly(input);
     }
 
@@ -1292,22 +1279,14 @@ public class IOUtilsTest {
         final int size = 1027;
 
         final InputStream input = new ByteArrayInputStream(new byte[size]);
-        try {
-            IOUtils.skipFully(input, -1);
-            fail("Should have failed with IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-            // expected
-        }
+        assertThrows(IllegalArgumentException.class, ()->IOUtils.skipFully(input, -1),
+                "Should have failed with IllegalArgumentException" );
+
         IOUtils.skipFully(input, 0);
         IOUtils.skipFully(input, size - 1);
-        try {
-            IOUtils.skipFully(input, 2);
-            fail("Should have failed with IOException");
-        } catch (final IOException expected) {
-            // expected
-        }
+        assertThrows(IOException.class, ()->  IOUtils.skipFully(input, size -1),
+        "Should have failed with IOException" );
         IOUtils.closeQuietly(input);
-
     }
 
     @Test
@@ -1315,20 +1294,12 @@ public class IOUtilsTest {
         final FileInputStream fileInputStream = new FileInputStream(testFile);
         final FileChannel fileChannel = fileInputStream.getChannel();
         try {
-            try {
-                IOUtils.skipFully(fileChannel, -1);
-                fail("Should have failed with IllegalArgumentException");
-            } catch (final IllegalArgumentException expected) {
-                // expected
-            }
+            assertThrows(IllegalArgumentException.class, ()->IOUtils.skipFully(fileChannel, -1),
+                    "Should have failed with IllegalArgumentException" );
             IOUtils.skipFully(fileChannel, 0);
             IOUtils.skipFully(fileChannel, FILE_SIZE - 1);
-            try {
-                IOUtils.skipFully(fileChannel, 2);
-                fail("Should have failed with IOException");
-            } catch (final IOException expected) {
-                // expected
-            }
+            assertThrows(IOException.class, ()->IOUtils.skipFully(fileChannel, 2),
+                    "Should have failed with IOException" );
         } finally {
             IOUtils.closeQuietly(fileChannel, fileInputStream);
         }
@@ -1337,22 +1308,14 @@ public class IOUtilsTest {
     @Test
     public void testSkipFully_Reader() throws Exception {
         final int size = 1027;
-
         final Reader input = new CharArrayReader(new char[size]);
+
         IOUtils.skipFully(input, 0);
         IOUtils.skipFully(input, size - 3);
-        try {
-            IOUtils.skipFully(input, -1);
-            fail("Should have failed with IllegalArgumentException");
-        } catch (final IllegalArgumentException expected) {
-            // expected
-        }
-        try {
-            IOUtils.skipFully(input, 5);
-            fail("Should have failed with IOException");
-        } catch (final IOException expected) {
-            // expected
-        }
+        assertThrows(IllegalArgumentException.class, ()->IOUtils.skipFully(input, -1),
+                "Should have failed with IllegalArgumentException" );
+        assertThrows(IOException.class, ()->IOUtils.skipFully(input, 5),
+                "Should have failed with IOException" );
         IOUtils.closeQuietly(input);
     }
 
@@ -1426,14 +1389,12 @@ public class IOUtilsTest {
     public void testToByteArray_InputStream_NegativeSize() throws Exception {
 
         try (InputStream fin = Files.newInputStream(testFilePath)) {
-            IOUtils.toByteArray(fin, -1);
-            fail("IllegalArgumentException expected");
-        } catch (final IllegalArgumentException exc) {
+           IllegalArgumentException exc = assertThrows(IllegalArgumentException.class,
+                   ()->IOUtils.toByteArray(fin, -1),
+                    "Should have failed with IllegalArgumentException" );
             assertTrue(exc.getMessage().startsWith("Size must be equal or greater than zero"),
                 "Exception message does not start with \"Size must be equal or greater than zero\"");
         }
-
-
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1412,26 +1412,24 @@ public class IOUtilsTest {
     public void testToByteArray_InputStream_SizeIllegal() throws Exception {
 
         try (InputStream fin = Files.newInputStream(testFilePath)) {
-            IOUtils.toByteArray(fin, testFile.length() + 1);
-            fail("IOException expected");
-        } catch (final IOException exc) {
+            IOException exc = assertThrows(IOException.class,
+                    ()->IOUtils.toByteArray(fin, testFile.length() + 1),
+                    "Should have failed with IOException" );
             assertTrue(exc.getMessage().startsWith("Unexpected read size"),
                 "Exception message does not start with \"Unexpected read size\"");
         }
-
     }
 
     @Test
     public void testToByteArray_InputStream_SizeLong() throws Exception {
 
         try (InputStream fin = Files.newInputStream(testFilePath)) {
-            IOUtils.toByteArray(fin, (long) Integer.MAX_VALUE + 1);
-            fail("IOException expected");
-        } catch (final IllegalArgumentException exc) {
+            IllegalArgumentException exc = assertThrows(IllegalArgumentException.class,
+                    ()-> IOUtils.toByteArray(fin, (long) Integer.MAX_VALUE + 1),
+                    "Should have failed with IllegalArgumentException" );
             assertTrue(exc.getMessage().startsWith("Size cannot be greater than Integer max value"),
                 "Exception message does not start with \"Size cannot be greater than Integer max value\"");
         }
-
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1284,7 +1284,7 @@ public class IOUtilsTest {
 
         IOUtils.skipFully(input, 0);
         IOUtils.skipFully(input, size - 1);
-        assertThrows(IOException.class, ()->  IOUtils.skipFully(input, size -1),
+        assertThrows(IOException.class, ()->  IOUtils.skipFully(input, 2),
         "Should have failed with IOException" );
         IOUtils.closeQuietly(input);
     }
@@ -1390,8 +1390,7 @@ public class IOUtilsTest {
 
         try (InputStream fin = Files.newInputStream(testFilePath)) {
            IllegalArgumentException exc = assertThrows(IllegalArgumentException.class,
-                   ()->IOUtils.toByteArray(fin, -1),
-                    "Should have failed with IllegalArgumentException" );
+                   ()->IOUtils.toByteArray(fin, -1), "Should have failed with IllegalArgumentException" );
             assertTrue(exc.getMessage().startsWith("Size must be equal or greater than zero"),
                 "Exception message does not start with \"Size must be equal or greater than zero\"");
         }
@@ -1413,8 +1412,7 @@ public class IOUtilsTest {
 
         try (InputStream fin = Files.newInputStream(testFilePath)) {
             IOException exc = assertThrows(IOException.class,
-                    ()->IOUtils.toByteArray(fin, testFile.length() + 1),
-                    "Should have failed with IOException" );
+                    ()->IOUtils.toByteArray(fin, testFile.length() + 1), "Should have failed with IOException" );
             assertTrue(exc.getMessage().startsWith("Unexpected read size"),
                 "Exception message does not start with \"Unexpected read size\"");
         }

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -25,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
@@ -72,8 +71,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * This is used to test IOUtils for correctness. The following checks are performed:


### PR DESCRIPTION
Refactor to use Junit5 assertions  instead of try/catch blocks in IOUtilsTest
- ~60 lines of boilerplate removed
- no changes to test logic