### PR TITLE
Configure Maven Fork Test parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@ file comparators, endian transformation classes, and much more.
           <classpathDependencyExcludes>
             <classpathDependencyExclude>xerces:xercesImpl</classpathDependencyExclude>
           </classpathDependencyExcludes>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
           <reuseForks>false</reuseForks>
           <!-- limit memory size see IO-161 -->
           <argLine>${argLine} -Xmx25M</argLine>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
