### PR TITLE
[IO-826] Add runtime exception support to broken streams

### DIFF
--- a/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
@@ -142,7 +142,7 @@ public class BrokenInputStream extends InputStream {
      * @throws IOException as configured.
      */
     @Override
-    public synchronized void reset() throws IOException {
+    public void reset() throws IOException {
         exceptionThrower.doThrow();
     }
 

--- a/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
@@ -21,7 +21,7 @@ import java.io.InputStream;
 import java.util.function.Supplier;
 
 /**
- * Always throws an {@link IOException} from all the {@link InputStream} methods where the exception is declared.
+ * Always throws an {@link IOException} or a {@link RuntimeException} from all the {@link InputStream} methods where {@link IOException} is declared.
  * <p>
  * This class is mostly useful for testing error handling.
  * </p>
@@ -38,9 +38,26 @@ public class BrokenInputStream extends InputStream {
     public static final BrokenInputStream INSTANCE = new BrokenInputStream();
 
     /**
-     * A supplier for the exception that is thrown by all methods of this class.
+     * Constructs a new stream that always throws a {@link RuntimeException}.
+     *
+     * @param exceptionSupplier a supplier for the exception to be thrown.
+     * @return a new stream that always throws a {@link RuntimeException}.
      */
-    private final Supplier<IOException> exceptionSupplier;
+    public static BrokenInputStream brokenInputStream(final Supplier<RuntimeException> exceptionSupplier) {
+        return new BrokenInputStream(() -> {
+            throw exceptionSupplier.get();
+        });
+    }
+
+    @FunctionalInterface
+    private interface ExceptionThrower {
+        void doThrow() throws IOException;
+    }
+
+    /**
+     * A function that throws the exception that is thrown by all methods of this class.
+     */
+    private final ExceptionThrower exceptionThrower;
 
     /**
      * Constructs a new stream that always throws an {@link IOException}.
@@ -59,55 +76,74 @@ public class BrokenInputStream extends InputStream {
     }
 
     /**
+     * Constructs a new stream that always throws the given exception.
+     *
+     * @param exception the exception to be thrown.
+     */
+    public BrokenInputStream(final RuntimeException exception) {
+        this(() -> {
+            throw exception;
+        });
+    }
+
+    /**
      * Constructs a new stream that always throws an {@link IOException}.
      *
      * @param exceptionSupplier a supplier for the exception to be thrown.
      * @since 2.12.0
      */
     public BrokenInputStream(final Supplier<IOException> exceptionSupplier) {
-        this.exceptionSupplier = exceptionSupplier;
+        this((ExceptionThrower) () -> {
+            throw exceptionSupplier.get();
+        });
+    }
+
+    private BrokenInputStream(final ExceptionThrower exceptionThrower) {
+        this.exceptionThrower = exceptionThrower;
     }
 
     /**
      * Throws the configured exception.
      *
      * @return nothing
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public int available() throws IOException {
-        throw exceptionSupplier.get();
+        exceptionThrower.doThrow();
+        return super.available();
     }
 
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public void close() throws IOException {
-        throw exceptionSupplier.get();
+        exceptionThrower.doThrow();
     }
 
     /**
      * Throws the configured exception.
      *
      * @return nothing
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public int read() throws IOException {
-        throw exceptionSupplier.get();
+        exceptionThrower.doThrow();
+        return 0;
     }
 
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public synchronized void reset() throws IOException {
-        throw exceptionSupplier.get();
+        exceptionThrower.doThrow();
     }
 
     /**
@@ -115,11 +151,12 @@ public class BrokenInputStream extends InputStream {
      *
      * @param n ignored
      * @return nothing
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public long skip(final long n) throws IOException {
-        throw exceptionSupplier.get();
+        exceptionThrower.doThrow();
+        return super.skip(n);
     }
 
 }

--- a/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
@@ -21,9 +21,9 @@ import java.io.InputStream;
 import java.util.function.Supplier;
 
 /**
- * Always throws an {@link IOException} or a {@link RuntimeException} from all the {@link InputStream} methods where {@link IOException} is declared.
+ * Always throws an {@link IOException} or a {@link RuntimeException} from all {@link InputStream} methods where {@link IOException} is declared.
  * <p>
- * This class is mostly useful for testing error handling.
+ * This class is mostly useful for testing error handling in code that uses an {@link InputStream}.
  * </p>
  *
  * @since 2.0
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 public class BrokenInputStream extends InputStream {
 
     /**
-     * The singleton instance.
+     * A singleton instance using a default IOException.
      *
      * @since 2.12.0
      */
@@ -105,7 +105,7 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @return nothing
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override
@@ -127,7 +127,7 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @return nothing
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override
@@ -149,8 +149,8 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @param n ignored
-     * @return nothing
+     * @param n ignored.
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override

--- a/src/main/java/org/apache/commons/io/input/BrokenReader.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenReader.java
@@ -156,7 +156,7 @@ public class BrokenReader extends Reader {
      * @throws IOException as configured.
      */
     @Override
-    public synchronized void reset() throws IOException {
+    public void reset() throws IOException {
         exceptionThrower.doThrow();
     }
 

--- a/src/main/java/org/apache/commons/io/input/BrokenReader.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenReader.java
@@ -21,9 +21,9 @@ import java.io.Reader;
 import java.util.function.Supplier;
 
 /**
- * Always throws an {@link IOException} or a {@link RuntimeException} from all the {@link Reader} methods where {@link IOException} is declared.
+ * Always throws an {@link IOException} or a {@link RuntimeException} from all {@link Reader} methods where {@link IOException} is declared.
  * <p>
- * This class is mostly useful for testing error handling.
+ * This class is mostly useful for testing error handling in code that uses a {@link Reader}.
  * </p>
  *
  * @since 2.7
@@ -87,7 +87,7 @@ public class BrokenReader extends Reader {
     }
 
     /**
-     * Constructs a new reader that always throws an {@link IOException}
+     * Constructs a new reader that always throws an {@link IOException}.
      *
      * @param exceptionSupplier a supplier for the exception to be thrown.
      * @since 2.12.0
@@ -115,7 +115,7 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @param readAheadLimit ignored
+     * @param readAheadLimit ignored.
      * @throws IOException as configured.
      */
     @Override
@@ -126,10 +126,10 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @param cbuf ignored
-     * @param off  ignored
-     * @param len  ignored
-     * @return nothing
+     * @param cbuf ignored.
+     * @param off  ignored.
+     * @param len  ignored.
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override
@@ -141,7 +141,7 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @return nothing
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override
@@ -163,8 +163,8 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @param n ignored
-     * @return nothing
+     * @param n ignored.
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override

--- a/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
@@ -21,11 +21,9 @@ import java.io.OutputStream;
 import java.util.function.Supplier;
 
 /**
- * Broken output stream. This stream always throws an {@link IOException} or a {@link RuntimeException} from
- * all {@link OutputStream} methods.
+ * Always throws an {@link IOException} or a {@link RuntimeException} from all {@link OutputStream} methods where {@link IOException} is declared.
  * <p>
- * This class is mostly useful for testing error handling in code that uses an
- * output stream.
+ * This class is mostly useful for testing error handling in code that uses an {@link OutputStream}.
  * </p>
  *
  * @since 2.0
@@ -33,7 +31,7 @@ import java.util.function.Supplier;
 public class BrokenOutputStream extends OutputStream {
 
     /**
-     * A singleton instance.
+     * A singleton instance using a default IOException.
      *
      * @since 2.12.0
      */
@@ -127,7 +125,7 @@ public class BrokenOutputStream extends OutputStream {
     /**
      * Throws the configured exception.
      *
-     * @param b ignored
+     * @param b ignored.
      * @throws IOException as configured.
      */
     @Override

--- a/src/main/java/org/apache/commons/io/output/BrokenWriter.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenWriter.java
@@ -21,9 +21,9 @@ import java.io.Writer;
 import java.util.function.Supplier;
 
 /**
- * Always throws an {@link IOException} or a {@link RuntimeException} from all {@link Writer} methods.
+ * Always throws an {@link IOException} or a {@link RuntimeException} from all {@link Writer} methods where {@link IOException} is declared.
  * <p>
- * This class is mostly useful for testing error handling in code that uses a writer.
+ * This class is mostly useful for testing error handling in code that uses a {@link Writer}.
  * </p>
  *
  * @since 2.0
@@ -31,7 +31,7 @@ import java.util.function.Supplier;
 public class BrokenWriter extends Writer {
 
     /**
-     * The singleton instance.
+     * A singleton instance using a default IOException.
      *
      * @since 2.12.0
      */
@@ -125,9 +125,9 @@ public class BrokenWriter extends Writer {
     /**
      * Throws the configured exception.
      *
-     * @param cbuf ignored
-     * @param off ignored
-     * @param len ignored
+     * @param cbuf ignored.
+     * @param off  ignored.
+     * @param len  ignored.
      * @throws IOException as configured.
      */
     @Override

--- a/src/test/java/org/apache/commons/io/input/BrokenInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BrokenInputStreamTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.io.input;
 
 import static org.apache.commons.io.input.BrokenInputStream.brokenInputStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -52,6 +53,11 @@ public class BrokenInputStreamTest {
     public void testRuntimeExceptionClose() {
         final RuntimeException exception = new RuntimeException("test exception");
         assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenInputStream(exception).close()));
+    }
+
+    @Test
+    public void testInstance() {
+        assertNotNull(BrokenInputStream.INSTANCE);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/input/BrokenInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BrokenInputStreamTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.io.input;
 
+import static org.apache.commons.io.input.BrokenInputStream.brokenInputStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,45 +30,74 @@ import org.junit.jupiter.api.Test;
  */
 public class BrokenInputStreamTest {
 
-    private IOException exception;
-
-    private InputStream stream;
-
-    @BeforeEach
-    public void setUp() {
-        exception = new IOException("test exception");
-        stream = new BrokenInputStream(exception);
+    @Test
+    public void testIOExceptionAvailable() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenInputStream(exception).available()));
     }
 
     @Test
-    public void testAvailable() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.available()));
+    public void testRuntimeExceptionAvailable() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenInputStream(exception).available()));
     }
 
     @Test
