### PR TITLE
[IO-781] Make CharSequenceInputStream.available() more correct in the face of multibyte encodings

### DIFF
--- a/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
@@ -210,18 +210,14 @@ public class CharSequenceInputStream extends InputStream {
     }
 
     /**
-     * Return an estimate of the number of bytes remaining in the byte stream.
+     * Return a lower bound on the number of bytes remaining in the byte stream.
+     * 
      * @return the count of bytes that can be read without blocking (or returning EOF).
-     *
      * @throws IOException if an error occurs (probably not possible).
      */
     @Override
     public int available() throws IOException {
-        // The cached entries are in bBuf; since encoding always creates at least one byte
-        // per character, we can add the two to get a better estimate (e.g. if bBuf is empty)
-        // Note that the implementation in 2.4 could return zero even though there were
-        // encoded bytes still available.
-        return this.bBuf.remaining() + this.cBuf.remaining();
+        return this.bBuf.remaining();
     }
 
     @Override

--- a/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
@@ -181,7 +181,7 @@ public class CharSequenceInputStream extends InputStream {
         this.cBufMark = NO_MARK;
         this.bBufMark = NO_MARK;
         try {
-        	fillBuffer();
+            fillBuffer();
         } catch (CharacterCodingException ex) {
             // Reset everything without filling the buffer
             // so the same exception can be thrown again later.

--- a/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
@@ -219,7 +219,7 @@ public class CharSequenceInputStream extends InputStream {
 
     /**
      * Return a lower bound on the number of bytes remaining in the byte stream.
-     * 
+     *
      * @return the count of bytes that can be read without blocking (or returning EOF).
      * @throws IOException if an error occurs (probably not possible).
      */

--- a/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
@@ -183,9 +183,9 @@ public class CharSequenceInputStream extends InputStream {
         try {
         	fillBuffer();
         } catch (CharacterCodingException ex) {
-        	// Reset everything without filling the buffer
-        	// so the same exception can be thrown again later.
-        	this.bBuf.clear();
+            // Reset everything without filling the buffer
+            // so the same exception can be thrown again later.
+            this.bBuf.clear();
             this.cBuf.rewind();
         }
     }

--- a/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
@@ -180,6 +180,14 @@ public class CharSequenceInputStream extends InputStream {
         this.cBuf = CharBuffer.wrap(cs);
         this.cBufMark = NO_MARK;
         this.bBufMark = NO_MARK;
+        try {
+        	fillBuffer();
+        } catch (CharacterCodingException ex) {
+        	// Reset everything without filling the buffer
+        	// so the same exception can be thrown again later.
+        	this.bBuf.clear();
+            this.cBuf.rewind();
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/io/input/CharSequenceInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/CharSequenceInputStreamTest.java
@@ -511,4 +511,15 @@ public class CharSequenceInputStreamTest {
             assertEquals(-1, r.read(), csName);
         }
     }
+    
+    @Test
+	// IO-781 available() returns 2 but only 1 byte is read afterwards
+    public void testAvailable() throws IOException {
+    	Charset charset = Charset.forName("Big5");
+    	CharSequenceInputStream in = new CharSequenceInputStream("\uD800\uDC00", charset);
+    	int available = in.available();
+    	byte[] data = new byte[available];
+    	int bytesRead = in.read(data);
+    	assertEquals(available, bytesRead);
+    }
 }

--- a/src/test/java/org/apache/commons/io/input/CharSequenceInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/CharSequenceInputStreamTest.java
@@ -515,7 +515,7 @@ public class CharSequenceInputStreamTest {
     @Test
     // IO-781 available() returns 2 but only 1 byte is read afterwards
     public void testAvailable() throws IOException {
-    	final Charset charset = Charset.forName("Big5");
+        final Charset charset = Charset.forName("Big5");
     	final CharSequenceInputStream in = new CharSequenceInputStream("\uD800\uDC00", charset);
     	final int available = in.available();
     	final byte[] data = new byte[available];

--- a/src/test/java/org/apache/commons/io/input/CharSequenceInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/CharSequenceInputStreamTest.java
@@ -511,15 +511,15 @@ public class CharSequenceInputStreamTest {
             assertEquals(-1, r.read(), csName);
         }
     }
-    
+
     @Test
-	// IO-781 available() returns 2 but only 1 byte is read afterwards
+    // IO-781 available() returns 2 but only 1 byte is read afterwards
     public void testAvailable() throws IOException {
-    	Charset charset = Charset.forName("Big5");
-    	CharSequenceInputStream in = new CharSequenceInputStream("\uD800\uDC00", charset);
-    	int available = in.available();
-    	byte[] data = new byte[available];
-    	int bytesRead = in.read(data);
+    	final Charset charset = Charset.forName("Big5");
+    	final CharSequenceInputStream in = new CharSequenceInputStream("\uD800\uDC00", charset);
+    	final int available = in.available();
+    	final byte[] data = new byte[available];
+    	final int bytesRead = in.read(data);
     	assertEquals(available, bytesRead);
     }
 }

--- a/src/test/java/org/apache/commons/io/input/CharSequenceInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/CharSequenceInputStreamTest.java
@@ -516,10 +516,10 @@ public class CharSequenceInputStreamTest {
     // IO-781 available() returns 2 but only 1 byte is read afterwards
     public void testAvailable() throws IOException {
         final Charset charset = Charset.forName("Big5");
-    	final CharSequenceInputStream in = new CharSequenceInputStream("\uD800\uDC00", charset);
-    	final int available = in.available();
-    	final byte[] data = new byte[available];
-    	final int bytesRead = in.read(data);
-    	assertEquals(available, bytesRead);
+        final CharSequenceInputStream in = new CharSequenceInputStream("\uD800\uDC00", charset);
+        final int available = in.available();
+        final byte[] data = new byte[available];
+        final int bytesRead = in.read(data);
+        assertEquals(available, bytesRead);
     }
 }


### PR DESCRIPTION
Per contract, available() is not required to return the exact or maximum number of bytes available without blocking. It is required to return a number less than or equal to that. Always returning 0 is an acceptable implementation (though here we can do better than that). 

@garydgregory 

FYI locally the build fails on JDK 8 with an apparently unrelated error:

[ERROR] /Users/elharo/commons-io/src/test/java/org/apache/commons/io/file/FilesUncheckTest.java:[99,25] cannot access org.apache.commons.io.file.FilesUncheck
  bad class file: /Users/elharo/commons-io/target/classes/org/apache/commons/io/file/FilesUncheck.class
    undeclared type variable: A
    Please remove or make sure it appears in the correct subdirectory of the classpath.

Let's see what the CI does with this. 