### PR TITLE
[IO-781] Fix CharSequenceInputStream coding exception handling

### DIFF
--- a/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/CharSequenceInputStream.java
@@ -186,6 +186,7 @@ public class CharSequenceInputStream extends InputStream {
             // Reset everything without filling the buffer
             // so the same exception can be thrown again later.
             this.bBuf.clear();
+            this.bBuf.flip();
             this.cBuf.rewind();
         }
     }

--- a/src/test/java/org/apache/commons/io/input/CharSequenceInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/CharSequenceInputStreamTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -31,7 +32,9 @@ import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.CoderResult;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnmappableCharacterException;
 import java.util.Random;
 
 import org.apache.commons.io.CharsetsTest;
@@ -523,5 +526,16 @@ public class CharSequenceInputStreamTest {
             r.skip(100);
             assertEquals(-1, r.read(), csName);
         }
+    }
+
+    @Test
+    public void testCharacterCodingException() throws IOException {
+        final Charset charset = StandardCharsets.US_ASCII;
+        final CharSequenceInputStream in = CharSequenceInputStream.builder()
+            .setCharsetEncoder(charset.newEncoder().onUnmappableCharacter(CodingErrorAction.REPORT))
+            .setCharSequence("\u0080")
+            .get();
+        assertEquals(0, in.available());
+        assertThrows(UnmappableCharacterException.class, in::read);
     }
 }


### PR DESCRIPTION
Follow-up for #525 (CC @elharo)

A `bBuf.flip()` call was missing so the `bBuf` was erroneously `HeapByteBuffer[pos=0 lim=8192]` (instead of `pos=0 lim=0`), and was therefore considered completely filled with 0s.
This can be seen with the newly added test which would have failed.