### PR TITLE
[IO-769] FileUtils copyDirectory() should NOT use COPY_ATTRIBUTES 

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -2853,7 +2853,7 @@ public class FileUtils {
             final BasicFileAttributeView destAttrView = Files.getFileAttributeView(targetFile.toPath(), BasicFileAttributeView.class);
             // null guards are not needed; BasicFileAttributes.setTimes(...) is null safe
             destAttrView.setTimes(srcAttr.lastModifiedTime(), srcAttr.lastAccessTime(), srcAttr.creationTime());
-        } catch(IOException unused) {
+        } catch (IOException unused) {
             // Fallback: Only set modified time to match source file
             targetFile.setLastModified(sourceFile.lastModified());
         }


### PR DESCRIPTION
Since commons-io@2.9, the `copyDirectory()` function uses `COPY_ATTRIBUTES` to honor the `preserveFileDate` boolean.

This properly preserves the date, but introduces an inadvertent effect on file permissions.

For example, if copying from `%USERPROFILE%` to `C:\Program Files` the following permissions changes can be observed.

| Version           | Permissions (`icals <file>`)    |
|-------------------|---------------------------------|
| `commons-io@2.8`  | `NT AUTHORITY\SYSTEM:(I)(F)`<br>`BUILTIN\Administrators:(I)(F)`<br>`BUILTIN\Users:(I)(RX)`<br>`APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES:(I)(RX)`<br>`APPLICATION PACKAGE AUTHORITY\ALL RESTRICTED APPLICATION PACKAGES:(I)(RX)` |
| `commons-io@2.9` | `NT AUTHORITY\SYSTEM:(F)`<br>`BUILTIN\Administrators:(F)`<br>`WIN10ARM\owner:(F)`<br> |

* This regression is very similar for Unixes.  Prior to 2.9, files copied to a `root:root` (Linux) or `root:admin` (MacOS) owned directory would inherit the target permissions.  Starting with 2.9, the files will retain their original ownership.
* The OLD behavior is a closer match to the OS's default copy behavior (Linux, Mac and Windows will use the permissions of the target directory when copying).

The regression can be traced to to the 2.9 release and all releases thereafter.

Prior to submitting the PR, a conversation was had on the mailing list and stackoverflow.
* Mailing list convo: https://lists.apache.org/thread/schfj3m01ppd3287mxnn04lpp25hgw74
* Stackoverflow convo: https://stackoverflow.com/questions/73428286

| Version           | Status                          |
|-------------------|---------------------------------|
| `commons-io@1.1` (2005) | :white_check_mark: Inherits permissions of destination |
| `commons-io@2.4` (2013) | :white_check_mark: Inherits permissions of destination |
| `commons-io@2.5` (2016) | :white_check_mark: Inherits permissions of destination |
| `commons-io@2.6` (2017) | :white_check_mark: Inherits permissions of destination |
| `commons-io@2.7` (2020) | :white_check_mark: Inherits permissions of destination |
| `commons-io@2.8` (2020) | :white_check_mark: Inherits permissions of destination |
| `commons-io@2.9` (2021) | :no_entry_sign: Does not inherit permissions of destination |
| `commons-io@2.10` (2021) | :no_entry_sign: Does not inherit permissions of destination |
| `commons-io@2.11` (2021) | :no_entry_sign: Does not inherit permissions of destination |

This PR removes the COPY_ATTRIBUTES flag unless a file is being moved (to match the OS default move behavior), and instead uses NIO calls to preserve the timestamp information.

TODO:
* [ ] :speech_balloon: **Discussion:** With this PR, the solution uses `BasicFileAttributeView.setTimes(FileTime, FileTime, FileTime)` to set ALL timestamp information.  This differs slightly from pre-2.9 versions.  According to the JavaDocs, this may actually set file stamps to beginning of epoch, so this may be undesired.  If there's an IOException, it will fallback to the older `File.setLastModified(long)` API, but it could be argued that this should remain the only API for maximum backwards compatibility.
* [ ] :speech_balloon: **Discussion:** Why did the previous `setLastModified(File, File)` need `PathUtils.setLastModifiedTime()` if
       `sourceFile.isFile()` was `true`, but needed `setLastModifiedTime(File, long)` if `sourceFile.isFile()` was `false`.  [This is the code I'm inquiring about](https://github.com/apache/commons-io/blob/f22a4227401855ecbfdf8184bbe37275c3aeb5c3/src/main/java/org/apache/commons/io/FileUtils.java#L2854-L2857) which will be lost with this PR, so I'd like to understand the history of this to ensure we aren't introducing a regression with the new change.
* [ ] :hourglass_flowing_sand: **Action:** Hand-test this change and impacting APIs on various platforms and compare behavior to pre-2.9 versions.