### PR TITLE
[IO-822] add a file size conversion tool.

### DIFF
--- a/src/main/java/org/apache/commons/io/FileSizeUnit.java
+++ b/src/main/java/org/apache/commons/io/FileSizeUnit.java
@@ -1,0 +1,234 @@
+package org.apache.commons.io;
+
+import java.text.DecimalFormat;
+
+/**
+ * File size conversion tool, supporting mutual conversion of TB, GB, MB, KB, Byte, etc.,
+ * as well as converting the size of numeric types into human-readable strings.
+ * @author hellozrh
+ * @date 2023-11-19
+ */
+public enum FileSizeUnit {
+    /**Byte*/
+    BYTE {
+        @Override
+        public long toByte(long duration) {
+            return duration;
+        }
+
+        @Override
+        public long toKb(long duration) {
+            return duration/(CKB/ CB);
+        }
+
+        @Override
+        public long toMb(long duration) {
+            return duration/(CMB/ CB);
+        }
+
+        @Override
+        public long toGb(long duration) {
+            return duration/(CGB/ CB);
+        }
+
+        @Override
+        public long toTb(long duration) {
+            return duration/(CTB/ CB);
+        }
+    },
+
+    /**KB*/
+    KB {
+        @Override
+        public long toByte(long duration) {
+            return x(duration, CKB/ CB, MAX/(CKB/ CB));
+        }
+
+        @Override
+        public long toKb(long duration) {
+            return duration;
+        }
+
+        @Override
+        public long toMb(long duration) {
+            return duration/(CMB/CKB);
+        }
+
+        @Override
+        public long toGb(long duration) {
+            return duration/(CGB/CKB);
+        }
+
+        @Override
+        public long toTb(long duration) {
+            return duration/(CTB/CKB);
+        }
+    },
+
+    /**MB*/
+    MB {
+        @Override
+        public long toByte(long duration) {
+            return x(duration, CMB/ CB, MAX/(CMB/ CB));
+        }
+
+        @Override
+        public long toKb(long duration) {
+            return x(duration, CMB/CKB, MAX/(CMB/CKB));
+        }
+
+        @Override
+        public long toMb(long duration) {
+            return duration;
+        }
+
+        @Override
+        public long toGb(long duration) {
+            return duration/(CGB/CMB);
+        }
+
+        @Override
+        public long toTb(long duration) {
+            return duration/(CTB/CMB);
+        }
+    },
+
+    /**GB*/
+    GB {
+        @Override
+        public long toByte(long duration) {
+            return x(duration, CGB/ CB, MAX/(CGB/ CB));
+        }
+
+        @Override
+        public long toKb(long duration) {
+            return x(duration, CGB/CKB, MAX/(CGB/CKB));
+        }
+
+        @Override
+        public long toMb(long duration) {
+            return x(duration, CGB/CMB, MAX/(CGB/CMB));
+        }
+
+        @Override
+        public long toGb(long duration) {
+            return duration;
+        }
+
+        @Override
+        public long toTb(long duration) {
+            return duration/(CTB/CGB);
+        }
+    },
+
+    /**TB*/
+    TB {
+        @Override
+        public long toByte(long duration) {
+            return x(duration, CTB/ CB, MAX/(CTB/ CB));
+        }
+
+        @Override
+        public long toKb(long duration) {
+            return x(duration, CTB/CKB, MAX/(CTB/CKB));
+        }
+
+        @Override
+        public long toMb(long duration) {
+            return x(duration, CTB/CMB, MAX/(CTB/CMB));
+        }
+
+        @Override
+        public long toGb(long duration) {
+            return x(duration, CTB/CGB, MAX/(CTB/CTB));
+        }
+
+        @Override
+        public long toTb(long duration) {
+            return duration;
+        }
+    }
+    ;
+
+    private static final long CB = 1L;
+    private static final long CKB = 1024L;
+    private static final long CMB = (CKB * CKB);
+    private static final long CGB = (CKB * CMB);
+    private static final long CTB = (CKB * CGB);
+
+    private static final long MAX = Long.MAX_VALUE;
+
+    /**
+     * Scale d by m, checking for overflow.
+     * This has a short name to make above code more readable.
+     */
+    private static long x(long d, long m, long over) {
+        if (d >  over) { return Long.MAX_VALUE; }
+        if (d < -over) { return Long.MIN_VALUE; }
+        return d * m;
+    }
+
+
+    public long toByte(long duration) { throw new AbstractMethodError(); }
+    public long toKb(long duration) { throw new AbstractMethodError(); }
+    public long toMb(long duration) { throw new AbstractMethodError(); }
+    public long toGb(long duration) { throw new AbstractMethodError(); }
+    public long toTb(long duration) { throw new AbstractMethodError(); }
+
+    /**
+     * Convert file size to a human-readable string with units, such as 3.1GB, 300.0MB, etc
+     * @param length the length of the file, int bytes, see as {@link java.io.File#length()}
+     * @return a human-readable string with units
+     */
+    public static String readableSize(long length) {
+        return readableSize(length, FileSizeUnit.BYTE);
+    }
+
+    /**
+     * Convert file size to a human-readable string with units, such as 3.1GB, 300.0MB, etc
+     * @param size the length of the file, int bytes, see as {@link java.io.File#length()}
+     * @param unit file length unit
+     * @return a human-readable string with units
+     */
+    public static String readableSize(long size, FileSizeUnit unit) {
+        if(size <= 0 || unit == null) {
+            return "";
+        }
+        long byteSize = unit.toByte(size);
+        String[] fileSizeArr = getFileSize(byteSize);
+        return fileSizeArr[0]+fileSizeArr[1];
+    }
+
+    /**
+     * Returns the file size and array in appropriate units,
+     * with String [0] as the file size number and String [1] as the unit
+     * @param length the length of the file, int bytes, see as {@link java.io.File#length()}
+     * @return String [0] as the file size number and String [1] as the unit
+     */
+    private static String[] getFileSize(long length) {
+        if(length <= 0) {
+            return new String[]{"0","Byte"};
+        }
+
+        String[] size = new String[2];
+        DecimalFormat df = new DecimalFormat("#.0");
+        if (length < CKB) {
+            size[0] = df.format(length);
+            size[1] = "Byte";
+        } else if (length < CMB) {
+            size[0] = df.format( length*1.0/ CKB);
+            size[1] = "KB";
+        } else if (length < CGB) {
+            size[0] = df.format(length*1.0/ CMB);
+            size[1] = "MB";
+        } else if (length < CTB) {
+            size[0] = df.format(length*1.0/ CGB);
+            size[1] = "GB";
+        } else {
+            size[0] = df.format(length*1.0/ CTB);
+            size[1] = "TB";
+        }
+        return size;
+    }
+
+}

