### PR TITLE
Javadoc shouldn't reference 1.x behavior

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -2946,10 +2946,9 @@ public class FileUtils {
     /**
      * Converts from a {@link URL} to a {@link File}.
      * <p>
-     * From version 1.1 this method will decode the URL.
      * Syntax such as {@code file:///my%20docs/file.txt} will be
-     * correctly decoded to {@code /my docs/file.txt}. Starting with version
-     * 1.5, this method uses UTF-8 to decode percent-encoded octets to characters.
+     * correctly decoded to {@code /my docs/file.txt}.
+     * UTF-8 is used to decode percent-encoded octets to characters.
      * Additionally, malformed percent-encoded octets are handled leniently by
      * passing them through literally.
      * </p>

--- a/src/main/java/org/apache/commons/io/input/CountingInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/CountingInputStream.java
@@ -74,7 +74,7 @@ public class CountingInputStream extends ProxyInputStream {
     /**
      * Gets number of bytes that have passed through this stream.
      * <p>
-     * NOTE: From v1.3 this method throws an ArithmeticException if the
+     * This method throws an ArithmeticException if the
      * count is greater than can be expressed by an {@code int}.
      * See {@link #getByteCount()} for a method using a {@code long}.
      * </p>
@@ -112,7 +112,7 @@ public class CountingInputStream extends ProxyInputStream {
     /**
      * Resets the byte count back to 0.
      * <p>
-     * NOTE: From v1.3 this method throws an ArithmeticException if the
+     * This method throws an ArithmeticException if the
      * count is greater than can be expressed by an {@code int}.
      * See {@link #resetByteCount()} for a method using a {@code long}.
      * </p>


### PR DESCRIPTION
@garydgregory minor cleanup