### PR TITLE
Better docs in IOUtils and IOUtils.byteArray(int size)

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -3537,9 +3537,7 @@ public class FileUtils {
 
     /**
      * Instances should NOT be constructed in standard programming.
-     * @deprecated Will be private in 3.0.
      */
-    @Deprecated
     public FileUtils() { //NOSONAR
 
     }

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -3537,6 +3537,7 @@ public class FileUtils {
 
     /**
      * Instances should NOT be constructed in standard programming.
+     * @deprecated Will be private in 3.0.
      */
     @Deprecated
     public FileUtils() { //NOSONAR

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -3538,6 +3538,7 @@ public class FileUtils {
     /**
      * Instances should NOT be constructed in standard programming.
      */
+    @Deprecated
     public FileUtils() { //NOSONAR
 
     }

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -346,9 +346,15 @@ public class IOUtils {
      *
      * @param size array size.
      * @return a new byte array of the given size.
+     *
+     * @exception  IllegalArgumentException  If {@code size <= 0}
+     *
      * @since 2.9.0
      */
     public static byte[] byteArray(final int size) {
+        if (size <= 0) {
+            throw new IllegalArgumentException("byte size <= 0");
+        }
         return new byte[size];
     }
 
@@ -479,7 +485,7 @@ public class IOUtils {
      * @param closeable the objects to close, may be null or already closed
      * @since 2.0
      *
-     * @see Throwable#addSuppressed(java.lang.Throwable)
+     * @see Throwable#addSuppressed(Throwable)
      */
     public static void closeQuietly(final Closeable closeable) {
         closeQuietly(closeable, null);
@@ -529,7 +535,7 @@ public class IOUtils {
      * @param closeables the objects to close, may be null or already closed
      * @see #closeQuietly(Closeable)
      * @since 2.5
-     * @see Throwable#addSuppressed(java.lang.Throwable)
+     * @see Throwable#addSuppressed(Throwable)
      */
     public static void closeQuietly(final Closeable... closeables) {
         if (closeables != null) {
@@ -583,7 +589,7 @@ public class IOUtils {
      * </p>
      *
      * @param input the InputStream to close, may be null or already closed
-     * @see Throwable#addSuppressed(java.lang.Throwable)
+     * @see Throwable#addSuppressed(Throwable)
      */
     public static void closeQuietly(final InputStream input) {
         closeQ(input);
@@ -633,7 +639,7 @@ public class IOUtils {
      * </p>
      *
      * @param output the OutputStream to close, may be null or already closed
-     * @see Throwable#addSuppressed(java.lang.Throwable)
+     * @see Throwable#addSuppressed(Throwable)
      */
     public static void closeQuietly(final OutputStream output) {
         closeQ(output);
@@ -666,7 +672,7 @@ public class IOUtils {
      * </p>
      *
      * @param reader the Reader to close, may be null or already closed
-     * @see Throwable#addSuppressed(java.lang.Throwable)
+     * @see Throwable#addSuppressed(Throwable)
      */
     public static void closeQuietly(final Reader reader) {
         closeQ(reader);
@@ -699,7 +705,7 @@ public class IOUtils {
      *
      * @param selector the Selector to close, may be null or already closed
      * @since 2.2
-     * @see Throwable#addSuppressed(java.lang.Throwable)
+     * @see Throwable#addSuppressed(Throwable)
      */
     public static void closeQuietly(final Selector selector) {
         closeQ(selector);
@@ -732,7 +738,7 @@ public class IOUtils {
      *
      * @param serverSocket the ServerSocket to close, may be null or already closed
      * @since 2.2
-     * @see Throwable#addSuppressed(java.lang.Throwable)
+     * @see Throwable#addSuppressed(Throwable)
      */
     public static void closeQuietly(final ServerSocket serverSocket) {
         closeQ(serverSocket);
@@ -765,7 +771,7 @@ public class IOUtils {
      *
      * @param socket the Socket to close, may be null or already closed
      * @since 2.0
-     * @see Throwable#addSuppressed(java.lang.Throwable)
+     * @see Throwable#addSuppressed(Throwable)
      */
     public static void closeQuietly(final Socket socket) {
         closeQ(socket);
@@ -813,7 +819,7 @@ public class IOUtils {
      * </p>
      *
      * @param writer the Writer to close, may be null or already closed
-     * @see Throwable#addSuppressed(java.lang.Throwable)
+     * @see Throwable#addSuppressed(Throwable)
      */
     public static void closeQuietly(final Writer writer) {
         closeQ(writer);
@@ -2603,7 +2609,7 @@ public class IOUtils {
      * Use this method instead of {@link #toByteArray(InputStream)}
      * when {@link InputStream} size is known.
      * <b>NOTE:</b> the method checks that the length can safely be cast to an int without truncation
-     * before using {@link IOUtils#toByteArray(java.io.InputStream, int)} to read into the byte array.
+     * before using {@link IOUtils#toByteArray(InputStream, int)} to read into the byte array.
      * (Arrays can have no more than Integer.MAX_VALUE entries anyway)
      *
      * @param input the {@link InputStream} to read from
@@ -2611,7 +2617,7 @@ public class IOUtils {
      * @return byte [] the requested byte array, of length {@code size}
      * @throws IOException              if an I/O error occurs or {@link InputStream} length is less than {@code size}
      * @throws IllegalArgumentException if size is less than zero or size is greater than Integer.MAX_VALUE
-     * @see IOUtils#toByteArray(java.io.InputStream, int)
+     * @see IOUtils#toByteArray(InputStream, int)
      * @since 2.1
      */
     public static byte[] toByteArray(final InputStream input, final long size) throws IOException {

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -341,20 +341,15 @@ public class IOUtils {
 
     /**
      * Returns a new byte array of the given size.
+     * Throws java.lang.NegativeArraySizeException if the size is negative.
      *
      * TODO Consider guarding or warning against large allocations...
      *
      * @param size array size.
      * @return a new byte array of the given size.
-     *
-     * @throws IllegalArgumentException If {@code size <= 0}
-     *
      * @since 2.9.0
      */
     public static byte[] byteArray(final int size) {
-        if (size <= 0) {
-            throw new IllegalArgumentException("byte size <= 0");
-        }
         return new byte[size];
     }
 

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -341,12 +341,12 @@ public class IOUtils {
 
     /**
      * Returns a new byte array of the given size.
-     * Throws java.lang.NegativeArraySizeException if the size is negative.
      *
      * TODO Consider guarding or warning against large allocations...
      *
      * @param size array size.
      * @return a new byte array of the given size.
+     * @throws NegativeArraySizeException if the size is negative.
      * @since 2.9.0
      */
     public static byte[] byteArray(final int size) {

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -3724,7 +3724,9 @@ public class IOUtils {
 
     /**
      * Instances should NOT be constructed in standard programming.
+     * @deprecated Will be private in 3.0.
      */
+    @Deprecated
     public IOUtils() { //NOSONAR
     }
 

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -347,7 +347,7 @@ public class IOUtils {
      * @param size array size.
      * @return a new byte array of the given size.
      *
-     * @exception  IllegalArgumentException  If {@code size <= 0}
+     * @throws IllegalArgumentException If {@code size <= 0}
      *
      * @since 2.9.0
      */

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -16,20 +16,40 @@
  */
 package org.apache.commons.io;
 
-import org.apache.commons.io.function.IOConsumer;
-import org.apache.commons.io.input.*;
-import org.apache.commons.io.output.*;
-import org.apache.commons.io.test.TestUtils;
-import org.apache.commons.io.test.ThrowOnCloseReader;
-import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.*;
-import java.net.*;
+import java.io.CharArrayReader;
+import java.io.CharArrayWriter;
+import java.io.Closeable;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.Writer;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLConnection;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.Selector;
@@ -40,7 +60,25 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.junit.jupiter.api.Assertions.*;
+import org.apache.commons.io.function.IOConsumer;
+import org.apache.commons.io.input.BrokenInputStream;
+import org.apache.commons.io.input.CircularInputStream;
+import org.apache.commons.io.input.NullInputStream;
+import org.apache.commons.io.input.NullReader;
+import org.apache.commons.io.input.StringInputStream;
+import org.apache.commons.io.output.AppendableWriter;
+import org.apache.commons.io.output.BrokenOutputStream;
+import org.apache.commons.io.output.CountingOutputStream;
+import org.apache.commons.io.output.NullOutputStream;
+import org.apache.commons.io.output.NullWriter;
+import org.apache.commons.io.output.StringBuilderWriter;
+import org.apache.commons.io.test.TestUtils;
+import org.apache.commons.io.test.ThrowOnCloseReader;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 /**
  * This is used to test {@link IOUtils} for correctness. The following checks are performed:

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1718,9 +1718,7 @@ public class IOUtilsTest {
 
     @Test
     public void testByteArrayWithNegativeSize() {
-        assertThrows(NegativeArraySizeException.class,() -> {
-            IOUtils.byteArray(-1);
-        });
+        assertThrows(NegativeArraySizeException.class,() -> IOUtils.byteArray(-1));
     }
 
 }

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1552,7 +1552,7 @@ public class IOUtilsTest {
 
     /**
      * Test for {@link IOUtils#toInputStream(CharSequence)} and {@link IOUtils#toInputStream(CharSequence, String)}.
-     * Note, this test utilizes on {@link IOUtils#toByteArray(java.io.InputStream)} and so relies on
+     * Note, this test utilizes on {@link IOUtils#toByteArray(InputStream)} and so relies on
      * {@link #testToByteArray_InputStream()} to ensure this method functions correctly.
      *
      * @throws Exception on error
@@ -1573,7 +1573,7 @@ public class IOUtilsTest {
 
     /**
      * Test for {@link IOUtils#toInputStream(String)} and {@link IOUtils#toInputStream(String, String)}. Note, this test
-     * utilizes on {@link IOUtils#toByteArray(java.io.InputStream)} and so relies on
+     * utilizes on {@link IOUtils#toByteArray(InputStream)} and so relies on
      * {@link #testToByteArray_InputStream()} to ensure this method functions correctly.
      *
      * @throws Exception on error
@@ -1714,6 +1714,20 @@ public class IOUtilsTest {
                 assertEquals(data.length(), os.getByteCount());
             }
         }
+    }
+
+    @Test
+    public void testByteArrayWithIllegalSize() {
+        try {
+            int size = -1;
+            byte[] bytes = IOUtils.byteArray(size);
+
+            size = 0;
+            bytes = IOUtils.byteArray(size);
+        }catch (Exception e) {
+            assertEquals(e.getClass().getName(), IllegalArgumentException.class.getName());
+        }
+
     }
 
 }

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -79,6 +79,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * This is used to test {@link IOUtils} for correctness. The following checks are performed:
@@ -1716,18 +1718,12 @@ public class IOUtilsTest {
         }
     }
 
-    @Test
-    public void testByteArrayWithZeroSize() {
-        assertThrows(IllegalArgumentException.class,() -> {
-            int size = 0;
-            byte[] bytes = IOUtils.byteArray(size);
-        });
-    }
 
-    @Test
-    public void testByteArrayWithNegativeSize() {
+    @ParameterizedTest
+    @ValueSource(ints = { -1, 0 })
+    public void testByteArrayWithIllegalSize(int size) {
+        System.out.println("size=" + size);
         assertThrows(IllegalArgumentException.class,() -> {
-            int size = -1;
             byte[] bytes = IOUtils.byteArray(size);
         });
     }

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1718,16 +1718,13 @@ public class IOUtilsTest {
 
     @Test
     public void testByteArrayWithIllegalSize() {
-        try {
+        assertThrows(IllegalArgumentException.class,() -> {
             int size = -1;
             byte[] bytes = IOUtils.byteArray(size);
 
             size = 0;
             bytes = IOUtils.byteArray(size);
-        }catch (Exception e) {
-            assertEquals(e.getClass().getName(), IllegalArgumentException.class.getName());
-        }
-
+        });
     }
 
 }

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1718,12 +1718,10 @@ public class IOUtilsTest {
         }
     }
 
-
-    @ParameterizedTest
-    @ValueSource(ints = { -1, 0 })
-    public void testByteArrayWithIllegalSize(int size) {
-        System.out.println("size=" + size);
-        assertThrows(IllegalArgumentException.class,() -> {
+    @Test
+    public void testByteArrayWithNegativeSize() {
+        int size = -1;
+        assertThrows(NegativeArraySizeException.class,() -> {
             byte[] bytes = IOUtils.byteArray(size);
         });
     }

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1718,7 +1718,7 @@ public class IOUtilsTest {
 
     @Test
     public void testByteArrayWithNegativeSize() {
-        assertThrows(NegativeArraySizeException.class,() -> IOUtils.byteArray(-1));
+        assertThrows(NegativeArraySizeException.class, () -> IOUtils.byteArray(-1));
     }
 
 }

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -16,40 +16,20 @@
  */
 package org.apache.commons.io;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNotSame;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.apache.commons.io.function.IOConsumer;
+import org.apache.commons.io.input.*;
+import org.apache.commons.io.output.*;
+import org.apache.commons.io.test.TestUtils;
+import org.apache.commons.io.test.ThrowOnCloseReader;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.CharArrayReader;
-import java.io.CharArrayWriter;
-import java.io.Closeable;
-import java.io.EOFException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.io.Reader;
-import java.io.StringReader;
-import java.io.Writer;
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.net.URI;
-import java.net.URL;
-import java.net.URLConnection;
+import java.io.*;
+import java.net.*;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.channels.Selector;
@@ -60,27 +40,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
-import org.apache.commons.io.function.IOConsumer;
-import org.apache.commons.io.input.BrokenInputStream;
-import org.apache.commons.io.input.CircularInputStream;
-import org.apache.commons.io.input.NullInputStream;
-import org.apache.commons.io.input.NullReader;
-import org.apache.commons.io.input.StringInputStream;
-import org.apache.commons.io.output.AppendableWriter;
-import org.apache.commons.io.output.BrokenOutputStream;
-import org.apache.commons.io.output.CountingOutputStream;
-import org.apache.commons.io.output.NullOutputStream;
-import org.apache.commons.io.output.NullWriter;
-import org.apache.commons.io.output.StringBuilderWriter;
-import org.apache.commons.io.test.TestUtils;
-import org.apache.commons.io.test.ThrowOnCloseReader;
-import org.apache.commons.lang3.StringUtils;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * This is used to test {@link IOUtils} for correctness. The following checks are performed:
@@ -1720,9 +1680,8 @@ public class IOUtilsTest {
 
     @Test
     public void testByteArrayWithNegativeSize() {
-        int size = -1;
         assertThrows(NegativeArraySizeException.class,() -> {
-            byte[] bytes = IOUtils.byteArray(size);
+            IOUtils.byteArray(-1);
         });
     }
 

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1717,13 +1717,18 @@ public class IOUtilsTest {
     }
 
     @Test
-    public void testByteArrayWithIllegalSize() {
+    public void testByteArrayWithZeroSize() {
+        assertThrows(IllegalArgumentException.class,() -> {
+            int size = 0;
+            byte[] bytes = IOUtils.byteArray(size);
+        });
+    }
+
+    @Test
+    public void testByteArrayWithNegativeSize() {
         assertThrows(IllegalArgumentException.class,() -> {
             int size = -1;
             byte[] bytes = IOUtils.byteArray(size);
-
-            size = 0;
-            bytes = IOUtils.byteArray(size);
         });
     }
 


### PR DESCRIPTION
IOUtils.byteArray(int size) add the verification to assure that the size is legal(size > 0), the illegal(size <=0) should throw IllegalArgumentException.