--- a/src/main/java/org/apache/commons/io/FileSizeUnit.java
+++ b/src/main/java/org/apache/commons/io/FileSizeUnit.java
@@ -12,140 +12,140 @@ public enum FileSizeUnit {
     /**Byte*/
     BYTE {
         @Override
-        public long toByte(long duration) {
-            return duration;
+        public long toByte(long length) {
+            return length;
         }
 
         @Override
-        public long toKb(long duration) {
-            return duration/(CKB/ CB);
+        public long toKb(long length) {
+            return length/(CKB/ CB);
         }
 
         @Override
-        public long toMb(long duration) {
-            return duration/(CMB/ CB);
+        public long toMb(long length) {
+            return length/(CMB/ CB);
         }
 
         @Override
-        public long toGb(long duration) {
-            return duration/(CGB/ CB);
+        public long toGb(long length) {
+            return length/(CGB/ CB);
         }
 
         @Override
-        public long toTb(long duration) {
-            return duration/(CTB/ CB);
+        public long toTb(long length) {
+            return length/(CTB/ CB);
         }
     },
 
     /**KB*/
     KB {
         @Override
-        public long toByte(long duration) {
-            return x(duration, CKB/ CB, MAX/(CKB/ CB));
+        public long toByte(long length) {
+            return x(length, CKB/ CB, MAX/(CKB/ CB));
         }
 
         @Override
-        public long toKb(long duration) {
-            return duration;
+        public long toKb(long length) {
+            return length;
         }
 
         @Override
-        public long toMb(long duration) {
-            return duration/(CMB/CKB);
+        public long toMb(long length) {
+            return length/(CMB/CKB);
         }
 
         @Override
-        public long toGb(long duration) {
-            return duration/(CGB/CKB);
+        public long toGb(long length) {
+            return length/(CGB/CKB);
         }
 
         @Override
-        public long toTb(long duration) {
-            return duration/(CTB/CKB);
+        public long toTb(long length) {
+            return length/(CTB/CKB);
         }
     },
 
     /**MB*/
     MB {
         @Override
-        public long toByte(long duration) {
-            return x(duration, CMB/ CB, MAX/(CMB/ CB));
+        public long toByte(long length) {
+            return x(length, CMB/ CB, MAX/(CMB/ CB));
         }
 
         @Override
-        public long toKb(long duration) {
-            return x(duration, CMB/CKB, MAX/(CMB/CKB));
+        public long toKb(long length) {
+            return x(length, CMB/CKB, MAX/(CMB/CKB));
         }
 
         @Override
-        public long toMb(long duration) {
-            return duration;
+        public long toMb(long length) {
+            return length;
         }
 
         @Override
-        public long toGb(long duration) {
-            return duration/(CGB/CMB);
+        public long toGb(long length) {
+            return length/(CGB/CMB);
         }
 
         @Override
-        public long toTb(long duration) {
-            return duration/(CTB/CMB);
+        public long toTb(long length) {
+            return length/(CTB/CMB);
         }
     },
 
     /**GB*/
     GB {
         @Override
-        public long toByte(long duration) {
-            return x(duration, CGB/ CB, MAX/(CGB/ CB));
+        public long toByte(long length) {
+            return x(length, CGB/ CB, MAX/(CGB/ CB));
         }
 
         @Override
-        public long toKb(long duration) {
-            return x(duration, CGB/CKB, MAX/(CGB/CKB));
+        public long toKb(long length) {
+            return x(length, CGB/CKB, MAX/(CGB/CKB));
         }
 
         @Override
-        public long toMb(long duration) {
-            return x(duration, CGB/CMB, MAX/(CGB/CMB));
+        public long toMb(long length) {
+            return x(length, CGB/CMB, MAX/(CGB/CMB));
         }
 
         @Override
-        public long toGb(long duration) {
-            return duration;
+        public long toGb(long length) {
+            return length;
         }
 
         @Override
-        public long toTb(long duration) {
-            return duration/(CTB/CGB);
+        public long toTb(long length) {
+            return length/(CTB/CGB);
         }
     },
 
     /**TB*/
     TB {
         @Override
-        public long toByte(long duration) {
-            return x(duration, CTB/ CB, MAX/(CTB/ CB));
+        public long toByte(long length) {
+            return x(length, CTB/ CB, MAX/(CTB/ CB));
         }
 
         @Override
-        public long toKb(long duration) {
-            return x(duration, CTB/CKB, MAX/(CTB/CKB));
+        public long toKb(long length) {
+            return x(length, CTB/CKB, MAX/(CTB/CKB));
         }
 
         @Override
-        public long toMb(long duration) {
-            return x(duration, CTB/CMB, MAX/(CTB/CMB));
+        public long toMb(long length) {
+            return x(length, CTB/CMB, MAX/(CTB/CMB));
         }
 
         @Override
-        public long toGb(long duration) {
-            return x(duration, CTB/CGB, MAX/(CTB/CTB));
+        public long toGb(long length) {
+            return x(length, CTB/CGB, MAX/(CTB/CTB));
         }
 
         @Override
-        public long toTb(long duration) {
-            return duration;
+        public long toTb(long length) {
+            return length;
         }
     }
     ;
@@ -169,11 +169,11 @@ public enum FileSizeUnit {
     }
 
 
-    public long toByte(long duration) { throw new AbstractMethodError(); }
-    public long toKb(long duration) { throw new AbstractMethodError(); }
-    public long toMb(long duration) { throw new AbstractMethodError(); }
-    public long toGb(long duration) { throw new AbstractMethodError(); }
-    public long toTb(long duration) { throw new AbstractMethodError(); }
+    public long toByte(long length) { throw new AbstractMethodError(); }
+    public long toKb(long length) { throw new AbstractMethodError(); }
+    public long toMb(long length) { throw new AbstractMethodError(); }
+    public long toGb(long length) { throw new AbstractMethodError(); }
+    public long toTb(long length) { throw new AbstractMethodError(); }
 
     /**
      * Convert file size to a human-readable string with units, such as 3.1GB, 300.0MB, etc

--- a/src/test/java/org/apache/commons/io/FileSizeUnitTest.java
+++ b/src/test/java/org/apache/commons/io/FileSizeUnitTest.java
@@ -1,0 +1,69 @@
+package org.apache.commons.io;
+
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class FileSizeUnitTest {
+
+    @Test
+    public void toByte() {
+        Assertions.assertEquals(FileSizeUnit.BYTE.toByte(1), 1);
+        Assertions.assertEquals(FileSizeUnit.KB.toByte(1), 2L<<9);
+        Assertions.assertEquals(FileSizeUnit.MB.toByte(1), 2L<<19);
+        Assertions.assertEquals(FileSizeUnit.GB.toByte(1), 2L<<29);
+        Assertions.assertEquals(FileSizeUnit.TB.toByte(1), 2L<<39);
+    }
+
+
+    @Test
+    public void toKb() {
+        Assertions.assertEquals(FileSizeUnit.BYTE.toKb(1024), 1);
+        Assertions.assertEquals(FileSizeUnit.KB.toKb(1), 1);
+        Assertions.assertEquals(FileSizeUnit.MB.toKb(1), 2L<<9);
+        Assertions.assertEquals(FileSizeUnit.GB.toKb(1), 2L<<19);
+        Assertions.assertEquals(FileSizeUnit.TB.toKb(1), 2L<<29);
+    }
+
+    @Test
+    public void toMb() {
+        Assertions.assertEquals(FileSizeUnit.BYTE.toMb(1024*1024), 1);
+        Assertions.assertEquals(FileSizeUnit.KB.toMb(1024), 1);
+        Assertions.assertEquals(FileSizeUnit.MB.toMb(1), 1);
+        Assertions.assertEquals(FileSizeUnit.GB.toMb(1), 2L<<9);
+        Assertions.assertEquals(FileSizeUnit.TB.toMb(1), 2L<<19);
+    }
+
+    @Test
+    public void toGb() {
+        Assertions.assertEquals(FileSizeUnit.BYTE.toGb(1024*1024*1024), 1);
+        Assertions.assertEquals(FileSizeUnit.KB.toGb(1024*1024), 1);
+        Assertions.assertEquals(FileSizeUnit.MB.toGb(1024), 1);
+        Assertions.assertEquals(FileSizeUnit.GB.toGb(1), 1);
+        Assertions.assertEquals(FileSizeUnit.TB.toGb(1), 2L<<9);
+    }
+
+    @Test
+    public void toTb() {
+        Assertions.assertEquals(FileSizeUnit.BYTE.toTb(1024L*1024*1024*1024), 1);
+        Assertions.assertEquals(FileSizeUnit.KB.toTb(1024*1024*1024), 1);
+        Assertions.assertEquals(FileSizeUnit.MB.toTb(1024*1024), 1);
+        Assertions.assertEquals(FileSizeUnit.GB.toTb(1024), 1);
+        Assertions.assertEquals(FileSizeUnit.TB.toTb(1), 1);
+    }
+
+    @Test
+    public void readableSize() {
+        long size = 1024*1024;
+        String sizeStr = FileSizeUnit.readableSize(size);
+        Assertions.assertEquals("1.0MB", sizeStr);
+    }
+
+    @Test
+    public void readableSizeUnit() {
+        long size = 2345;
+        String sizeStr = FileSizeUnit.readableSize(size, FileSizeUnit.MB);
+        Assertions.assertEquals("2.3GB", sizeStr);
+    }
+
+}


### PR DESCRIPTION
File size conversion tool, supporting mutual conversion of TB, GB, MB, KB, Byte, etc.,as well as converting the size of numeric types into human-readable strings. #https://issues.apache.org/jira/browse/IO-822 

 The tool can convert any size unit into a human readable version, and support file size unit conversion to and from each other. The implementation method refers to TimeUnit, adopts the feature of enumeration, simplifies the code, and has high efficiency.