-    public void testClose() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.close()));
+    public void testIOExceptionClose() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenInputStream(exception).close()));
     }
 
     @Test
-    public void testRead() {
+    public void testRuntimeExceptionClose() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenInputStream(exception).close()));
+    }
+
+    @Test
+    public void testIOExceptionRead() {
+        final IOException exception = new IOException("test exception");
+        final InputStream stream = new BrokenInputStream(exception);
         assertEquals(exception, assertThrows(IOException.class, () -> stream.read()));
         assertEquals(exception, assertThrows(IOException.class, () -> stream.read(new byte[1])));
         assertEquals(exception, assertThrows(IOException.class, () -> stream.read(new byte[1], 0, 1)));
     }
 
     @Test
-    public void testReset() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.reset()));
+    public void testRuntimeExceptionRead() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        final InputStream stream = new BrokenInputStream(exception);
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> stream.read()));
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> stream.read(new byte[1])));
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> stream.read(new byte[1], 0, 1)));
     }
 
     @Test
-    public void testSkip() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.skip(1)));
+    public void testIOExceptionReset() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenInputStream(exception).reset()));
     }
 
     @Test
-    public void testTryWithResources() {
+    public void testRuntimeExceptionReset() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenInputStream(exception).reset()));
+    }
+
+    @Test
+    public void testIOExceptionSkip() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenInputStream(exception).skip(1)));
+    }
+
+    @Test
+    public void testRuntimeExceptionSkip() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenInputStream(exception).skip(1)));
+    }
+
+    @Test
+    public void testIOExceptionTryWithResources() {
         final IOException thrown = assertThrows(IOException.class, () -> {
             try (InputStream newStream = new BrokenInputStream()) {
                 newStream.read();
@@ -80,5 +109,20 @@ public class BrokenInputStreamTest {
         assertEquals(1, suppressed.length);
         assertEquals(IOException.class, suppressed[0].getClass());
         assertEquals("Broken input stream", suppressed[0].getMessage());
+    }
+
+    @Test
+    public void testRuntimeExceptionTryWithResources() {
+        final RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+            try (InputStream newStream = brokenInputStream(() -> new RuntimeException("test exception"))) {
+                newStream.read();
+            }
+        });
+        assertEquals("test exception", thrown.getMessage());
+
+        final Throwable[] suppressed = thrown.getSuppressed();
+        assertEquals(1, suppressed.length);
+        assertEquals(RuntimeException.class, suppressed[0].getClass());
+        assertEquals("test exception", suppressed[0].getMessage());
     }
 }

--- a/src/test/java/org/apache/commons/io/input/BrokenReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/BrokenReaderTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.io.input;
 
+import static org.apache.commons.io.input.BrokenReader.brokenReader;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -23,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.io.IOException;
 import java.io.Reader;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -31,19 +31,16 @@ import org.junit.jupiter.api.Test;
  */
 public class BrokenReaderTest {
 
-    private IOException exception;
-
-    private Reader brokenReader;
-
-    @BeforeEach
-    public void setUp() {
-        exception = new IOException("test exception");
-        brokenReader = new BrokenReader(exception);
+    @Test
+    public void testIOExceptionClose() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenReader(exception).close()));
     }
 
     @Test
