### PR TITLE
Add test for AbstractByteArrayOutputStream.resetImpl and .toByteArrayImpl

### DIFF
--- a/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTest.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.Writer;
 import java.io.OutputStreamWriter;
 import java.nio.charset.StandardCharsets;
@@ -37,7 +36,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.function.IOFunction;
 import org.apache.commons.io.input.ClosedInputStream;
 import org.apache.commons.io.test.TestUtils;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -360,8 +358,8 @@ public class ByteArrayOutputStreamTest {
 
     @Test
     public void testToByteArrayImplAndResetImpl() throws Exception {
-        final int file_size = (1024 * 4) + 1;
-        final byte[] inData = TestUtils.generateTestData(file_size);
+        final int fileSize = 4097;
+        final byte[] inData = TestUtils.generateTestData(fileSize);
         try (InputStream in = new ByteArrayInputStream(inData)) {
             try (ByteArrayOutputStream baout = new ByteArrayOutputStream()) {
                 try (Writer writer = new OutputStreamWriter(baout, StandardCharsets.US_ASCII)) {
@@ -369,7 +367,7 @@ public class ByteArrayOutputStreamTest {
                     writer.flush();
                 }
                 baout.reset();
-                Assertions.assertEquals("", baout.toString());
+                assertEquals("", baout.toString());
             }
         }
     }

--- a/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTest.java
@@ -37,8 +37,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.function.IOFunction;
 import org.apache.commons.io.input.ClosedInputStream;
 import org.apache.commons.io.test.TestUtils;
-import org.apache.commons.io.test.ThrowOnCloseInputStream;
-import org.apache.commons.io.test.ThrowOnFlushAndCloseOutputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -360,20 +358,20 @@ public class ByteArrayOutputStreamTest {
         }
     }
 
-    private static final int FILE_SIZE = (1024 * 4) + 1;
-    private final byte[] inData = TestUtils.generateTestData(FILE_SIZE);
-
     @Test
     public void testToByteArrayImplAndResetImpl() throws Exception {
-        InputStream in = new ByteArrayInputStream(inData);
-        in = new ThrowOnCloseInputStream(in);
-        final ByteArrayOutputStream baout = new ByteArrayOutputStream();
-        final OutputStream out = new ThrowOnFlushAndCloseOutputStream(baout, false, true);
-        final Writer writer = new OutputStreamWriter(out, StandardCharsets.US_ASCII);
-        CopyUtils.copy(in, writer);
-        writer.flush();
-        baout.reset();
-        Assertions.assertEquals("", baout.toString());
+        final int file_size = (1024 * 4) + 1;
+        final byte[] inData = TestUtils.generateTestData(file_size);
+        try (InputStream in = new ByteArrayInputStream(inData)) {
+            try (ByteArrayOutputStream baout = new ByteArrayOutputStream()) {
+                try (Writer writer = new OutputStreamWriter(baout, StandardCharsets.US_ASCII)) {
+                    CopyUtils.copy(in, writer);
+                    writer.flush();
+                }
+                baout.reset();
+                Assertions.assertEquals("", baout.toString());
+            }
+        }
     }
 
     private int writeData(final AbstractByteArrayOutputStream baout, final java.io.ByteArrayOutputStream ref, final int count) {

--- a/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/ByteArrayOutputStreamTest.java
@@ -26,11 +26,21 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Writer;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.stream.Stream;
 
+import org.apache.commons.io.CopyUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.function.IOFunction;
 import org.apache.commons.io.input.ClosedInputStream;
+import org.apache.commons.io.test.TestUtils;
+import org.apache.commons.io.test.ThrowOnCloseInputStream;
+import org.apache.commons.io.test.ThrowOnFlushAndCloseOutputStream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -348,6 +358,22 @@ public class ByteArrayOutputStreamTest {
             baout.write(IOUtils.EMPTY_BYTE_ARRAY, 0, 0);
             assertTrue(true, "Dummy");
         }
+    }
+
+    private static final int FILE_SIZE = (1024 * 4) + 1;
+    private final byte[] inData = TestUtils.generateTestData(FILE_SIZE);
+
+    @Test
+    public void testToByteArrayImplAndResetImpl() throws Exception {
+        InputStream in = new ByteArrayInputStream(inData);
+        in = new ThrowOnCloseInputStream(in);
+        final ByteArrayOutputStream baout = new ByteArrayOutputStream();
+        final OutputStream out = new ThrowOnFlushAndCloseOutputStream(baout, false, true);
+        final Writer writer = new OutputStreamWriter(out, StandardCharsets.US_ASCII);
+        CopyUtils.copy(in, writer);
+        writer.flush();
+        baout.reset();
+        Assertions.assertEquals("", baout.toString());
     }
 
     private int writeData(final AbstractByteArrayOutputStream baout, final java.io.ByteArrayOutputStream ref, final int count) {


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `baout.toString()` is equal to `""` when `reset` is called. 
This tests the methods [`AbstractByteArrayOutputStream.toByteArrayImpl`](https://github.com/apache/commons-io/blob/4aab769c3279ea63b7bcdaa163c50761bc540f8c/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java#L188) and [`AbstractByteArrayOutputStream.resetImpl`](https://github.com/apache/commons-io/blob/4aab769c3279ea63b7bcdaa163c50761bc540f8c/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java#L148). 
This test is based on the test [`copy_inputStreamToWriter`](https://github.com/apache/commons-io/blob/4aab769c3279ea63b7bcdaa163c50761bc540f8c/src/test/java/org/apache/commons/io/CopyUtilsTest.java#L83).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))