### PR TITLE
adds new method to query the host OS for the temp directory path

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1444,7 +1444,7 @@ public class FileUtils {
 
     /**
      * Returns a {@link File} representing the system temporary directory.
-     *
+     * 
      * @return the system temporary directory.
      * @since 2.0
      */
@@ -1453,8 +1453,38 @@ public class FileUtils {
     }
 
     /**
-     * Returns the path to the system temporary directory.
+     * Returns the path to the system temporary directory with the option to include or disinclude the trailing 
+     * file separator. 
      *
+     * @param includeTrailingSeparator switch indicating whether or not you want the returned path to include a 
+     * trailing file separator. 
+     * @return the path to the system temporary directory with or without the trailing file separator as per 
+     * caller supplied argument.
+     * @since 2.14.1
+     */
+    public static String getTempDirectoryPathConsistent(boolean includeTrailingSeparator) {
+        String tempDir = System.getProperty("java.io.tmpdir");
+        String tempDirLastChar = tempDir.substring(tempDir.length() - 1);
+        String systemFileSeparator = System.getProperty("file.separator");
+        if (includeTrailingSeparator) {
+            tempDir = tempDirLastChar.equals(systemFileSeparator) 
+                            ? tempDir 
+                            : tempDir + systemFileSeparator;
+        } else {
+            tempDir = tempDirLastChar.equals(systemFileSeparator) 
+                            ? tempDir.substring(0, tempDir.length() - 1) 
+                            : tempDir;
+        }
+
+        return tempDir;
+    }
+
+    /**
+     * Returns the path to the system temporary directory.
+     * 
+     * @apiNote this method relies on Java system property 'java.io.tmpdir' which may or may not return a path with 
+     * a trailing file separator, depending on the OS Java is running in. If you need the temp directory reported in a
+     * consistent manner across all OS environments, use {@link #getTempDirectoryPathConsistent(boolean)}.
      * @return the path to the system temporary directory.
      * @since 2.0
      */

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1453,7 +1453,7 @@ public class FileUtils {
     }
 
     /**
-     * Returns the path to the system temporary directory with the option to include or disinclude the trailing 
+     * Returns the path to the system temporary directory with the option to include or exclude the trailing 
      * file separator. 
      *
      * @param includeTrailingSeparator switch indicating whether or not you want the returned path to include a 

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1444,7 +1444,7 @@ public class FileUtils {
 
     /**
      * Returns a {@link File} representing the system temporary directory.
-     * 
+     *
      * @return the system temporary directory.
      * @since 2.0
      */
@@ -1483,7 +1483,7 @@ public class FileUtils {
      * Returns the path to the system temporary directory.
      * 
      * @apiNote this method relies on Java system property 'java.io.tmpdir' which may or may not return a path with 
-     * a trailing file separator, depending on the OS Java is running in. If you need the temp directory reported in a
+     * a trailing file separator, depending on the OS environment. If you need the temp directory reported in a
      * consistent manner across all OS environments, use {@link #getTempDirectoryPathConsistent(boolean)}.
      * @return the path to the system temporary directory.
      * @since 2.0

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -1587,7 +1587,7 @@ public class FileUtilsTest extends AbstractTempDirTest {
     public void testGetTempDirectory() {
         final File tempDirectory = new File(FileUtils.getTempDirectoryPath());
         assertEquals(tempDirectory, FileUtils.getTempDirectory());
-    }  
+    } 
 
     @Test
     public void testGetTempDirectoryPath() {

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -1598,18 +1598,38 @@ public class FileUtilsTest extends AbstractTempDirTest {
     public void testGetTempDirectoryPathConsistentNoTrailingSeparator() {
         String tempDirectoryPath = FileUtils.getTempDirectoryPathConsistent(false);
         assertTrue(tempDirectoryPath.startsWith(System.getProperty("java.io.tmpdir")));
+
         String systemFileSeparator = System.getProperty("file.separator");
         String lastCharOfTempDirectoryPath = tempDirectoryPath.substring(tempDirectoryPath.length() - 1);
         assertNotEquals(lastCharOfTempDirectoryPath, systemFileSeparator);
+
+        String lastCharOfJavaReportedTempDirectoryPath = 
+            System.getProperty("java.io.tmpdir").substring(tempDirectoryPath.length() - 1);
+
+        if (lastCharOfJavaReportedTempDirectoryPath.equals(systemFileSeparator)) {
+            assertEquals(System.getProperty("java.io.tmpdir").length() - 1, tempDirectoryPath.length());
+        } else {
+            assertEquals(System.getProperty("java.io.tmpdir").length(), tempDirectoryPath.length());
+        }
     }
 
     @Test
     public void testGetTempDirectoryPathConsistentWithTrailingSeparator() {
         String tempDirectoryPath = FileUtils.getTempDirectoryPathConsistent(true);
         assertTrue(tempDirectoryPath.startsWith(System.getProperty("java.io.tmpdir")));
+
         String systemFileSeparator = System.getProperty("file.separator");
         String lastCharOfTempDirectoryPath = tempDirectoryPath.substring( tempDirectoryPath.length() - 1);
         assertEquals(lastCharOfTempDirectoryPath, systemFileSeparator);
+
+        String lastCharOfJavaReportedTempDirectoryPath = 
+            System.getProperty("java.io.tmpdir").substring(tempDirectoryPath.length() - 1);
+
+        if (lastCharOfJavaReportedTempDirectoryPath.equals(systemFileSeparator)) {
+            assertEquals(System.getProperty("java.io.tmpdir").length(), tempDirectoryPath.length());
+        } else {
+            assertEquals(System.getProperty("java.io.tmpdir").length(), tempDirectoryPath.length() - 1);
+        }
     }  
 
     @Test

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -1597,6 +1597,7 @@ public class FileUtilsTest extends AbstractTempDirTest {
     @Test
     public void testGetTempDirectoryPathConsistentNoTrailingSeparator() {
         String tempDirectoryPath = FileUtils.getTempDirectoryPathConsistent(false);
+        assertTrue(tempDirectoryPath.startsWith(System.getProperty("java.io.tmpdir")));
         String systemFileSeparator = System.getProperty("file.separator");
         String lastCharOfTempDirectoryPath = tempDirectoryPath.substring(tempDirectoryPath.length() - 1);
         assertNotEquals(lastCharOfTempDirectoryPath, systemFileSeparator);
@@ -1605,6 +1606,7 @@ public class FileUtilsTest extends AbstractTempDirTest {
     @Test
     public void testGetTempDirectoryPathConsistentWithTrailingSeparator() {
         String tempDirectoryPath = FileUtils.getTempDirectoryPathConsistent(true);
+        assertTrue(tempDirectoryPath.startsWith(System.getProperty("java.io.tmpdir")));
         String systemFileSeparator = System.getProperty("file.separator");
         String lastCharOfTempDirectoryPath = tempDirectoryPath.substring( tempDirectoryPath.length() - 1);
         assertEquals(lastCharOfTempDirectoryPath, systemFileSeparator);

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -1587,12 +1587,28 @@ public class FileUtilsTest extends AbstractTempDirTest {
     public void testGetTempDirectory() {
         final File tempDirectory = new File(FileUtils.getTempDirectoryPath());
         assertEquals(tempDirectory, FileUtils.getTempDirectory());
-    }
+    }  
 
     @Test
     public void testGetTempDirectoryPath() {
         assertEquals(System.getProperty("java.io.tmpdir"), FileUtils.getTempDirectoryPath());
     }
+
+    @Test
+    public void testGetTempDirectoryPathConsistentNoTrailingSeparator() {
+        String tempDirectoryPath = FileUtils.getTempDirectoryPathConsistent(false);
+        String systemFileSeparator = System.getProperty("file.separator");
+        String lastCharOfTempDirectoryPath = tempDirectoryPath.substring(tempDirectoryPath.length() - 1);
+        assertNotEquals(lastCharOfTempDirectoryPath, systemFileSeparator);
+    }
+
+    @Test
+    public void testGetTempDirectoryPathConsistentWithTrailingSeparator() {
+        String tempDirectoryPath = FileUtils.getTempDirectoryPathConsistent(true);
+        String systemFileSeparator = System.getProperty("file.separator");
+        String lastCharOfTempDirectoryPath = tempDirectoryPath.substring( tempDirectoryPath.length() - 1);
+        assertEquals(lastCharOfTempDirectoryPath, systemFileSeparator);
+    }  
 
     @Test
     public void testGetUserDirectory() {

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -1587,7 +1587,7 @@ public class FileUtilsTest extends AbstractTempDirTest {
     public void testGetTempDirectory() {
         final File tempDirectory = new File(FileUtils.getTempDirectoryPath());
         assertEquals(tempDirectory, FileUtils.getTempDirectory());
-    } 
+    }
 
     @Test
     public void testGetTempDirectoryPath() {


### PR DESCRIPTION
adds new method `FileUtils.getTempDirectoryPathConsistent(boolean)` to give developers the ability to ensure the system temp path is reported in a consistent manner across all OS's. 

At issue is the fact that the underlying call to `System.getProperty("java.io.tmpdir")` does not return results in a consistent format. Depending on the host OS, the system file separator may or may not be included at the tail of the result. If the developer is unaware of this behavior their code may break in unexpected ways when ported to an OS that behaves differently than the one they wrote the code on. See these bug reports for details and background: 

https://bugs.java.com/bugdatabase/view_bug?bug_id=4391434
https://bugs.java.com/bugdatabase/view_bug?bug_id=JDK-8318067

PR does not change behavior of existing `FileUtils.getTempDirectoryPath()` but does add a docstring comment alerting developers of the issue and directing them to `FileUtils.getTempDirectoryPathConsistent(boolean)` if need to ensure the system temp directory is reported in a consistent manner across all host OS's. 

New method is tested by way of `FileUtilsTest.testGetTempDirectoryPathConsistentNoTrailingSeparator()` and `FileUtilesTest.testGetTempDirectoryPathConsistentWithTrailingSeparator()`. 