-    public void testClose() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.close()));
+    public void testRuntimeExceptionClose() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenReader(exception).close()));
     }
 
     @Test
@@ -52,42 +49,91 @@ public class BrokenReaderTest {
     }
 
     @Test
-    public void testMark() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.mark(1)));
+    public void testIOExceptionMark() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenReader(exception).mark(1)));
     }
 
     @Test
-    public void testRead() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.read()));
+    public void testRuntimeExceptionMark() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenReader(exception).mark(1)));
     }
 
     @Test
-    public void testReadCharArray() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.read(new char[1])));
+    public void testIOExceptionRead() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenReader(exception).read()));
     }
 
     @Test
-    public void testReadCharArrayIndexed() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.read(new char[1], 0, 1)));
+    public void testRuntimeExceptionRead() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenReader(exception).read()));
     }
 
     @Test
-    public void testReady() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.ready()));
+    public void testIOExceptionReadCharArray() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenReader(exception).read(new char[1])));
     }
 
     @Test
-    public void testReset() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.reset()));
+    public void testRuntimeExceptionReadCharArray() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenReader(exception).read(new char[1])));
     }
 
     @Test
-    public void testSkip() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.skip(1)));
+    public void testIOExceptionReadCharArrayIndexed() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenReader(exception).read(new char[1], 0, 1)));
     }
 
     @Test
