### PR TITLE
[IO-826] Reimplemented add runtime exception support to broken streams

### DIFF
--- a/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
@@ -120,7 +120,7 @@ public class BrokenInputStream extends InputStream {
      * @throws IOException as configured.
      */
     @Override
-    public synchronized void reset() throws IOException {
+    public void reset() throws IOException {
         throw rethrow();
     }
 

--- a/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
@@ -33,7 +33,7 @@ import org.apache.commons.io.function.Erase;
 public class BrokenInputStream extends InputStream {
 
     /**
-     * The singleton instance.
+     * A singleton instance using a default IOException.
      *
      * @since 2.12.0
      */
@@ -85,7 +85,7 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @return nothing
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override
@@ -106,7 +106,7 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @return nothing
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override
@@ -136,8 +136,8 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @param n ignored
-     * @return nothing
+     * @param n ignored.
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override

--- a/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
@@ -33,7 +33,7 @@ import org.apache.commons.io.function.Erase;
 public class BrokenInputStream extends InputStream {
 
     /**
-     * A singleton instance using a default IOException.
+     * The singleton instance using a default IOException.
      *
      * @since 2.12.0
      */

--- a/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
@@ -86,7 +86,7 @@ public class BrokenInputStream extends InputStream {
      * Throws the configured exception.
      *
      * @return nothing.
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public int available() throws IOException {
@@ -96,7 +96,7 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public void close() throws IOException {
@@ -107,7 +107,7 @@ public class BrokenInputStream extends InputStream {
      * Throws the configured exception.
      *
      * @return nothing.
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public int read() throws IOException {
@@ -117,7 +117,7 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public void reset() throws IOException {
@@ -138,7 +138,7 @@ public class BrokenInputStream extends InputStream {
      *
      * @param n ignored.
      * @return nothing.
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public long skip(final long n) throws IOException {

--- a/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
 import org.apache.commons.io.function.Erase;
 
 /**
- * Always throws an {@link IOException} from all the {@link InputStream} methods where the exception is declared.
+ * Always throws an exception from all {@link InputStream} methods where {@link IOException} is declared.
  * <p>
  * This class is mostly useful for testing error handling.
  * </p>
@@ -73,7 +73,7 @@ public class BrokenInputStream extends InputStream {
     }
 
     /**
-     * Constructs a new stream that always throws an {@link IOException}.
+     * Constructs a new stream that always throws the supplied exception.
      *
      * @param exceptionSupplier a supplier for the IOException or RuntimeException to be thrown.
      * @since 2.12.0
@@ -86,7 +86,7 @@ public class BrokenInputStream extends InputStream {
      * Throws the configured exception.
      *
      * @return nothing
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public int available() throws IOException {
@@ -96,7 +96,7 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public void close() throws IOException {
@@ -107,7 +107,7 @@ public class BrokenInputStream extends InputStream {
      * Throws the configured exception.
      *
      * @return nothing
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public int read() throws IOException {
@@ -117,7 +117,7 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public synchronized void reset() throws IOException {
@@ -138,7 +138,7 @@ public class BrokenInputStream extends InputStream {
      *
      * @param n ignored
      * @return nothing
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public long skip(final long n) throws IOException {

--- a/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
@@ -120,7 +120,7 @@ public class BrokenInputStream extends InputStream {
      * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         throw rethrow();
     }
 

--- a/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenInputStream.java
@@ -86,7 +86,7 @@ public class BrokenInputStream extends InputStream {
      * Throws the configured exception.
      *
      * @return nothing.
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public int available() throws IOException {
@@ -96,7 +96,7 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public void close() throws IOException {
@@ -107,7 +107,7 @@ public class BrokenInputStream extends InputStream {
      * Throws the configured exception.
      *
      * @return nothing.
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public int read() throws IOException {
@@ -117,7 +117,7 @@ public class BrokenInputStream extends InputStream {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public synchronized void reset() throws IOException {
@@ -138,7 +138,7 @@ public class BrokenInputStream extends InputStream {
      *
      * @param n ignored.
      * @return nothing.
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public long skip(final long n) throws IOException {

--- a/src/main/java/org/apache/commons/io/input/BrokenReader.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenReader.java
@@ -134,7 +134,7 @@ public class BrokenReader extends Reader {
      * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
-    public synchronized void reset() throws IOException {
+    public void reset() throws IOException {
         throw rethrow();
     }
 

--- a/src/main/java/org/apache/commons/io/input/BrokenReader.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenReader.java
@@ -134,7 +134,7 @@ public class BrokenReader extends Reader {
      * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         throw rethrow();
     }
 

--- a/src/main/java/org/apache/commons/io/input/BrokenReader.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenReader.java
@@ -85,7 +85,7 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public void close() throws IOException {
@@ -96,7 +96,7 @@ public class BrokenReader extends Reader {
      * Throws the configured exception.
      *
      * @param readAheadLimit ignored.
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public void mark(final int readAheadLimit) throws IOException {
@@ -110,7 +110,7 @@ public class BrokenReader extends Reader {
      * @param off  ignored.
      * @param len  ignored.
      * @return nothing.
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public int read(final char[] cbuf, final int off, final int len) throws IOException {
@@ -121,7 +121,7 @@ public class BrokenReader extends Reader {
      * Throws the configured exception.
      *
      * @return nothing.
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public boolean ready() throws IOException {
@@ -131,7 +131,7 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public void reset() throws IOException {
@@ -152,7 +152,7 @@ public class BrokenReader extends Reader {
      *
      * @param n ignored.
      * @return nothing.
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public long skip(final long n) throws IOException {

--- a/src/main/java/org/apache/commons/io/input/BrokenReader.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenReader.java
@@ -95,7 +95,7 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @param readAheadLimit ignored
+     * @param readAheadLimit ignored.
      * @throws IOException as configured.
      */
     @Override
@@ -106,10 +106,10 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @param cbuf ignored
-     * @param off  ignored
-     * @param len  ignored
-     * @return nothing
+     * @param cbuf ignored.
+     * @param off  ignored.
+     * @param len  ignored.
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override
@@ -120,7 +120,7 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @return nothing
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override
@@ -150,8 +150,8 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @param n ignored
-     * @return nothing
+     * @param n ignored.
+     * @return nothing.
      * @throws IOException as configured.
      */
     @Override

--- a/src/main/java/org/apache/commons/io/input/BrokenReader.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenReader.java
@@ -134,7 +134,7 @@ public class BrokenReader extends Reader {
      * @throws IOException as configured.
      */
     @Override
-    public synchronized void reset() throws IOException {
+    public void reset() throws IOException {
         throw rethrow();
     }
 

--- a/src/main/java/org/apache/commons/io/input/BrokenReader.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenReader.java
@@ -20,8 +20,10 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.function.Supplier;
 
+import org.apache.commons.io.function.Erase;
+
 /**
- * Always throws an {@link IOException} from all the {@link Reader} methods where the exception is declared.
+ * Always throws an exception from all {@link Reader} methods where {@link IOException} is declared.
  * <p>
  * This class is mostly useful for testing error handling.
  * </p>
@@ -40,7 +42,7 @@ public class BrokenReader extends Reader {
     /**
      * A supplier for the exception that is thrown by all methods of this class.
      */
-    private final Supplier<IOException> exceptionSupplier;
+    private final Supplier<Throwable> exceptionSupplier;
 
     /**
      * Constructs a new reader that always throws an {@link IOException}.
@@ -53,40 +55,52 @@ public class BrokenReader extends Reader {
      * Constructs a new reader that always throws the given exception.
      *
      * @param exception the exception to be thrown.
+     * @deprecated Use {@link #BrokenReader(Throwable)}.
      */
+    @Deprecated
     public BrokenReader(final IOException exception) {
         this(() -> exception);
     }
 
     /**
-     * Constructs a new reader that always throws an {@link IOException}
+     * Constructs a new reader that always throws the given exception.
      *
-     * @param exceptionSupplier a supplier for the exception to be thrown.
+     * @param exception the exception to be thrown.
+     * @since 2.16.0
+     */
+    public BrokenReader(final Throwable exception) {
+        this(() -> exception);
+    }
+
+    /**
+     * Constructs a new reader that always throws the supplied exception.
+     *
+     * @param exceptionSupplier a supplier for the IOException or RuntimeException to be thrown.
      * @since 2.12.0
      */
-    public BrokenReader(final Supplier<IOException> exceptionSupplier) {
+    public BrokenReader(final Supplier<Throwable> exceptionSupplier) {
         this.exceptionSupplier = exceptionSupplier;
     }
 
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public void close() throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
     }
 
     /**
      * Throws the configured exception.
      *
      * @param readAheadLimit ignored
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public void mark(final int readAheadLimit) throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
     }
 
     /**
@@ -96,32 +110,41 @@ public class BrokenReader extends Reader {
      * @param off  ignored
      * @param len  ignored
      * @return nothing
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public int read(final char[] cbuf, final int off, final int len) throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
     }
 
     /**
      * Throws the configured exception.
      *
      * @return nothing
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public boolean ready() throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
     }
 
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public synchronized void reset() throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
+    }
+
+    /**
+     * Throws the configured exception from its supplier.
+     *
+     * @return Throws the configured exception from its supplier.
+     */
+    private RuntimeException rethrow() {
+        return Erase.rethrow(exceptionSupplier.get());
     }
 
     /**
@@ -129,11 +152,11 @@ public class BrokenReader extends Reader {
      *
      * @param n ignored
      * @return nothing
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public long skip(final long n) throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
     }
 
 }

--- a/src/main/java/org/apache/commons/io/input/BrokenReader.java
+++ b/src/main/java/org/apache/commons/io/input/BrokenReader.java
@@ -85,7 +85,7 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public void close() throws IOException {
@@ -96,7 +96,7 @@ public class BrokenReader extends Reader {
      * Throws the configured exception.
      *
      * @param readAheadLimit ignored.
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public void mark(final int readAheadLimit) throws IOException {
@@ -110,7 +110,7 @@ public class BrokenReader extends Reader {
      * @param off  ignored.
      * @param len  ignored.
      * @return nothing.
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public int read(final char[] cbuf, final int off, final int len) throws IOException {
@@ -121,7 +121,7 @@ public class BrokenReader extends Reader {
      * Throws the configured exception.
      *
      * @return nothing.
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public boolean ready() throws IOException {
@@ -131,7 +131,7 @@ public class BrokenReader extends Reader {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public void reset() throws IOException {
@@ -152,7 +152,7 @@ public class BrokenReader extends Reader {
      *
      * @param n ignored.
      * @return nothing.
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public long skip(final long n) throws IOException {

--- a/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
@@ -85,7 +85,7 @@ public class BrokenOutputStream extends OutputStream {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public void close() throws IOException {
@@ -95,7 +95,7 @@ public class BrokenOutputStream extends OutputStream {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public void flush() throws IOException {
@@ -115,7 +115,7 @@ public class BrokenOutputStream extends OutputStream {
      * Throws the configured exception.
      *
      * @param b ignored.
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public void write(final int b) throws IOException {

--- a/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
@@ -33,14 +33,14 @@ import org.apache.commons.io.function.Erase;
 public class BrokenOutputStream extends OutputStream {
 
     /**
-     * A singleton instance using a default IOException.
+     * The singleton instance using a default IOException.
      *
      * @since 2.12.0
      */
     public static final BrokenOutputStream INSTANCE = new BrokenOutputStream();
 
     /**
-     * A supplier for the exception that is thrown by all methods of this class.
+     * Supplies the exception that is thrown by all methods of this class.
      */
     private final Supplier<Throwable> exceptionSupplier;
 

--- a/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
@@ -20,9 +20,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.function.Supplier;
 
+import org.apache.commons.io.function.Erase;
+
 /**
- * Broken output stream. This stream always throws an {@link IOException} from
- * all {@link OutputStream} methods.
+ * Always throws an exception from all {@link OutputStream} methods where {@link IOException} is declared.
  * <p>
  * This class is mostly useful for testing error handling in code that uses an
  * output stream.
@@ -42,7 +43,7 @@ public class BrokenOutputStream extends OutputStream {
     /**
      * A supplier for the exception that is thrown by all methods of this class.
      */
-    private final Supplier<IOException> exceptionSupplier;
+    private final Supplier<Throwable> exceptionSupplier;
 
     /**
      * Constructs a new stream that always throws an {@link IOException}.
@@ -55,50 +56,71 @@ public class BrokenOutputStream extends OutputStream {
      * Constructs a new stream that always throws the given exception.
      *
      * @param exception the exception to be thrown.
+     * @deprecated Use {@link #BrokenOutputStream(Throwable)}.
      */
+    @Deprecated
     public BrokenOutputStream(final IOException exception) {
         this(() -> exception);
     }
 
     /**
-     * Constructs a new stream that always throws an {@link IOException}.
+     * Constructs a new stream that always throws the given exception.
      *
-     * @param exceptionSupplier a supplier for the exception to be thrown.
+     * @param exception the exception to be thrown.
+     * @since 2.16.0
+     */
+    public BrokenOutputStream(final Throwable exception) {
+        this(() -> exception);
+    }
+
+    /**
+     * Constructs a new stream that always throws the supplied exception.
+     *
+     * @param exceptionSupplier a supplier for the IOException or RuntimeException to be thrown.
      * @since 2.12.0
      */
-    public BrokenOutputStream(final Supplier<IOException> exceptionSupplier) {
+    public BrokenOutputStream(final Supplier<Throwable> exceptionSupplier) {
         this.exceptionSupplier = exceptionSupplier;
     }
 
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public void close() throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
     }
 
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public void flush() throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
+    }
+
+    /**
+     * Throws the configured exception from its supplier.
+     *
+     * @return Throws the configured exception from its supplier.
+     */
+    private RuntimeException rethrow() {
+        return Erase.rethrow(exceptionSupplier.get());
     }
 
     /**
      * Throws the configured exception.
      *
      * @param b ignored
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public void write(final int b) throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
     }
 
 }

--- a/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
@@ -85,7 +85,7 @@ public class BrokenOutputStream extends OutputStream {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public void close() throws IOException {
@@ -95,7 +95,7 @@ public class BrokenOutputStream extends OutputStream {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public void flush() throws IOException {
@@ -115,7 +115,7 @@ public class BrokenOutputStream extends OutputStream {
      * Throws the configured exception.
      *
      * @param b ignored.
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public void write(final int b) throws IOException {

--- a/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenOutputStream.java
@@ -25,8 +25,7 @@ import org.apache.commons.io.function.Erase;
 /**
  * Always throws an exception from all {@link OutputStream} methods where {@link IOException} is declared.
  * <p>
- * This class is mostly useful for testing error handling in code that uses an
- * output stream.
+ * This class is mostly useful for testing error handling.
  * </p>
  *
  * @since 2.0
@@ -34,7 +33,7 @@ import org.apache.commons.io.function.Erase;
 public class BrokenOutputStream extends OutputStream {
 
     /**
-     * A singleton instance.
+     * A singleton instance using a default IOException.
      *
      * @since 2.12.0
      */
@@ -115,7 +114,7 @@ public class BrokenOutputStream extends OutputStream {
     /**
      * Throws the configured exception.
      *
-     * @param b ignored
+     * @param b ignored.
      * @throws IOException as configured.
      */
     @Override

--- a/src/main/java/org/apache/commons/io/output/BrokenWriter.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenWriter.java
@@ -33,14 +33,14 @@ import org.apache.commons.io.function.Erase;
 public class BrokenWriter extends Writer {
 
     /**
-     * A singleton instance using a default IOException.
+     * The singleton instance using a default IOException.
      *
      * @since 2.12.0
      */
     public static final BrokenWriter INSTANCE = new BrokenWriter();
 
     /**
-     * A supplier for the exception that is thrown by all methods of this class.
+     * Supplies the exception that is thrown by all methods of this class.
      */
     private final Supplier<Throwable> exceptionSupplier;
 

--- a/src/main/java/org/apache/commons/io/output/BrokenWriter.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenWriter.java
@@ -25,7 +25,7 @@ import org.apache.commons.io.function.Erase;
 /**
  * Always throws an exception from all {@link Writer} methods where {@link IOException} is declared.
  * <p>
- * This class is mostly useful for testing error handling in code that uses a writer.
+ * This class is mostly useful for testing error handling.
  * </p>
  *
  * @since 2.0
@@ -33,7 +33,7 @@ import org.apache.commons.io.function.Erase;
 public class BrokenWriter extends Writer {
 
     /**
-     * The singleton instance.
+     * A singleton instance using a default IOException.
      *
      * @since 2.12.0
      */
@@ -114,9 +114,9 @@ public class BrokenWriter extends Writer {
     /**
      * Throws the configured exception.
      *
-     * @param cbuf ignored
-     * @param off ignored
-     * @param len ignored
+     * @param cbuf ignored.
+     * @param off  ignored.
+     * @param len  ignored.
      * @throws IOException as configured.
      */
     @Override

--- a/src/main/java/org/apache/commons/io/output/BrokenWriter.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenWriter.java
@@ -85,7 +85,7 @@ public class BrokenWriter extends Writer {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public void close() throws IOException {
@@ -95,7 +95,7 @@ public class BrokenWriter extends Writer {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public void flush() throws IOException {
@@ -117,7 +117,7 @@ public class BrokenWriter extends Writer {
      * @param cbuf ignored.
      * @param off  ignored.
      * @param len  ignored.
-     * @throws IOException always throws the exception configured in the constructor.
+     * @throws IOException always throws the exception configured in a constructor.
      */
     @Override
     public void write(final char[] cbuf, final int off, final int len) throws IOException {

--- a/src/main/java/org/apache/commons/io/output/BrokenWriter.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenWriter.java
@@ -85,7 +85,7 @@ public class BrokenWriter extends Writer {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public void close() throws IOException {
@@ -95,7 +95,7 @@ public class BrokenWriter extends Writer {
     /**
      * Throws the configured exception.
      *
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public void flush() throws IOException {
@@ -117,7 +117,7 @@ public class BrokenWriter extends Writer {
      * @param cbuf ignored.
      * @param off  ignored.
      * @param len  ignored.
-     * @throws IOException as configured.
+     * @throws IOException always throws the exception configured in the constructor.
      */
     @Override
     public void write(final char[] cbuf, final int off, final int len) throws IOException {

--- a/src/main/java/org/apache/commons/io/output/BrokenWriter.java
+++ b/src/main/java/org/apache/commons/io/output/BrokenWriter.java
@@ -20,8 +20,10 @@ import java.io.IOException;
 import java.io.Writer;
 import java.util.function.Supplier;
 
+import org.apache.commons.io.function.Erase;
+
 /**
- * Always throws an {@link IOException} from all {@link Writer} methods.
+ * Always throws an exception from all {@link Writer} methods where {@link IOException} is declared.
  * <p>
  * This class is mostly useful for testing error handling in code that uses a writer.
  * </p>
@@ -40,7 +42,7 @@ public class BrokenWriter extends Writer {
     /**
      * A supplier for the exception that is thrown by all methods of this class.
      */
-    private final Supplier<IOException> exceptionSupplier;
+    private final Supplier<Throwable> exceptionSupplier;
 
     /**
      * Constructs a new writer that always throws an {@link IOException}.
@@ -53,39 +55,60 @@ public class BrokenWriter extends Writer {
      * Constructs a new writer that always throws the given exception.
      *
      * @param exception the exception to be thrown.
+     * @deprecated Use {@link #BrokenWriter(Throwable)}.
      */
+    @Deprecated
     public BrokenWriter(final IOException exception) {
         this(() -> exception);
     }
 
     /**
-     * Constructs a new writer that always throws an {@link IOException}.
+     * Constructs a new writer that always throws the given exception.
      *
-     * @param exceptionSupplier a supplier for the exception to be thrown.
+     * @param exception the exception to be thrown.
+     * @since 2.16.0
+     */
+    public BrokenWriter(final Throwable exception) {
+        this(() -> exception);
+    }
+
+    /**
+     * Constructs a new writer that always throws the supplied exception.
+     *
+     * @param exceptionSupplier a supplier for the IOException or RuntimeException to be thrown.
      * @since 2.12.0
      */
-    public BrokenWriter(final Supplier<IOException> exceptionSupplier) {
+    public BrokenWriter(final Supplier<Throwable> exceptionSupplier) {
         this.exceptionSupplier = exceptionSupplier;
     }
 
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public void close() throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
     }
 
     /**
      * Throws the configured exception.
      *
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public void flush() throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
+    }
+
+    /**
+     * Throws the configured exception from its supplier.
+     *
+     * @return Throws the configured exception from its supplier.
+     */
+    private RuntimeException rethrow() {
+        return Erase.rethrow(exceptionSupplier.get());
     }
 
     /**
@@ -94,11 +117,11 @@ public class BrokenWriter extends Writer {
      * @param cbuf ignored
      * @param off ignored
      * @param len ignored
-     * @throws IOException always thrown
+     * @throws IOException as configured.
      */
     @Override
     public void write(final char[] cbuf, final int off, final int len) throws IOException {
-        throw exceptionSupplier.get();
+        throw rethrow();
     }
 
 }

--- a/src/test/java/org/apache/commons/io/BrokenTestFactories.java
+++ b/src/test/java/org/apache/commons/io/BrokenTestFactories.java
@@ -22,7 +22,7 @@ import java.nio.file.FileSystemNotFoundException;
 import java.util.stream.Stream;
 
 /**
- * Factory for parameterized tests of BrokenInputStream / BrokenReader / BrokenOutputStream / BrokenWriter
+ * Factory for parameterized tests of BrokenInputStream, BrokenReader, BrokenOutputStream, and BrokenWriter.
  */
 public class BrokenTestFactories {
 

--- a/src/test/java/org/apache/commons/io/BrokenTestFactories.java
+++ b/src/test/java/org/apache/commons/io/BrokenTestFactories.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.file.FileSystemNotFoundException;
+import java.util.stream.Stream;
+
+/**
+ * Factory for parameterized tests of BrokenInputStream / BrokenReader / BrokenOutputStream / BrokenWriter
+ */
+public class BrokenTestFactories {
+
+    public static final class CustomException extends Exception {
+
+        private static final long serialVersionUID = 1L;
+
+    }
+
+    public static Stream<Class<? extends Throwable>> parameters() {
+        // @formatter:off
+        return Stream.of(
+            IOException.class,
+            FileNotFoundException.class,
+            FileSystemNotFoundException.class,
+            RuntimeException.class,
+            IllegalArgumentException.class,
+            IllegalStateException.class,
+            Error.class,
+            ExceptionInInitializerError.class,
+            CustomException.class
+        );
+        // @formatter:on
+    }
+}

--- a/src/test/java/org/apache/commons/io/input/BrokenInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BrokenInputStreamTest.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class BrokenInputStreamTest {
 
-    static final class CustomeException extends Exception {
+    static final class CustomException extends Exception {
 
         private static final long serialVersionUID = 1L;
 
@@ -51,12 +51,12 @@ public class BrokenInputStreamTest {
             IllegalStateException.class,
             Error.class,
             ExceptionInInitializerError.class,
-            CustomeException.class
+            CustomException.class
         );
         // @formatter:on
     }
 
-    private BrokenInputStream createBrokenInputStream(final Throwable exception) {
+    private static BrokenInputStream createBrokenInputStream(final Throwable exception) {
         if (exception instanceof IOException) {
             return new BrokenInputStream((IOException) exception);
         }
@@ -69,7 +69,7 @@ public class BrokenInputStreamTest {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
         final BrokenInputStream stream = createBrokenInputStream(exception);
-        assertEquals(exception, assertThrows(exception.getClass(), () -> stream.available()));
+        assertEquals(exception, assertThrows(clazz, () -> stream.available()));
     }
 
     @ParameterizedTest
@@ -78,7 +78,7 @@ public class BrokenInputStreamTest {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
         final BrokenInputStream stream = createBrokenInputStream(exception);
-        assertEquals(exception, assertThrows(exception.getClass(), () -> stream.close()));
+        assertEquals(exception, assertThrows(clazz, () -> stream.close()));
     }
 
     @ParameterizedTest
@@ -87,9 +87,9 @@ public class BrokenInputStreamTest {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
         final BrokenInputStream stream = createBrokenInputStream(exception);
-        assertEquals(exception, assertThrows(exception.getClass(), () -> stream.read()));
-        assertEquals(exception, assertThrows(exception.getClass(), () -> stream.read(new byte[1])));
-        assertEquals(exception, assertThrows(exception.getClass(), () -> stream.read(new byte[1], 0, 1)));
+        assertEquals(exception, assertThrows(clazz, () -> stream.read()));
+        assertEquals(exception, assertThrows(clazz, () -> stream.read(new byte[1])));
+        assertEquals(exception, assertThrows(clazz, () -> stream.read(new byte[1], 0, 1)));
     }
 
     @ParameterizedTest
@@ -98,7 +98,7 @@ public class BrokenInputStreamTest {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
         final BrokenInputStream stream = createBrokenInputStream(exception);
-        assertEquals(exception, assertThrows(exception.getClass(), () -> stream.reset()));
+        assertEquals(exception, assertThrows(clazz, () -> stream.reset()));
     }
 
     @ParameterizedTest
@@ -107,11 +107,11 @@ public class BrokenInputStreamTest {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
         final BrokenInputStream stream = createBrokenInputStream(exception);
-        assertEquals(exception, assertThrows(exception.getClass(), () -> stream.skip(1)));
+        assertEquals(exception, assertThrows(clazz, () -> stream.skip(1)));
     }
 
     @Test
-    public void testTryWithResources() throws Exception {
+    public void testTryWithResources() {
         final IOException thrown = assertThrows(IOException.class, () -> {
             try (InputStream newStream = new BrokenInputStream()) {
                 newStream.read();

--- a/src/test/java/org/apache/commons/io/input/BrokenInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BrokenInputStreamTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.io.input;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
@@ -81,6 +82,11 @@ public class BrokenInputStreamTest {
         assertEquals(exception, assertThrows(clazz, () -> stream.close()));
     }
 
+    @Test
+    public void testInstance() {
+        assertNotNull(BrokenInputStream.INSTANCE);
+    }
+
     @ParameterizedTest
     @MethodSource("parameters")
     public void testRead(final Class<Exception> clazz) throws Exception {
@@ -124,4 +130,5 @@ public class BrokenInputStreamTest {
         assertEquals(IOException.class, suppressed[0].getClass());
         assertEquals("Broken input stream", suppressed[0].getMessage());
     }
+
 }

--- a/src/test/java/org/apache/commons/io/input/BrokenInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BrokenInputStreamTest.java
@@ -20,11 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.file.FileSystemNotFoundException;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,28 +32,6 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class BrokenInputStreamTest {
 
-    static final class CustomException extends Exception {
-
-        private static final long serialVersionUID = 1L;
-
-    }
-
-    static Stream<Class<? extends Throwable>> parameters() {
-        // @formatter:off
-        return Stream.of(
-            IOException.class,
-            FileNotFoundException.class,
-            FileSystemNotFoundException.class,
-            RuntimeException.class,
-            IllegalArgumentException.class,
-            IllegalStateException.class,
-            Error.class,
-            ExceptionInInitializerError.class,
-            CustomException.class
-        );
-        // @formatter:on
-    }
-
     private static BrokenInputStream createBrokenInputStream(final Throwable exception) {
         if (exception instanceof IOException) {
             return new BrokenInputStream((IOException) exception);
@@ -65,7 +40,7 @@ public class BrokenInputStreamTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testAvailable(final Class<Exception> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -74,7 +49,7 @@ public class BrokenInputStreamTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testClose(final Class<Exception> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -88,7 +63,7 @@ public class BrokenInputStreamTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testRead(final Class<Exception> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -99,7 +74,7 @@ public class BrokenInputStreamTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testReset(final Class<Exception> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -108,7 +83,7 @@ public class BrokenInputStreamTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testSkip(final Class<Exception> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")

--- a/src/test/java/org/apache/commons/io/input/BrokenReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/BrokenReaderTest.java
@@ -20,11 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Reader;
-import java.nio.file.FileSystemNotFoundException;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,28 +32,6 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class BrokenReaderTest {
 
-    static final class CustomException extends Exception {
-
-        private static final long serialVersionUID = 1L;
-
-    }
-
-    static Stream<Class<? extends Throwable>> parameters() {
-        // @formatter:off
-        return Stream.of(
-            IOException.class,
-            FileNotFoundException.class,
-            FileSystemNotFoundException.class,
-            RuntimeException.class,
-            IllegalArgumentException.class,
-            IllegalStateException.class,
-            Error.class,
-            ExceptionInInitializerError.class,
-            CustomException.class
-        );
-        // @formatter:on
-    }
-
     private static BrokenReader createBrokenReader(final Throwable exception) {
         if (exception instanceof IOException) {
             return new BrokenReader((IOException) exception);
@@ -65,7 +40,7 @@ public class BrokenReaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testClose(final Class<Exception> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -79,7 +54,7 @@ public class BrokenReaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testMark(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -88,7 +63,7 @@ public class BrokenReaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testRead(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -97,7 +72,7 @@ public class BrokenReaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testReadCharArray(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -106,7 +81,7 @@ public class BrokenReaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testReadCharArrayIndexed(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -115,7 +90,7 @@ public class BrokenReaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testReady(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -124,7 +99,7 @@ public class BrokenReaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testReset(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -133,7 +108,7 @@ public class BrokenReaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testSkip(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")

--- a/src/test/java/org/apache/commons/io/input/BrokenReaderTest.java
+++ b/src/test/java/org/apache/commons/io/input/BrokenReaderTest.java
@@ -20,30 +20,57 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.file.FileSystemNotFoundException;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests {@link BrokenReader}.
  */
 public class BrokenReaderTest {
 
-    private IOException exception;
+    static final class CustomException extends Exception {
 
-    private Reader brokenReader;
+        private static final long serialVersionUID = 1L;
 
-    @BeforeEach
-    public void setUp() {
-        exception = new IOException("test exception");
-        brokenReader = new BrokenReader(exception);
     }
 
-    @Test
-    public void testClose() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.close()));
+    static Stream<Class<? extends Throwable>> parameters() {
+        // @formatter:off
+        return Stream.of(
+            IOException.class,
+            FileNotFoundException.class,
+            FileSystemNotFoundException.class,
+            RuntimeException.class,
+            IllegalArgumentException.class,
+            IllegalStateException.class,
+            Error.class,
+            ExceptionInInitializerError.class,
+            CustomException.class
+        );
+        // @formatter:on
+    }
+
+    private static BrokenReader createBrokenReader(final Throwable exception) {
+        if (exception instanceof IOException) {
+            return new BrokenReader((IOException) exception);
+        }
+        return new BrokenReader(exception);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testClose(final Class<Exception> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenReader brokenReader = createBrokenReader(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenReader.close()));
     }
 
     @Test
@@ -51,39 +78,67 @@ public class BrokenReaderTest {
         assertNotNull(BrokenReader.INSTANCE);
     }
 
-    @Test
-    public void testMark() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.mark(1)));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testMark(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenReader brokenReader = createBrokenReader(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenReader.mark(1)));
     }
 
-    @Test
-    public void testRead() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.read()));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testRead(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenReader brokenReader = createBrokenReader(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenReader.read()));
     }
 
-    @Test
-    public void testReadCharArray() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.read(new char[1])));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testReadCharArray(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenReader brokenReader = createBrokenReader(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenReader.read(new char[1])));
     }
 
-    @Test
-    public void testReadCharArrayIndexed() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.read(new char[1], 0, 1)));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testReadCharArrayIndexed(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenReader brokenReader = createBrokenReader(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenReader.read(new char[1], 0, 1)));
     }
 
-    @Test
-    public void testReady() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.ready()));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testReady(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenReader brokenReader = createBrokenReader(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenReader.ready()));
     }
 
-    @Test
-    public void testReset() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.reset()));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testReset(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenReader brokenReader = createBrokenReader(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenReader.reset()));
     }
 
-    @Test
-    public void testSkip() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenReader.skip(1)));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testSkip(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenReader brokenReader = createBrokenReader(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenReader.skip(1)));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/output/BrokenOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/BrokenOutputStreamTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.io.output;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
@@ -79,6 +80,11 @@ public class BrokenOutputStreamTest {
         @SuppressWarnings("resource")
         final BrokenOutputStream stream = createBrokenOutputStream(exception);
         assertEquals(exception, assertThrows(clazz, () -> stream.flush()));
+    }
+
+    @Test
+    public void testInstance() {
+        assertNotNull(BrokenOutputStream.INSTANCE);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/output/BrokenOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/BrokenOutputStreamTest.java
@@ -19,35 +19,66 @@ package org.apache.commons.io.output;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.file.FileSystemNotFoundException;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests {@link BrokenOutputStream}.
  */
 public class BrokenOutputStreamTest {
 
-    private IOException exception;
+    static final class CustomException extends Exception {
 
-    private OutputStream stream;
+        private static final long serialVersionUID = 1L;
 
-    @BeforeEach
-    public void setUp() {
-        exception = new IOException("test exception");
-        stream = new BrokenOutputStream(exception);
     }
 
-    @Test
-    public void testClose() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.close()));
+    static Stream<Class<? extends Throwable>> parameters() {
+        // @formatter:off
+        return Stream.of(
+            IOException.class,
+            FileNotFoundException.class,
+            FileSystemNotFoundException.class,
+            RuntimeException.class,
+            IllegalArgumentException.class,
+            IllegalStateException.class,
+            Error.class,
+            ExceptionInInitializerError.class,
+            CustomException.class
+        );
+        // @formatter:on
     }
 
-    @Test
-    public void testFlush() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.flush()));
+    private static BrokenOutputStream createBrokenOutputStream(final Throwable exception) {
+        if (exception instanceof IOException) {
+            return new BrokenOutputStream((IOException) exception);
+        }
+        return new BrokenOutputStream(exception);
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testClose(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenOutputStream stream = createBrokenOutputStream(exception);
+        assertEquals(exception, assertThrows(clazz, () -> stream.close()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testFlush(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenOutputStream stream = createBrokenOutputStream(exception);
+        assertEquals(exception, assertThrows(clazz, () -> stream.flush()));
     }
 
     @Test
@@ -65,19 +96,31 @@ public class BrokenOutputStreamTest {
         assertEquals("Broken output stream", suppressed[0].getMessage());
     }
 
-    @Test
-    public void testWriteByteArray() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.write(new byte[1])));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testWriteByteArray(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenOutputStream stream = createBrokenOutputStream(exception);
+        assertEquals(exception, assertThrows(clazz, () -> stream.write(new byte[1])));
     }
 
-    @Test
-    public void testWriteByteArrayIndexed() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.write(new byte[1], 0, 1)));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testWriteByteArrayIndexed(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenOutputStream stream = createBrokenOutputStream(exception);
+        assertEquals(exception, assertThrows(clazz, () -> stream.write(new byte[1], 0, 1)));
     }
 
-    @Test
-    public void testWriteInt() {
-        assertEquals(exception, assertThrows(IOException.class, () -> stream.write(1)));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testWriteInt(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenOutputStream stream = createBrokenOutputStream(exception);
+        assertEquals(exception, assertThrows(clazz, () -> stream.write(1)));
     }
 
 }

--- a/src/test/java/org/apache/commons/io/output/BrokenOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/BrokenOutputStreamTest.java
@@ -20,11 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.file.FileSystemNotFoundException;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,28 +32,6 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class BrokenOutputStreamTest {
 
-    static final class CustomException extends Exception {
-
-        private static final long serialVersionUID = 1L;
-
-    }
-
-    static Stream<Class<? extends Throwable>> parameters() {
-        // @formatter:off
-        return Stream.of(
-            IOException.class,
-            FileNotFoundException.class,
-            FileSystemNotFoundException.class,
-            RuntimeException.class,
-            IllegalArgumentException.class,
-            IllegalStateException.class,
-            Error.class,
-            ExceptionInInitializerError.class,
-            CustomException.class
-        );
-        // @formatter:on
-    }
-
     private static BrokenOutputStream createBrokenOutputStream(final Throwable exception) {
         if (exception instanceof IOException) {
             return new BrokenOutputStream((IOException) exception);
@@ -65,7 +40,7 @@ public class BrokenOutputStreamTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testClose(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -74,7 +49,7 @@ public class BrokenOutputStreamTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testFlush(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -103,7 +78,7 @@ public class BrokenOutputStreamTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testWriteByteArray(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -112,7 +87,7 @@ public class BrokenOutputStreamTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testWriteByteArrayIndexed(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -121,7 +96,7 @@ public class BrokenOutputStreamTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testWriteInt(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")

--- a/src/test/java/org/apache/commons/io/output/BrokenWriterTest.java
+++ b/src/test/java/org/apache/commons/io/output/BrokenWriterTest.java
@@ -19,69 +19,124 @@ package org.apache.commons.io.output;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Writer;
+import java.nio.file.FileSystemNotFoundException;
+import java.util.stream.Stream;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests {@link BrokenWriter}.
  */
 public class BrokenWriterTest {
 
-    private IOException exception;
+    static final class CustomException extends Exception {
 
-    private Writer brokenWriter;
+        private static final long serialVersionUID = 1L;
 
-    @BeforeEach
-    public void setUp() {
-        exception = new IOException("test exception");
-        brokenWriter = new BrokenWriter(exception);
     }
 
-    @Test
-    public void testAppendChar() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.append('1')));
+    static Stream<Class<? extends Throwable>> parameters() {
+        // @formatter:off
+        return Stream.of(
+            IOException.class,
+            FileNotFoundException.class,
+            FileSystemNotFoundException.class,
+            RuntimeException.class,
+            IllegalArgumentException.class,
+            IllegalStateException.class,
+            Error.class,
+            ExceptionInInitializerError.class,
+            CustomException.class
+        );
+        // @formatter:on
     }
 
-    @Test
-    public void testAppendCharSequence() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.append("01")));
+    private static BrokenWriter createBrokenWriter(final Throwable exception) {
+        if (exception instanceof IOException) {
+            return new BrokenWriter((IOException) exception);
+        }
+        return new BrokenWriter(exception);
     }
 
-    @Test
-    public void testAppendCharSequenceIndexed() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.append("01", 0, 1)));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testAppendChar(final Class<Exception> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.append('1')));
     }
 
-    @Test
-    public void testClose() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.close()));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testAppendCharSequence(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.append("01")));
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testAppendCharSequenceIndexed(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.append("01", 0, 1)));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testClose(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.close()));
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameters")
     @Disabled("What should happen here?")
-    public void testEquals() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.equals(null)));
+    public void testEquals(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.equals(null)));
     }
 
-    @Test
-    public void testFlush() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.flush()));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testFlush(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.flush()));
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("parameters")
     @Disabled("What should happen here?")
-    public void testHashCode() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.hashCode()));
+    public void testHashCode(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.hashCode()));
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("parameters")
     @Disabled("What should happen here?")
-    public void testToString() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.toString()));
+    public void testToString(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.toString()));
     }
 
     @Test
@@ -99,29 +154,49 @@ public class BrokenWriterTest {
         assertEquals("Broken writer", suppressed[0].getMessage());
     }
 
-    @Test
-    public void testWriteCharArray() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.write(new char[1])));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testWriteCharArray(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.write(new char[1])));
     }
 
-    @Test
-    public void testWriteCharArrayIndexed() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.write(new char[1], 0, 1)));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testWriteCharArrayIndexed(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.write(new char[1], 0, 1)));
     }
 
-    @Test
-    public void testWriteInt() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.write(1)));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testWriteInt(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.write(1)));
     }
 
-    @Test
-    public void testWriteString() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.write("01")));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testWriteString(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.write("01")));
     }
 
