### PR TITLE
[IO-810] Wrong Javadoc regarding FileNotFoundException in FileUtils

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -2570,9 +2570,8 @@ public class FileUtils {
      * @param file the file to read, must not be {@code null}
      * @return the file contents, never {@code null}
      * @throws NullPointerException if file is {@code null}.
-     * @throws FileNotFoundException if the file does not exist, is a directory rather than a regular file, or for some
-     *         other reason cannot be opened for reading.
-     * @throws IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs, including when the file does not exist, is a directory rather than a
+     *         regular file, or for some other reason why the file cannot be opened for reading.
      * @since 1.1
      */
     public static byte[] readFileToByteArray(final File file) throws IOException {
@@ -2587,9 +2586,8 @@ public class FileUtils {
      * @param file the file to read, must not be {@code null}
      * @return the file contents, never {@code null}
      * @throws NullPointerException if file is {@code null}.
-     * @throws FileNotFoundException if the file does not exist, is a directory rather than a regular file, or for some
-     *         other reason cannot be opened for reading.
-     * @throws IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs, including when the file does not exist, is a directory rather than a
+     *         regular file, or for some other reason why the file cannot be opened for reading.
      * @since 1.3.1
      * @deprecated 2.5 use {@link #readFileToString(File, Charset)} instead (and specify the appropriate encoding)
      */
@@ -2606,9 +2604,8 @@ public class FileUtils {
      * @param charsetName the name of the requested charset, {@code null} means platform default
      * @return the file contents, never {@code null}
      * @throws NullPointerException if file is {@code null}.
-     * @throws FileNotFoundException if the file does not exist, is a directory rather than a regular file, or for some
-     *         other reason cannot be opened for reading.
-     * @throws IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs, including when the file does not exist, is a directory rather than a
+     *         regular file, or for some other reason why the file cannot be opened for reading.
      * @since 2.3
      */
     public static String readFileToString(final File file, final Charset charsetName) throws IOException {
@@ -2622,9 +2619,8 @@ public class FileUtils {
      * @param charsetName the name of the requested charset, {@code null} means platform default
      * @return the file contents, never {@code null}
      * @throws NullPointerException if file is {@code null}.
-     * @throws FileNotFoundException if the file does not exist, is a directory rather than a regular file, or for some
-     *         other reason cannot be opened for reading.
-     * @throws IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs, including when the file does not exist, is a directory rather than a
+     *         regular file, or for some other reason why the file cannot be opened for reading.
      * @throws java.nio.charset.UnsupportedCharsetException thrown instead of {@link java.io
      * .UnsupportedEncodingException} in version 2.2 if the named charset is unavailable.
      * @since 2.3
@@ -2640,9 +2636,8 @@ public class FileUtils {
      * @param file the file to read, must not be {@code null}
      * @return the list of Strings representing each line in the file, never {@code null}
      * @throws NullPointerException if file is {@code null}.
-     * @throws FileNotFoundException if the file does not exist, is a directory rather than a regular file, or for some
-     *         other reason cannot be opened for reading.
-     * @throws IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs, including when the file does not exist, is a directory rather than a
+     *         regular file, or for some other reason why the file cannot be opened for reading.
      * @since 1.3
      * @deprecated 2.5 use {@link #readLines(File, Charset)} instead (and specify the appropriate encoding)
      */
@@ -2659,9 +2654,8 @@ public class FileUtils {
      * @param charset the charset to use, {@code null} means platform default
      * @return the list of Strings representing each line in the file, never {@code null}
      * @throws NullPointerException if file is {@code null}.
-     * @throws FileNotFoundException if the file does not exist, is a directory rather than a regular file, or for some
-     *         other reason cannot be opened for reading.
-     * @throws IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs, including when the file does not exist, is a directory rather than a
+     *         regular file, or for some other reason why the file cannot be opened for reading.
      * @since 2.3
      */
     public static List<String> readLines(final File file, final Charset charset) throws IOException {
@@ -2675,9 +2669,8 @@ public class FileUtils {
      * @param charsetName the name of the requested charset, {@code null} means platform default
      * @return the list of Strings representing each line in the file, never {@code null}
      * @throws NullPointerException if file is {@code null}.
-     * @throws FileNotFoundException if the file does not exist, is a directory rather than a regular file, or for some
-     *         other reason cannot be opened for reading.
-     * @throws IOException if an I/O error occurs.
+     * @throws IOException if an I/O error occurs, including when the file does not exist, is a directory rather than a
+     *         regular file, or for some other reason why the file cannot be opened for reading.
      * @throws java.nio.charset.UnsupportedCharsetException thrown instead of {@link java.io
      * .UnsupportedEncodingException} in version 2.2 if the named charset is unavailable.
      * @since 1.1

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -40,6 +40,7 @@ import java.math.BigInteger;
 import java.net.URL;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -47,6 +48,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.AclFileAttributeView;
 import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -86,6 +88,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -2445,6 +2448,23 @@ public class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
+    public void testReadFileToByteArray_Errors() {
+        assertThrows(NullPointerException.class, () -> FileUtils.readFileToByteArray(null));
+        assertThrows(IOException.class, () -> FileUtils.readFileToByteArray(new File("non-exsistent")));
+        assertThrows(IOException.class, () -> FileUtils.readFileToByteArray(tempDirFile));
+    }
+
+    @Test
+    @EnabledIf("isPosixFilePermissionsSupported")
+    public void testReadFileToByteArray_IOExceptionOnPosixFileSystem() throws Exception {
+        final File file = TestUtils.newFile(tempDirFile, "cant-read.txt");
+        TestUtils.createFile(file, 100);
+        Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("---------"));
+
+        assertThrows(IOException.class, () -> FileUtils.readFileToByteArray(file));
+    }
+
+    @Test
     public void testReadFileToStringWithDefaultEncoding() throws Exception {
         final File file = new File(tempDirFile, "read.obj");
         final String fixture = "Hello /u1234";
@@ -2464,6 +2484,24 @@ public class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
+    public void testReadFileToString_Errors() {
+        assertThrows(NullPointerException.class, () -> FileUtils.readFileToString(null));
+        assertThrows(IOException.class, () -> FileUtils.readFileToString(new File("non-exsistent")));
+        assertThrows(IOException.class, () -> FileUtils.readFileToString(tempDirFile));
+        assertThrows(UnsupportedCharsetException.class, () -> FileUtils.readFileToString(tempDirFile, "unsupported-charset"));
+    }
+
+    @Test
+    @EnabledIf("isPosixFilePermissionsSupported")
+    public void testReadFileToString_IOExceptionOnPosixFileSystem() throws Exception {
+        final File file = TestUtils.newFile(tempDirFile, "cant-read.txt");
+        TestUtils.createFile(file, 100);
+        Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("---------"));
+
+        assertThrows(IOException.class, () -> FileUtils.readFileToString(file));
+    }
+
+    @Test
     public void testReadLines() throws Exception {
         final File file = TestUtils.newFile(tempDirFile, "lines.txt");
         try {
@@ -2475,6 +2513,24 @@ public class FileUtilsTest extends AbstractTempDirTest {
         } finally {
             TestUtils.deleteFile(file);
         }
+    }
+
+    @Test
+    public void testReadLines_Errors() {
+        assertThrows(NullPointerException.class, () -> FileUtils.readLines(null));
+        assertThrows(IOException.class, () -> FileUtils.readLines(new File("non-exsistent")));
+        assertThrows(IOException.class, () -> FileUtils.readLines(tempDirFile));
+        assertThrows(UnsupportedCharsetException.class, () -> FileUtils.readLines(tempDirFile, "unsupported-charset"));
+    }
+
+    @Test
+    @EnabledIf("isPosixFilePermissionsSupported")
+    public void testReadLines_IOExceptionOnPosixFileSystem() throws Exception {
+        final File file = TestUtils.newFile(tempDirFile, "cant-read.txt");
+        TestUtils.createFile(file, 100);
+        Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("---------"));
+
+        assertThrows(IOException.class, () -> FileUtils.readLines(file));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/file/AbstractTempDirTest.java
+++ b/src/test/java/org/apache/commons/io/file/AbstractTempDirTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.io.file;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -52,4 +53,8 @@ public abstract class AbstractTempDirTest {
         tempDirFile = tempDirPath.toFile();
     }
 
+
+    protected final boolean isPosixFilePermissionsSupported() {
+        return FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+    }
 }


### PR DESCRIPTION
Update Javadoc of `FileUtils.readFileToByteArray(...)`, `FileUtils.readFileToString(...)` and `FileUtils.readLines(...)` regarding `FileNotFoundException`.

Since commons-io [2.12](https://github.com/apache/commons-io/commit/dcb09db922e1edbd6dc6cb1531b827451d58aa83#diff-0bd8160a11e12ea1f96476a00e78d0a95b965d07c7fe126e1af498c08511dd70), the methods throw a `NoSuchFileException` rather than a `FileNotFoundException`.