-    public void testTryWithResources() {
+    public void testRuntimeExceptionReadCharArrayIndexed() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenReader(exception).read(new char[1], 0, 1)));
+    }
+
+    @Test
+    public void testIOExceptionReady() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenReader(exception).ready()));
+    }
+
+    @Test
+    public void testRuntimeExceptionReady() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenReader(exception).ready()));
+    }
+
+    @Test
+    public void testIOExceptionReset() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenReader(exception).reset()));
+    }
+
+    @Test
+    public void testRuntimeExceptionReset() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenReader(exception).reset()));
+    }
+
+    @Test
+    public void testIOExceptionSkip() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenReader(exception).skip(1)));
+    }
+
+    @Test
+    public void testRuntimeExceptionSkip() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenReader(exception).skip(1)));
+    }
+
+    @Test
+    public void testIOExceptionTryWithResources() {
         final IOException thrown = assertThrows(IOException.class, () -> {
             try (Reader newReader = new BrokenReader()) {
                 newReader.read();
@@ -99,6 +145,21 @@ public class BrokenReaderTest {
         assertEquals(1, suppressed.length);
         assertEquals(IOException.class, suppressed[0].getClass());
         assertEquals("Broken reader", suppressed[0].getMessage());
+    }
+
+    @Test
+    public void testRuntimeExceptionTryWithResources() {
+        final RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+            try (Reader newReader = brokenReader(() -> new RuntimeException("test exception"))) {
+                newReader.read();
+            }
+        });
+        assertEquals("test exception", thrown.getMessage());
+
+        final Throwable[] suppressed = thrown.getSuppressed();
+        assertEquals(1, suppressed.length);
+        assertEquals(RuntimeException.class, suppressed[0].getClass());
+        assertEquals("test exception", suppressed[0].getMessage());
     }
 
 }

--- a/src/test/java/org/apache/commons/io/output/BrokenOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/BrokenOutputStreamTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.io.output;
 
 import static org.apache.commons.io.output.BrokenOutputStream.brokenOutputStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
@@ -52,6 +53,11 @@ public class BrokenOutputStreamTest {
     public void testRuntimeExceptionFlush() {
         final RuntimeException exception = new RuntimeException("test exception");
         assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenOutputStream(exception).flush()));
+    }
+
+    @Test
+    public void testInstance() {
+        assertNotNull(BrokenOutputStream.INSTANCE);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/output/BrokenOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/BrokenOutputStreamTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.io.output;
 
+import static org.apache.commons.io.output.BrokenOutputStream.brokenOutputStream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.OutputStream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -30,28 +30,32 @@ import org.junit.jupiter.api.Test;
  */
 public class BrokenOutputStreamTest {
 
-    private IOException exception;
-
-    private OutputStream stream;
-
-    @BeforeEach
-    public void setUp() {
-        exception = new IOException("test exception");
-        stream = new BrokenOutputStream(exception);
+    @Test
+    public void testIOExceptionClose() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenOutputStream(exception).close()));
     }
 
     @Test
