### PR TITLE
Implemented overloaded readFileToByteArray() method 

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -2582,6 +2582,29 @@ public class FileUtils {
     }
 
     /**
+     * Reads the contents of a file into a byte[]. Start reading from offSet in file index to specific length.
+     *
+     * @param file the file to read, nust not be {@code null}
+     * @param arrayOffset read from an offset in the file
+     * @param arrayLength read file up to certain length based on index
+     * @return byte[]
+     * @throws IOException if an I/O error occurs
+     * @since 2.12.0
+     */
+    public static byte[] readFileToByteArray(final File file, final int arrayOffset, int arrayLength) throws IOException {
+        Objects.requireNonNull(file, "file");
+        try (InputStream inputStream = openInputStream(file)) {
+            final long fileLength = file.length();
+            // file.length() may return 0 for system-dependent entities, treat 0 as unknown length - see IO-453
+            return fileLength > 0 ? IOUtils.toByteArray(inputStream, arrayOffset, arrayLength) : IOUtils.toByteArray(inputStream);
+        }
+
+
+    }
+
+
+
+    /**
      * Reads the contents of a file into a String using the default encoding for the VM.
      * The file is always closed.
      *

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -2664,6 +2664,50 @@ public class IOUtils {
         return data;
     }
 
+
+    /**
+     *
+     * Gets the contents of an {@link InputStream} as a {@code byte[]}.Use this method when you want to specify the
+     * indexes that you want to read from the InputStream.
+     *
+     * @param input
+     * @param offset The offset from the start of the InputStream to start ready - index based
+     * @param length The end of the InputStream to stop reading - index based
+     * @return byte[]
+     * @throws IOException if an I/O error occurs or {@link InputStream} length is smaller than parameter {@code size}.
+     * @throws NullPointerException if offset is greater than length or array index is out of bounds
+     * @throws IllegalArgumentException if {@code size} is less than zero.
+     * @since 2.12.0
+     */
+    public static byte[] toByteArray(final InputStream input, final int offset, final int length) throws IOException {
+
+        if (length < 0) {
+            throw new IllegalArgumentException("Size must be equal or greater than zero: " + length);
+        }
+        if (offset < 0 ) {
+            throw new IllegalArgumentException("Offset must be grater than or equal to zero: " + offset);
+        }
+        if (length < offset) {
+            throw new IllegalArgumentException("Length must be greater than or equal to offset: " + offset);
+        }
+
+        // read inputStream to byte[] -
+        final byte[] data = byteArray(input.available());
+        input.read(data, 0, length + 1);
+
+        // create new byte[] to read from the offset
+        int arraySize = length - offset;
+        byte[] responseData = byteArray(arraySize + 1);
+        int k = 0;
+
+        for (int i = offset; i <= length; i++) {
+            responseData[k] = data[i];
+            k++;
+        }
+
+        return responseData;
+    }
+
     /**
      * Gets contents of an {@link InputStream} as a {@code byte[]}.
      * Use this method instead of {@link #toByteArray(InputStream)}

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -2691,18 +2691,23 @@ public class IOUtils {
             throw new IllegalArgumentException("Length must be greater than or equal to offset: " + offset);
         }
 
-        // read inputStream to byte[] -
+        // read inputStream to byte[]
         final byte[] data = byteArray(input.available());
         input.read(data, 0, length + 1);
 
         // create new byte[] to read from the offset
         int arraySize = length - offset;
-        byte[] responseData = byteArray(arraySize + 1);
-        int k = 0;
+        byte[] responseData;
+        if (arraySize == 0) {
+            responseData = byteArray(0);
+        } else {
+            responseData = byteArray(arraySize + 1);
+            int k = 0;
 
-        for (int i = offset; i <= length; i++) {
-            responseData[k] = data[i];
-            k++;
+            for (int i = offset; i <= length; i++) {
+                responseData[k] = data[i];
+                k++;
+            }
         }
 
         return responseData;

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -2477,8 +2477,7 @@ public class FileUtilsTest extends AbstractTempDirTest {
         Files.write(file.toPath(), arr);
 
         final byte[] data = FileUtils.readFileToByteArray(file, 0, 0);
-        assertEquals(1, data.length);
-        assertEquals(10, data[0]); // return one byte
+        assertEquals(0, data.length);// return one byte
     }
 
 

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -81,6 +81,7 @@ import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.NameFileFilter;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.apache.commons.io.test.TestUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -2444,6 +2445,57 @@ public class FileUtilsTest extends AbstractTempDirTest {
         assertEquals(11, data[0]);
         assertEquals(21, data[1]);
         assertEquals(31, data[2]);
+    }
+
+    @Test
+    public void testReadFileToByteArrayOffsetAndLength() throws Exception {
+        final File file = new File(tempDirFile, "read.txt");
+        final byte[] arr = new byte[] {10, 20, 30, 40 ,50, 60, 70};
+        Files.write(file.toPath(), arr);
+
+        final byte[] data = FileUtils.readFileToByteArray(file, 2, 5);
+        assertEquals(4, data.length);
+        assertEquals(30, data[0]); // arrayOffSet
+        assertEquals(60, data[3]); // arrayLength
+    }
+
+    @Test
+    public void testReadFileToByteArrayOffsetAndLengthSameValue() throws Exception {
+        final File file = new File(tempDirFile, "read.txt");
+        final byte[] arr = new byte[] {10, 20, 30, 40 ,50, 60, 70};
+        Files.write(file.toPath(), arr);
+
+        final byte[] data = FileUtils.readFileToByteArray(file, 2, 2);
+        assertEquals(1, data.length);
+        assertEquals(30, data[0]); // return one byte
+    }
+
+    @Test
+    public void testReadFileToByteArrayOffsetAndLengthZero() throws Exception {
+        final File file = new File(tempDirFile, "read.txt");
+        final byte[] arr = new byte[] {10, 20, 30, 40 ,50, 60, 70};
+        Files.write(file.toPath(), arr);
+
+        final byte[] data = FileUtils.readFileToByteArray(file, 0, 0);
+        assertEquals(1, data.length);
+        assertEquals(10, data[0]); // return one byte
+    }
+
+
+    @Test()
+    public void testReadFileToByteArrayOffsetAndLengthException() {
+
+        final File file = new File(tempDirFile, "read.txt");
+        final byte[] arr = new byte[] {10, 20, 30, 40, 50, 60, 70};
+
+        try {
+            Files.write(file.toPath(), arr);
+            FileUtils.readFileToByteArray(file, 2, 1);
+        } catch (IOException | IllegalArgumentException ex) {
+            assertEquals("Length must be greater than or equal to offset: " + 2, ex.getMessage());
+        }
+
+
     }
 
     @Test


### PR DESCRIPTION
Hello team,

Implemented a new overloaded readFileToByteArray() method that creates byte[] based on offset and length parameters. This is a new feature that was request by the following [jira ticket](https://issues.apache.org/jira/projects/IO/issues/IO-548?filter=allissues). 

- The file will be read starting by the arrayOffset parameter and read up until the arrayLength parameter based on the byte[] index. 