### PR TITLE
[IO-611] FilenameUtils.normalize javadoc and tests.

### DIFF
--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -1234,7 +1234,7 @@ public class FilenameUtils {
      * /foo/../bar          --&gt;   /bar
      * /foo/../bar/         --&gt;   /bar/
      * /foo/../bar/../baz   --&gt;   /baz
-     * //foo//./bar         --&gt;   /foo/bar
+     * //foo//./bar         --&gt;   //foo/bar
      * /../                 --&gt;   null
      * ../foo               --&gt;   null
      * foo/bar/..           --&gt;   foo/

--- a/src/test/java/org/apache/commons/io/FilenameUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FilenameUtilsTest.java
@@ -932,6 +932,31 @@ public class FilenameUtilsTest {
         assertNull(FilenameUtils.normalize("\\\\..\\foo"));
     }
 
+    @Test
+    public void testNormalizeFromJavaDoc() {
+    	// Examples from javadoc
+        assertEquals(SEP + "foo" + SEP, FilenameUtils.normalize("/foo//"));
+        assertEquals(SEP + "foo" + SEP, FilenameUtils.normalize(SEP + "foo" + SEP + "." + SEP));
+        assertEquals(SEP + "bar", FilenameUtils.normalize(SEP + "foo" + SEP + ".." + SEP + "bar"));
+        assertEquals(SEP + "bar" + SEP, FilenameUtils.normalize(SEP + "foo" + SEP + ".." + SEP + "bar" + SEP));
+        assertEquals(SEP + "baz", FilenameUtils.normalize(SEP + "foo" + SEP + ".." + SEP + "bar" + SEP + ".." + SEP + "baz"));
+        assertEquals(SEP + SEP + "foo" + SEP + "bar", FilenameUtils.normalize("//foo//./bar"));
+        assertNull(FilenameUtils.normalize(SEP + ".." + SEP));
+        assertNull(FilenameUtils.normalize(".." + SEP + "foo"));
+        assertEquals("foo" + SEP, FilenameUtils.normalize("foo" + SEP + "bar" + SEP + ".."));
+        assertNull(FilenameUtils.normalize("foo" + SEP + ".." + SEP + ".." + SEP + "bar"));
+        assertEquals("bar", FilenameUtils.normalize("foo" + SEP + ".." + SEP + "bar"));
+        assertEquals(SEP + SEP + "server" + SEP + "bar", FilenameUtils.normalize(SEP + SEP + "server" + SEP + "foo" + SEP + ".." + SEP + "bar"));
+        assertNull(FilenameUtils.normalize(SEP + SEP + "server" + SEP + ".." + SEP + "bar"));
+        assertEquals("C:" + SEP + "bar", FilenameUtils.normalize("C:" + SEP + "foo" + SEP + ".." + SEP + "bar"));
+        assertNull(FilenameUtils.normalize("C:" + SEP + ".." + SEP + "bar"));
+        assertEquals("~" + SEP + "bar" + SEP, FilenameUtils.normalize("~" + SEP + "foo" + SEP + ".." + SEP + "bar" + SEP));
+        assertNull(FilenameUtils.normalize("~" + SEP + ".." + SEP + "bar"));
+        
+        assertEquals(SEP + SEP + "foo" + SEP + "bar", FilenameUtils.normalize("//foo//./bar"));
+        assertEquals(SEP + SEP + "foo" + SEP + "bar", FilenameUtils.normalize("\\\\foo\\\\.\\bar"));
+    }
+    
     /**
      */
     @Test

--- a/src/test/java/org/apache/commons/io/FilenameUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FilenameUtilsTest.java
@@ -934,7 +934,7 @@ public class FilenameUtilsTest {
 
     @Test
     public void testNormalizeFromJavaDoc() {
-    	// Examples from javadoc
+        // Examples from javadoc
         assertEquals(SEP + "foo" + SEP, FilenameUtils.normalize("/foo//"));
         assertEquals(SEP + "foo" + SEP, FilenameUtils.normalize(SEP + "foo" + SEP + "." + SEP));
         assertEquals(SEP + "bar", FilenameUtils.normalize(SEP + "foo" + SEP + ".." + SEP + "bar"));
@@ -952,11 +952,11 @@ public class FilenameUtilsTest {
         assertNull(FilenameUtils.normalize("C:" + SEP + ".." + SEP + "bar"));
         assertEquals("~" + SEP + "bar" + SEP, FilenameUtils.normalize("~" + SEP + "foo" + SEP + ".." + SEP + "bar" + SEP));
         assertNull(FilenameUtils.normalize("~" + SEP + ".." + SEP + "bar"));
-        
+
         assertEquals(SEP + SEP + "foo" + SEP + "bar", FilenameUtils.normalize("//foo//./bar"));
         assertEquals(SEP + SEP + "foo" + SEP + "bar", FilenameUtils.normalize("\\\\foo\\\\.\\bar"));
     }
-    
+
     /**
      */
     @Test


### PR DESCRIPTION
Looks like someone fixed the code, but javadoc describes the method wrong.