-    public void testClose() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.close()));
+    public void testRuntimeExceptionClose() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenOutputStream(exception).close()));
     }
 
     @Test
-    public void testFlush() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.flush()));
+    public void testIOExceptionFlush() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenOutputStream(exception).flush()));
     }
 
     @Test
-    public void testTryWithResources() {
+    public void testRuntimeExceptionFlush() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenOutputStream(exception).flush()));
+    }
+
+    @Test
+    public void testIOExceptionTryWithResources() {
         final IOException thrown = assertThrows(IOException.class, () -> {
             try (OutputStream newStream = new BrokenOutputStream()) {
                 newStream.write(1);
@@ -66,18 +70,54 @@ public class BrokenOutputStreamTest {
     }
 
     @Test
-    public void testWriteByteArray() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.write(new byte[1])));
+    public void testRuntimeExceptionTryWithResources() {
+        final RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+            try (OutputStream newStream = brokenOutputStream(() -> new RuntimeException("test exception"))) {
+                newStream.write(1);
+            }
+        });
+        assertEquals("test exception", thrown.getMessage());
+
+        final Throwable[] suppressed = thrown.getSuppressed();
+        assertEquals(1, suppressed.length);
+        assertEquals(RuntimeException.class, suppressed[0].getClass());
+        assertEquals("test exception", suppressed[0].getMessage());
     }
 
     @Test
-    public void testWriteByteArrayIndexed() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.write(new byte[1], 0, 1)));
+    public void testIOExceptionWriteByteArray() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenOutputStream(exception).write(new byte[1])));
     }
 
     @Test
-    public void testWriteInt() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.write(1)));
+    public void testRuntimeExceptionWriteByteArray() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenOutputStream(exception).write(new byte[1])));
+    }
+
+    @Test
+    public void testIOExceptionWriteByteArrayIndexed() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenOutputStream(exception).write(new byte[1], 0, 1)));
+    }
+
+    @Test
+    public void testRuntimeExceptionWriteByteArrayIndexed() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenOutputStream(exception).write(new byte[1], 0, 1)));
+    }
+
+    @Test
+    public void testIOExceptionWriteInt() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenOutputStream(exception).write(1)));
+    }
+
+    @Test
+    public void testRuntimeExceptionWriteInt() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenOutputStream(exception).write(1)));
     }
 
 }

