### PR TITLE
`FileUtils.deleteDirectory` could throw `UncheckedIOException`

### DIFF
--- a/src/main/java/org/apache/commons/io/file/DirectoryStreamFilter.java
+++ b/src/main/java/org/apache/commons/io/file/DirectoryStreamFilter.java
@@ -18,6 +18,7 @@
 package org.apache.commons.io.file;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Path;
@@ -48,7 +49,11 @@ public class DirectoryStreamFilter implements DirectoryStream.Filter<Path> {
 
     @Override
     public boolean accept(final Path path) throws IOException {
-        return pathFilter.accept(path, PathUtils.readBasicFileAttributes(path, PathUtils.EMPTY_LINK_OPTION_ARRAY)) == FileVisitResult.CONTINUE;
+        try {
+            return pathFilter.accept(path, PathUtils.readBasicFileAttributes(path, PathUtils.EMPTY_LINK_OPTION_ARRAY)) == FileVisitResult.CONTINUE;
+        } catch (UncheckedIOException x) {
+            throw x.getCause();
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/io/file/PathUtilsDeleteFileTest.java
+++ b/src/test/java/org/apache/commons/io/file/PathUtilsDeleteFileTest.java
@@ -107,6 +107,14 @@ public class PathUtilsDeleteFileTest {
         Files.deleteIfExists(tempDir);
     }
 
+    /**
+     * Tests a file that does not exist in force-deletion mode.
+     */
+    @Test
+    public void testForceDeleteFileDoesNotExist() throws IOException {
+        Assertions.assertThrows(IOException.class, () -> PathUtils.deleteFile(tempDir.resolve("nonexistent").resolve("file-does-not-exist.bin"), StandardDeleteOption.OVERRIDE_READ_ONLY));
+    }
+
     private void testDeleteFileEmpty(final PathCounters pathCounts) {
         assertCounts(0, 0, 0, pathCounts);
     }

--- a/src/test/java/org/apache/commons/io/file/PathUtilsDeleteFileTest.java
+++ b/src/test/java/org/apache/commons/io/file/PathUtilsDeleteFileTest.java
@@ -112,7 +112,8 @@ public class PathUtilsDeleteFileTest {
      */
     @Test
     public void testForceDeleteFileDoesNotExist() throws IOException {
-        Assertions.assertThrows(IOException.class, () -> PathUtils.deleteFile(tempDir.resolve("nonexistent").resolve("file-does-not-exist.bin"), StandardDeleteOption.OVERRIDE_READ_ONLY));
+        Assertions.assertThrows(IOException.class, () ->
+            PathUtils.deleteFile(tempDir.resolve("nonexistent").resolve("file-does-not-exist.bin"), StandardDeleteOption.OVERRIDE_READ_ONLY));
     }
 
     private void testDeleteFileEmpty(final PathCounters pathCounts) {


### PR DESCRIPTION
At some point between 2.11.0 and 2.13.0, I think as of 323d376b4a934a5a6ebdc552dc923db9e267e569, there seems to have been an incompatible change due to use of `UncheckedIOException`. I found the following from a piece of code calling `FileUtils.deleteDirectory` and catching and logging `IOException`, which failed to catch the runtime exception:

```
java.nio.file.NoSuchFileException: /path/to/file
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileAttributeViews$Posix.readAttributes(UnixFileAttributeViews.java:234)
	at java.base/sun.nio.fs.UnixFileAttributeViews$Posix.readAttributes(UnixFileAttributeViews.java:147)
	at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:149)
	at java.base/sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
	at java.base/java.nio.file.Files.readAttributes(Files.java:1764)
	at org.apache.commons.io.function.Uncheck.apply(Uncheck.java:162)
Caused: java.io.UncheckedIOException
	at org.apache.commons.io.function.Uncheck.wrap(Uncheck.java:242)
	at org.apache.commons.io.function.Uncheck.apply(Uncheck.java:164)
	at org.apache.commons.io.file.PathUtils.readAttributes(PathUtils.java:1259)
	at org.apache.commons.io.file.PathUtils.readPosixFileAttributes(PathUtils.java:1349)
	at org.apache.commons.io.file.PathUtils.deleteFile(PathUtils.java:582)
	at org.apache.commons.io.file.PathUtils.delete(PathUtils.java:476)
	at org.apache.commons.io.FileUtils.forceDelete(FileUtils.java:1337)
	at org.apache.commons.io.function.IOStream.lambda$forAll$11(IOStream.java:340)
	at java.base/java.util.Spliterators$ArraySpliterator.forEachRemaining(Spliterators.java:948)
	at java.base/java.util.stream.ReferencePipeline$Head.forEach(ReferencePipeline.java:658)
	at org.apache.commons.io.function.IOStream.forAll(IOStream.java:338)
	at org.apache.commons.io.function.IOStreams.forAll(IOStreams.java:42)
	at org.apache.commons.io.function.IOStreams.forAll(IOStreams.java:36)
	at org.apache.commons.io.function.IOConsumer.forAll(IOConsumer.java:80)
	at org.apache.commons.io.FileUtils.cleanDirectory(FileUtils.java:333)
	at org.apache.commons.io.FileUtils.deleteDirectory(FileUtils.java:1192)
```

Never mind the exact reason for the failure of `Files.readAttributes`; something to do with NFS I think. The point is that `deleteDirectory` should either succeed, or throw some subtype of `IOException`. Reproduced similar behavior in the unit test prior to `src/main/` fix:

```
org.opentest4j.AssertionFailedError: Unexpected exception type thrown, expected: <java.io.IOException> but was: <java.io.UncheckedIOException>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:67)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:35)
	at org.junit.jupiter.api.Assertions.assertThrows(Assertions.java:3111)
	at org.apache.commons.io.file.PathUtilsDeleteFileTest.testForceDeleteFileDoesNotExist(PathUtilsDeleteFileTest.java:115)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1541)
Caused by: java.io.UncheckedIOException: java.nio.file.NoSuchFileException: /tmp/org.apache.commons.io.file.PathUtilsDeleteFileTest15920347910072703873/nonexistent
	at org.apache.commons.io.function.Uncheck.wrap(Uncheck.java:339)
	at org.apache.commons.io.function.Uncheck.apply(Uncheck.java:165)
	at org.apache.commons.io.file.PathUtils.readAttributes(PathUtils.java:1259)
	at org.apache.commons.io.file.PathUtils.readPosixFileAttributes(PathUtils.java:1349)
	at org.apache.commons.io.file.PathUtils.deleteFile(PathUtils.java:582)
	at org.apache.commons.io.file.PathUtils.deleteFile(PathUtils.java:544)
	at org.apache.commons.io.file.PathUtilsDeleteFileTest.lambda$testForceDeleteFileDoesNotExist$0(PathUtilsDeleteFileTest.java:115)
	at org.junit.jupiter.api.AssertThrows.assertThrows(AssertThrows.java:53)
	... 6 more
Caused by: java.nio.file.NoSuchFileException: /tmp/org.apache.commons.io.file.PathUtilsDeleteFileTest15920347910072703873/nonexistent
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileAttributeViews$Posix.readAttributes(UnixFileAttributeViews.java:234)
	at java.base/sun.nio.fs.UnixFileAttributeViews$Posix.readAttributes(UnixFileAttributeViews.java:147)
	at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:149)
	at java.base/sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
	at java.base/java.nio.file.Files.readAttributes(Files.java:1764)
	at org.apache.commons.io.function.Uncheck.apply(Uncheck.java:163)
	... 12 more
```

I attempted to track all direct or indirect callers of `PathUtils.readAttributes` and make sure they either documented `UncheckedIOException` or translated it to `IOException`. I did not attempt to do the same for the many other uses of `Uncheck`.
