### PR TITLE
[IO-800] Fix back-incompatible change for PathUtils.deleteDirectory(): throw NoSuchFileException instead of IllegalArgumentException

### DIFF
--- a/src/main/java/org/apache/commons/io/file/PathUtils.java
+++ b/src/main/java/org/apache/commons/io/file/PathUtils.java
@@ -1646,6 +1646,7 @@ public final class PathUtils {
      * @param <T> See {@link Files#walkFileTree(Path,FileVisitor)}.
      * @return the given visitor.
      *
+     * @throws NoSuchFileException if the directory does not exist.
      * @throws IOException if an I/O error is thrown by a visitor method.
      * @throws NullPointerException if the directory is {@code null}.
      */

--- a/src/main/java/org/apache/commons/io/file/PathUtils.java
+++ b/src/main/java/org/apache/commons/io/file/PathUtils.java
@@ -1650,7 +1650,6 @@ public final class PathUtils {
      * @throws NullPointerException if the directory is {@code null}.
      */
     public static <T extends FileVisitor<? super Path>> T visitFileTree(final T visitor, final Path directory) throws IOException {
-        requireExists(directory, "directory");
         Files.walkFileTree(directory, visitor);
         return visitor;
     }

--- a/src/test/java/org/apache/commons/io/file/PathUtilsDeleteDirectoryTest.java
+++ b/src/test/java/org/apache/commons/io/file/PathUtilsDeleteDirectoryTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -37,7 +38,7 @@ public class PathUtilsDeleteDirectoryTest extends AbstractTempDirTest {
     public void testDeleteAbsentDirectory() throws IOException {
         final Path absent = tempDirPath.resolve("ThisDirectoryDoesNotExist");
         assertFalse(Files.exists(absent));
-        final Class<IllegalArgumentException> expectedType = IllegalArgumentException.class;
+        final Class<NoSuchFileException> expectedType = NoSuchFileException.class;
         assertThrows(expectedType, () -> PathUtils.deleteDirectory(absent));
         assertThrows(expectedType, () -> PathUtils.deleteDirectory(absent, StandardDeleteOption.OVERRIDE_READ_ONLY));
         assertThrows(expectedType, () -> PathUtils.deleteDirectory(absent, PathUtils.EMPTY_DELETE_OPTION_ARRAY));
@@ -95,16 +96,6 @@ public class PathUtilsDeleteDirectoryTest extends AbstractTempDirTest {
     public void testDeleteDirectory2FileSize2() throws IOException {
         PathUtils.copyDirectory(Paths.get("src/test/resources/org/apache/commons/io/dirs-2-file-size-2"), tempDirPath);
         assertCounts(3, 2, 2, PathUtils.deleteDirectory(tempDirPath));
-        // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
-    }
-
-    /**
-     * Tests an empty folder.
-     */
-    @Test
-    public void testDeleteEmptyDirectory() throws IOException {
-        assertCounts(1, 0, 0, PathUtils.deleteDirectory(tempDirPath));
         // This will throw if not empty.
         Files.deleteIfExists(tempDirPath);
     }

--- a/src/test/java/org/apache/commons/io/file/PathUtilsDeleteDirectoryTest.java
+++ b/src/test/java/org/apache/commons/io/file/PathUtilsDeleteDirectoryTest.java
@@ -99,4 +99,14 @@ public class PathUtilsDeleteDirectoryTest extends AbstractTempDirTest {
         // This will throw if not empty.
         Files.deleteIfExists(tempDirPath);
     }
+
+    /**
+     * Tests an empty folder.
+     */
+    @Test
+    public void testDeleteEmptyDirectory() throws IOException {
+        assertCounts(1, 0, 0, PathUtils.deleteDirectory(tempDirPath));
+        // This will throw if not empty.
+        Files.deleteIfExists(tempDirPath);
+    }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IO-800

On non-existing path. In earlier version it would throw `NoSuchFileException` but in 2.12.0 it changed behavior. This reverts one line change in https://github.com/apache/commons-io/commit/dcb09db922e1edbd6dc6cb1531b827451d58aa83