--- a/src/test/java/org/apache/commons/io/output/BrokenWriterTest.java
+++ b/src/test/java/org/apache/commons/io/output/BrokenWriterTest.java
@@ -18,12 +18,12 @@ package org.apache.commons.io.output;
 
 import static org.apache.commons.io.output.BrokenWriter.brokenWriter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.Writer;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -80,20 +80,6 @@ public class BrokenWriterTest {
     }
 
     @Test
-    @Disabled("What should happen here?")
-    public void testIOExceptionEquals() {
-        final IOException exception = new IOException("test exception");
-        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).equals(null)));
-    }
-
-    @Test
-    @Disabled("What should happen here?")
-    public void testRuntimeExceptionEquals() {
-        final RuntimeException exception = new RuntimeException("test exception");
-        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).equals(null)));
-    }
-
-    @Test
     public void testIOExceptionFlush() {
         final IOException exception = new IOException("test exception");
         assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).flush()));
@@ -106,31 +92,8 @@ public class BrokenWriterTest {
     }
 
     @Test
-    @Disabled("What should happen here?")
-    public void testIOExceptionHashCode() {
-        final IOException exception = new IOException("test exception");
-        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).hashCode()));
-    }
-
-    @Test
-    @Disabled("What should happen here?")
-    public void testRuntimeExceptionHashCode() {
-        final RuntimeException exception = new RuntimeException("test exception");
-        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).hashCode()));
-    }
-
-    @Test
-    @Disabled("What should happen here?")
-    public void testIOExceptionToString() {
-        final IOException exception = new IOException("test exception");
-        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).toString()));
-    }
-
-    @Test
-    @Disabled("What should happen here?")
-    public void testRuntimeExceptionToString() {
-        final RuntimeException exception = new RuntimeException("test exception");
-        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).toString()));
+    public void testInstance() {
+        assertNotNull(BrokenWriter.INSTANCE);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/output/BrokenWriterTest.java
+++ b/src/test/java/org/apache/commons/io/output/BrokenWriterTest.java
@@ -16,13 +16,13 @@
  */
 package org.apache.commons.io.output;
 
+import static org.apache.commons.io.output.BrokenWriter.brokenWriter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.io.Writer;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -31,61 +31,110 @@ import org.junit.jupiter.api.Test;
  */
 public class BrokenWriterTest {
 
-    private IOException exception;
-
-    private Writer brokenWriter;
-
-    @BeforeEach
-    public void setUp() {
-        exception = new IOException("test exception");
-        brokenWriter = new BrokenWriter(exception);
+    @Test
+    public void testIOExceptionAppendChar() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).append('1')));
     }
 
     @Test
-    public void testAppendChar() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.append('1')));
+    public void testRuntimeExceptionAppendChar() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).append('1')));
     }
 
     @Test
-    public void testAppendCharSequence() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.append("01")));
+    public void testIOExceptionAppendCharSequence() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).append("01")));
     }
 
     @Test
-    public void testAppendCharSequenceIndexed() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.append("01", 0, 1)));
+    public void testRuntimeExceptionAppendCharSequence() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).append("01")));
     }
 
     @Test
-    public void testClose() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.close()));
+    public void testIOExceptionAppendCharSequenceIndexed() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).append("01", 0, 1)));
+    }
+
+    @Test
+    public void testRuntimeExceptionAppendCharSequenceIndexed() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).append("01", 0, 1)));
+    }
+
+    @Test
+    public void testIOExceptionClose() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).close()));
+    }
+
+    @Test
+    public void testRuntimeExceptionClose() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).close()));
     }
 
     @Test
     @Disabled("What should happen here?")
-    public void testEquals() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.equals(null)));
-    }
-
-    @Test
-    public void testFlush() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.flush()));
+    public void testIOExceptionEquals() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).equals(null)));
     }
 
     @Test
     @Disabled("What should happen here?")
-    public void testHashCode() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.hashCode()));
+    public void testRuntimeExceptionEquals() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).equals(null)));
+    }
+
+    @Test
+    public void testIOExceptionFlush() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).flush()));
+    }
+
+    @Test
+    public void testRuntimeExceptionFlush() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).flush()));
     }
 
     @Test
     @Disabled("What should happen here?")
