### PR TITLE
Add blocking read mode to QueueInputStream.

### DIFF
--- a/src/main/java/org/apache/commons/io/input/QueueInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/QueueInputStream.java
@@ -133,7 +133,8 @@ public class QueueInputStream extends InputStream {
                 Thread.currentThread().interrupt();
                 final InterruptedIOException ioException = new InterruptedIOException();
                 ioException.initCause(e);
-                // throw runtime unchecked exception to maintain backward-compatibilty
+                // throw runtime unchecked exception to maintain signature backward-compatibilty of
+                // super class' read method, which does not declare any exception
                 throw new UncheckedIOException(ioException);
             }
         }


### PR DESCRIPTION
Add blocking read mode to QueueInputStream.

To more closely mimic InputStream::read behavior, add blocking read mode to QueueInputStream that will wait until a queue element becomes available.