### PR TITLE
[IO-414] don't write a BOM on every (or any) line

### DIFF
--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -3828,7 +3828,7 @@ public class IOUtils {
      * Writes the {@link #toString()} value of each item in a collection to
      * an {@link OutputStream} line by line, using the specified character
      * encoding and the specified line ending.
-     * 
+     *
      * UTF-16 is written big-endian with no byte order mark.
      * For little endian, use UTF-16LE. For a BOM, write it to the stream
      * before calling this method.

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -3828,12 +3828,16 @@ public class IOUtils {
      * Writes the {@link #toString()} value of each item in a collection to
      * an {@link OutputStream} line by line, using the specified character
      * encoding and the specified line ending.
+     * 
+     * UTF-16 is written big-endian with no byte order mark.
+     * For little endian, use UTF-16LE. For a BOM, write it to the stream
+     * before calling this method.
      *
      * @param lines the lines to write, null entries produce blank lines
      * @param lineEnding the line separator to use, null is system default
      * @param output the {@link OutputStream} to write to, not null, not closed
      * @param charset the charset to use, null means platform default
-     * @throws NullPointerException if the output is null
+     * @throws NullPointerException if output is null
      * @throws IOException          if an I/O error occurs
      * @since 2.3
      */

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -3848,7 +3848,7 @@ public class IOUtils {
         Charset cs = Charsets.toCharset(charset);
         // don't write a BOM
         if (cs == StandardCharsets.UTF_16) {
-        	cs = StandardCharsets.UTF_16BE;
+            cs = StandardCharsets.UTF_16BE;
         }
         final byte[] eolBytes = lineEnding.getBytes(cs);
         for (final Object line : lines) {

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -45,6 +45,7 @@ import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.Selector;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.Collection;
@@ -3844,7 +3845,11 @@ public class IOUtils {
         if (lineEnding == null) {
             lineEnding = System.lineSeparator();
         }
-        final Charset cs = Charsets.toCharset(charset);
+        Charset cs = Charsets.toCharset(charset);
+        // don't write a BOM
+        if (cs == StandardCharsets.UTF_16) {
+        	cs = StandardCharsets.UTF_16BE;
+        }
         final byte[] eolBytes = lineEnding.getBytes(cs);
         for (final Object line : lines) {
             if (line != null) {

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1763,10 +1763,10 @@ public class IOUtilsTest {
 
     @Test
     public void testWriteLines() throws IOException {
-        String[] data = {"The", "quick"};
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final String[] data = {"The", "quick"};
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
         IOUtils.writeLines(Arrays.asList(data), "\n", out, "UTF-16");
-        String result = new String(out.toByteArray(), StandardCharsets.UTF_16);
+        final String result = new String(out.toByteArray(), StandardCharsets.UTF_16);
         assertEquals("The\nquick\n", result);
     }  
     

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1768,7 +1768,6 @@ public class IOUtilsTest {
         IOUtils.writeLines(Arrays.asList(data), "\n", out, "UTF-16");
         String result = new String(out.toByteArray(), StandardCharsets.UTF_16);
         assertEquals("The\nquick\n", result);
-    }
-    
+    }  
     
 }

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1761,4 +1761,14 @@ public class IOUtilsTest {
         }
     }
 
+    @Test
+    public void testWriteLines() throws IOException {
+        String[] data = {"The", "quick"};
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IOUtils.writeLines(Arrays.asList(data), "\n", out, "UTF-16");
+        String result = new String(out.toByteArray(), StandardCharsets.UTF_16);
+        assertEquals("The\nquick\n", result);
+    }
+    
+    
 }

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -1768,6 +1768,6 @@ public class IOUtilsTest {
         IOUtils.writeLines(Arrays.asList(data), "\n", out, "UTF-16");
         final String result = new String(out.toByteArray(), StandardCharsets.UTF_16);
         assertEquals("The\nquick\n", result);
-    }  
-    
+    }
+
 }


### PR DESCRIPTION
Per JDK docs, "When decoding, the UTF-16 charset interprets the byte-order mark at the beginning of the input stream to indicate the byte-order of the stream but defaults to big-endian if there is no byte-order mark; when encoding, it uses big-endian byte order and writes a big-endian byte-order mark."