-    public void testToString() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.toString()));
+    public void testIOExceptionHashCode() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).hashCode()));
     }
 
     @Test
-    public void testTryWithResources() {
+    @Disabled("What should happen here?")
+    public void testRuntimeExceptionHashCode() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).hashCode()));
+    }
+
+    @Test
+    @Disabled("What should happen here?")
+    public void testIOExceptionToString() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).toString()));
+    }
+
+    @Test
+    @Disabled("What should happen here?")
+    public void testRuntimeExceptionToString() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).toString()));
+    }
+
+    @Test
+    public void testIOExceptionTryWithResources() {
         final IOException thrown = assertThrows(IOException.class, () -> {
             try (Writer newWriter = new BrokenWriter()) {
                 newWriter.write(1);
@@ -100,28 +149,78 @@ public class BrokenWriterTest {
     }
 
     @Test
-    public void testWriteCharArray() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.write(new char[1])));
+    public void testRuntimeExceptionTryWithResources() {
+        final RuntimeException thrown = assertThrows(RuntimeException.class, () -> {
+            try (Writer newWriter = brokenWriter(() -> new RuntimeException("test exception"))) {
+                newWriter.write(1);
+            }
+        });
+        assertEquals("test exception", thrown.getMessage());
+
+        final Throwable[] suppressed = thrown.getSuppressed();
+        assertEquals(1, suppressed.length);
+        assertEquals(RuntimeException.class, suppressed[0].getClass());
+        assertEquals("test exception", suppressed[0].getMessage());
     }
 
     @Test
-    public void testWriteCharArrayIndexed() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.write(new char[1], 0, 1)));
+    public void testIOExceptionWriteCharArray() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).write(new char[1])));
     }
 
     @Test
-    public void testWriteInt() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.write(1)));
+    public void testRuntimeExceptionWriteCharArray() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).write(new char[1])));
     }
 
     @Test
-    public void testWriteString() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.write("01")));
+    public void testIOExceptionWriteCharArrayIndexed() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).write(new char[1], 0, 1)));
     }
 
     @Test
-    public void testWriteStringIndexed() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.write("01", 0, 1)));
+    public void testRuntimeExceptionWriteCharArrayIndexed() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).write(new char[1], 0, 1)));
+    }
+
+    @Test
+    public void testIOExceptionWriteInt() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).write(1)));
+    }
+
+    @Test
+    public void testRuntimeExceptionWriteInt() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).write(1)));
+    }
+
+    @Test
+    public void testIOExceptionWriteString() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).write("01")));
+    }
+
+    @Test
+    public void testRuntimeExceptionWriteString() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).write("01")));
+    }
+
+    @Test
+    public void testIOExceptionWriteStringIndexed() {
+        final IOException exception = new IOException("test exception");
+        assertEquals(exception, assertThrows(IOException.class, () -> new BrokenWriter(exception).write("01", 0, 1)));
+    }
+
+    @Test
+    public void testRuntimeExceptionWriteStringIndexed() {
+        final RuntimeException exception = new RuntimeException("test exception");
+        assertEquals(exception, assertThrows(RuntimeException.class, () -> new BrokenWriter(exception).write("01", 0, 1)));
     }
 
 }


### PR DESCRIPTION
While implementing this, I came across a few minor and cosmetic issues.  I've addressed those in a couple of subsequent commits with the intention of making each easier to review.

The commits are:
1. The implementation of the feature:
    1. Because of runtime type erasure, I couldn't overload the `public BrokenX(final Supplier<IOException> exceptionSupplier)` constructors with `public BrokenX(final Supplier<RuntimeException> exceptionSupplier)`.  I've added factory methods instead, e.g . `public static BrokenReader brokenReader(final Supplier<RuntimeException> exceptionSupplier)`.
    2. All the tests have acquired duplicates that vary only in the type of exception they throw.  This *could* be achieved with parameterized tests, but it seemed more readable to write them out explicitly.
3. I removed the `synchronized` modifier from a couple of methods, because it appeared to have been added in error.
4. I consistified the JavaDoc and testing across all four BrokenX classes.