### PR TITLE
[IO-825] Add byte array size validation for methods in EndianUtils

### DIFF
--- a/src/main/java/org/apache/commons/io/EndianUtils.java
+++ b/src/main/java/org/apache/commons/io/EndianUtils.java
@@ -48,7 +48,7 @@ public class EndianUtils {
      * @param byteNeeded the needed number of bytes
      * @throws IllegalArgumentException if the byte array does not have enough data
      */
-    private static void validateByteArrayOffset(byte[] data, final int offset, final int byteNeeded) {
+    private static void validateByteArrayOffset(final byte[] data, final int offset, final int byteNeeded) {
         if (data.length < offset + byteNeeded) {
             throw new IllegalArgumentException("Data only has " + data.length + "bytes, needed " + (offset + byteNeeded) + "bytes.");
         }

--- a/src/main/java/org/apache/commons/io/EndianUtils.java
+++ b/src/main/java/org/apache/commons/io/EndianUtils.java
@@ -40,6 +40,19 @@ import java.io.OutputStream;
  * @see org.apache.commons.io.input.SwappedDataInputStream
  */
 public class EndianUtils {
+    /**
+     * Validate if the provided byte array have enough data.
+     * @param data the input byte array
+     * @param offset the input offset
+     * @param byteNeeded the needed number of bytes
+     * @throws IllegalArgumentException if the byte array does not have enough data
+     */
+    private static void validateByteArrayOffset(byte[] data, final int offset, final int byteNeeded) {
+        if (data.length < offset + byteNeeded) {
+            throw new IllegalArgumentException(
+                "Data only has " + data.length + "bytes, needed " + (offset + byteNeeded) + "bytes.");
+        }
+    }
 
     /**
      * Reads the next byte from the input stream.
@@ -107,6 +120,7 @@ public class EndianUtils {
      * @return the value read
      */
     public static int readSwappedInteger(final byte[] data, final int offset) {
+        validateByteArrayOffset(data, offset, Integer.SIZE / Byte.SIZE);
         return ((data[offset + 0] & 0xff) << 0) +
             ((data[offset + 1] & 0xff) << 8) +
             ((data[offset + 2] & 0xff) << 16) +
@@ -136,6 +150,7 @@ public class EndianUtils {
      * @return the value read
      */
     public static long readSwappedLong(final byte[] data, final int offset) {
+        validateByteArrayOffset(data, offset, Long.SIZE / Byte.SIZE);
         final long low = readSwappedInteger(data, offset);
         final long high = readSwappedInteger(data, offset + 4);
         return (high << 32) + (0xffffffffL & low);
@@ -164,6 +179,7 @@ public class EndianUtils {
      * @return the value read
      */
     public static short readSwappedShort(final byte[] data, final int offset) {
+        validateByteArrayOffset(data, offset, Short.SIZE / Byte.SIZE);
         return (short) (((data[offset + 0] & 0xff) << 0) + ((data[offset + 1] & 0xff) << 8));
     }
 
@@ -187,6 +203,7 @@ public class EndianUtils {
      * @return the value read
      */
     public static long readSwappedUnsignedInteger(final byte[] data, final int offset) {
+        validateByteArrayOffset(data, offset, Integer.SIZE / Byte.SIZE);
         final long low = ((data[offset + 0] & 0xff) << 0) +
                      ((data[offset + 1] & 0xff) << 8) +
                      ((data[offset + 2] & 0xff) << 16);
@@ -220,6 +237,7 @@ public class EndianUtils {
      * @return the value read
      */
     public static int readSwappedUnsignedShort(final byte[] data, final int offset) {
+        validateByteArrayOffset(data, offset, Short.SIZE / Byte.SIZE);
         return ((data[offset + 0] & 0xff) << 0) + ((data[offset + 1] & 0xff) << 8);
     }
 
@@ -347,6 +365,7 @@ public class EndianUtils {
      * @param value value to write
      */
     public static void writeSwappedInteger(final byte[] data, final int offset, final int value) {
+        validateByteArrayOffset(data, offset, Integer.SIZE / Byte.SIZE);
         data[offset + 0] = (byte) (value >> 0 & 0xff);
         data[offset + 1] = (byte) (value >> 8 & 0xff);
         data[offset + 2] = (byte) (value >> 16 & 0xff);
@@ -375,6 +394,7 @@ public class EndianUtils {
      * @param value value to write
      */
     public static void writeSwappedLong(final byte[] data, final int offset, final long value) {
+        validateByteArrayOffset(data, offset, Long.SIZE / Byte.SIZE);
         data[offset + 0] = (byte) (value >> 0 & 0xff);
         data[offset + 1] = (byte) (value >> 8 & 0xff);
         data[offset + 2] = (byte) (value >> 16 & 0xff);
@@ -411,6 +431,7 @@ public class EndianUtils {
      * @param value value to write
      */
     public static void writeSwappedShort(final byte[] data, final int offset, final short value) {
+        validateByteArrayOffset(data, offset, Short.SIZE / Byte.SIZE);
         data[offset + 0] = (byte) (value >> 0 & 0xff);
         data[offset + 1] = (byte) (value >> 8 & 0xff);
     }

--- a/src/main/java/org/apache/commons/io/EndianUtils.java
+++ b/src/main/java/org/apache/commons/io/EndianUtils.java
@@ -40,8 +40,9 @@ import java.io.OutputStream;
  * @see org.apache.commons.io.input.SwappedDataInputStream
  */
 public class EndianUtils {
+
     /**
-     * Validate if the provided byte array have enough data.
+     * Validates if the provided byte array have enough data.
      * @param data the input byte array
      * @param offset the input offset
      * @param byteNeeded the needed number of bytes
@@ -49,8 +50,7 @@ public class EndianUtils {
      */
     private static void validateByteArrayOffset(byte[] data, final int offset, final int byteNeeded) {
         if (data.length < offset + byteNeeded) {
-            throw new IllegalArgumentException(
-                "Data only has " + data.length + "bytes, needed " + (offset + byteNeeded) + "bytes.");
+            throw new IllegalArgumentException("Data only has " + data.length + "bytes, needed " + (offset + byteNeeded) + "bytes.");
         }
     }
 

--- a/src/test/java/org/apache/commons/io/EndianUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/EndianUtilsTest.java
@@ -308,4 +308,18 @@ public class EndianUtilsTest  {
         assertEquals( 0x01, bytes[1] );
     }
 
+    @Test
+    public void testInvalidOffset() throws IOException {
+        final byte[] bytes = new byte[0];
+
+        assertThrows(IllegalArgumentException.class, () -> EndianUtils.readSwappedInteger(bytes, 0));
+        assertThrows(IllegalArgumentException.class, () -> EndianUtils.readSwappedLong(bytes, 0));
+        assertThrows(IllegalArgumentException.class, () -> EndianUtils.readSwappedShort(bytes, 0));
+        assertThrows(IllegalArgumentException.class, () -> EndianUtils.readSwappedUnsignedInteger(bytes, 0));
+        assertThrows(IllegalArgumentException.class, () -> EndianUtils.readSwappedUnsignedShort(bytes, 0));
+        assertThrows(IllegalArgumentException.class, () -> EndianUtils.writeSwappedInteger(bytes, 0, 0));
+        assertThrows(IllegalArgumentException.class, () -> EndianUtils.writeSwappedLong(bytes, 0, 0l));
+        assertThrows(IllegalArgumentException.class, () -> EndianUtils.writeSwappedShort(bytes, 0, (short) 0));
+    }
+
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/IO-825

This PR fixes the possible `IndexOutOfBoundsException` from methods in `EndianUtils` by adding a validation method to those methods. The validation method throws an `IllegalArgumentException` if the provided byte array does not have enough data for reading or does not have enough space for writing.