-    @Test
-    public void testWriteStringIndexed() {
-        assertEquals(exception, assertThrows(IOException.class, () -> brokenWriter.write("01", 0, 1)));
+    @ParameterizedTest
+    @MethodSource("parameters")
+    public void testWriteStringIndexed(final Class<Throwable> clazz) throws Exception {
+        final Throwable exception = clazz.newInstance();
+        @SuppressWarnings("resource")
+        final BrokenWriter brokenWriter = createBrokenWriter(exception);
+        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.write("01", 0, 1)));
     }
 
 }

--- a/src/test/java/org/apache/commons/io/output/BrokenWriterTest.java
+++ b/src/test/java/org/apache/commons/io/output/BrokenWriterTest.java
@@ -20,11 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Writer;
-import java.nio.file.FileSystemNotFoundException;
-import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -35,28 +32,6 @@ import org.junit.jupiter.params.provider.MethodSource;
  */
 public class BrokenWriterTest {
 
-    static final class CustomException extends Exception {
-
-        private static final long serialVersionUID = 1L;
-
-    }
-
-    static Stream<Class<? extends Throwable>> parameters() {
-        // @formatter:off
-        return Stream.of(
-            IOException.class,
-            FileNotFoundException.class,
-            FileSystemNotFoundException.class,
-            RuntimeException.class,
-            IllegalArgumentException.class,
-            IllegalStateException.class,
-            Error.class,
-            ExceptionInInitializerError.class,
-            CustomException.class
-        );
-        // @formatter:on
-    }
-
     private static BrokenWriter createBrokenWriter(final Throwable exception) {
         if (exception instanceof IOException) {
             return new BrokenWriter((IOException) exception);
@@ -65,7 +40,7 @@ public class BrokenWriterTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testAppendChar(final Class<Exception> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -74,7 +49,7 @@ public class BrokenWriterTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testAppendCharSequence(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -83,7 +58,7 @@ public class BrokenWriterTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testAppendCharSequenceIndexed(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -92,7 +67,7 @@ public class BrokenWriterTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testClose(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -101,7 +76,7 @@ public class BrokenWriterTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testFlush(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -130,7 +105,7 @@ public class BrokenWriterTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testWriteCharArray(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -139,7 +114,7 @@ public class BrokenWriterTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testWriteCharArrayIndexed(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -148,7 +123,7 @@ public class BrokenWriterTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testWriteInt(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -157,7 +132,7 @@ public class BrokenWriterTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testWriteString(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -166,7 +141,7 @@ public class BrokenWriterTest {
     }
 
     @ParameterizedTest
-    @MethodSource("parameters")
+    @MethodSource("org.apache.commons.io.BrokenTestFactories#parameters")
     public void testWriteStringIndexed(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")

--- a/src/test/java/org/apache/commons/io/output/BrokenWriterTest.java
+++ b/src/test/java/org/apache/commons/io/output/BrokenWriterTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.io.output;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
@@ -25,7 +26,6 @@ import java.io.Writer;
 import java.nio.file.FileSystemNotFoundException;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -102,16 +102,6 @@ public class BrokenWriterTest {
 
     @ParameterizedTest
     @MethodSource("parameters")
-    @Disabled("What should happen here?")
-    public void testEquals(final Class<Throwable> clazz) throws Exception {
-        final Throwable exception = clazz.newInstance();
-        @SuppressWarnings("resource")
-        final BrokenWriter brokenWriter = createBrokenWriter(exception);
-        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.equals(null)));
-    }
-
-    @ParameterizedTest
-    @MethodSource("parameters")
     public void testFlush(final Class<Throwable> clazz) throws Exception {
         final Throwable exception = clazz.newInstance();
         @SuppressWarnings("resource")
@@ -119,24 +109,9 @@ public class BrokenWriterTest {
         assertEquals(exception, assertThrows(clazz, () -> brokenWriter.flush()));
     }
 
-    @ParameterizedTest
-    @MethodSource("parameters")
-    @Disabled("What should happen here?")
-    public void testHashCode(final Class<Throwable> clazz) throws Exception {
-        final Throwable exception = clazz.newInstance();
-        @SuppressWarnings("resource")
-        final BrokenWriter brokenWriter = createBrokenWriter(exception);
-        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.hashCode()));
-    }
-
-    @ParameterizedTest
-    @MethodSource("parameters")
-    @Disabled("What should happen here?")
-    public void testToString(final Class<Throwable> clazz) throws Exception {
-        final Throwable exception = clazz.newInstance();
-        @SuppressWarnings("resource")
-        final BrokenWriter brokenWriter = createBrokenWriter(exception);
-        assertEquals(exception, assertThrows(clazz, () -> brokenWriter.toString()));
+    @Test
+    public void testInstance() {
+        assertNotNull(BrokenWriter.INSTANCE);
     }
 
     @Test


### PR DESCRIPTION
As discussed in #528.

One point to note: Is there a reason to keep the deprecated constructors such as `BrokenInputStream(final IOException exception)`?  Given that the new constructors such as `BrokenInputStream(final Throwable exception)` accept a superclass of `IOException`, it seems the old constructor could be removed without a breaking change.