### PR TITLE
[IO-808] better handling when source is unexpectedly deleted during move

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -292,7 +292,7 @@ public class FileUtils {
      * @return the checksum specified, updated with the content of the file
      * @throws NullPointerException if the given {@link File} is {@code null}.
      * @throws NullPointerException if the given {@link Checksum} is {@code null}.
-     * @throws IllegalArgumentException if the given {@link File} does not exist or is not a file.
+     * @throws IllegalArgumentException if the given {@link File} is not a file.
      * @throws IOException if an IO error occurs reading the file.
      * @since 1.3
      */

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -2393,9 +2393,17 @@ public class FileUtils {
      * @since 2.9.0
      */
     public static void moveFile(final File srcFile, final File destFile, final CopyOption... copyOptions) throws IOException {
-        validateMoveParameters(srcFile, destFile);
-        requireFile(srcFile, "srcFile");
-        requireAbsent(destFile, "destFile");
+        Objects.requireNonNull(srcFile, "source");
+        Objects.requireNonNull(destFile, "destination");
+        if (!srcFile.isFile()) {
+            if (srcFile.exists()) {
+                throw new IllegalArgumentException("Parameter '" + "srcFile" + "' is not a file: " + srcFile);
+            }
+            throw new FileNotFoundException("Source '" + srcFile + "' does not exist");
+        }
+        if (destFile.exists()) {
+            throw new FileExistsException(String.format("File element in parameter '%s' already exists: '%s'", "destFile", destFile));
+        }
         final boolean rename = srcFile.renameTo(destFile);
         if (!rename) {
             // Don't interfere with file date on move, handled by StandardCopyOption.COPY_ATTRIBUTES

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -1914,7 +1914,6 @@ public class FileUtilsTest extends AbstractTempDirTest {
             iterateFilesAndDirs(subDir1, fileFilterAllFiles, fileFilterAllDirs, expectedFilesAndDirs);
             //
             // "*.txt" and "*"
-            final int filesCount;
             expectedFilesAndDirs = Arrays.asList(subDir1, subDir2, someFile, subDir3, subDir4);
             iterateFilesAndDirs(subDir1, fileFilterExtTxt, fileFilterAllDirs, expectedFilesAndDirs);
             //


### PR DESCRIPTION
@garydgregory I think this is roughly what's required to address IO-808. Inlining the various validations makes the flow much more obvious and avoids double null checks.

There's no way I know to lock an file so it can't be deleted after we check that it exists and before we move it, but given that we can distinguish between source files that don't exist and ones that are deleted later. The key is to do the exists check after the file type check. Not obvious in the PR, but this is the reverse of how the checks were performed previously.

Now if the source file is a directory an IllegalArgumentException is still thrown. However the new feature is that in all cases where the method fails because the source file doesn't exist an IOException is thrown, no matter whether the source file was deleted while the method was executing. 