### PR TITLE
[IO-764] IOUtils.write() throws OutOfMemoryError/NegativeArraySizeException while writing big strings

### DIFF
--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -40,8 +40,10 @@ import java.net.URL;
 import java.net.URLConnection;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.Selector;
+import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -3362,7 +3364,14 @@ public class IOUtils {
      */
     public static void write(final String data, final OutputStream output, final Charset charset) throws IOException {
         if (data != null) {
-            output.write(data.getBytes(Charsets.toCharset(charset)));
+           final Charset usableCharset = Charsets.toCharset(charset);
+
+           // A ByteBuffer needs to be used here, since calling getBytes directly on the String might result in NegativeArraySizeException
+           final ByteBuffer bytebuffer = usableCharset.encode(data);
+
+           // Since the underlying OutputStream should not be closed, the channel is not closed
+           final WritableByteChannel channel = Channels.newChannel(output);
+           channel.write(bytebuffer);
         }
     }
 


### PR DESCRIPTION
If Strings with a certain size are written to a stream, this fails with an exception on OpenJDK 11. 

```
java.lang.NegativeArraySizeException: -1283060862
at java.base/java.lang.StringCoding.encodeUTF8(StringCoding.java:904)
at java.base/java.lang.StringCoding.encode(StringCoding.java:449)
at java.base/java.lang.String.getBytes(String.java:964)
at org.apache.commons.io.IOUtils.write(IOUtils.java:3251)
at org.apache.commons.io.FileUtils.writeStringToFile(FileUtils.java:3541)
at org.apache.commons.io.FileUtils.writeStringToFile(FileUtils.java:3524)
```

This PR fixes the problem by using a `ByteBuffer` instead `getBytes`. 

Unfortunately, this increases test time significantly. One workaround would be to disable the test and only enable it if needed - but testing whether big Strings can be written is not possible without handling such a big string.