### PR TITLE
Test that char sequences can be read in multiple encodings

### DIFF
--- a/src/test/java/org/apache/commons/io/build/CharSequenceOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/CharSequenceOriginTest.java
@@ -16,10 +16,12 @@
  */
 package org.apache.commons.io.build;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
@@ -68,4 +70,12 @@ public class CharSequenceOriginTest extends AbstractOriginTest<CharSequence, Cha
         assertThrows(UnsupportedOperationException.class, super::testGetWriter);
     }
 
+    @Test
+    public void testGetReader_UTF16() throws IOException {
+        CharSequenceOrigin origin = new CharSequenceOrigin("This is a test");
+        Reader reader16 = origin.getReader(StandardCharsets.UTF_16);
+        Reader reader8 = origin.getReader(StandardCharsets.UTF_8);
+        assertEquals(reader8.read(), reader16.read());
+    }
+    
 }

--- a/src/test/java/org/apache/commons/io/build/CharSequenceOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/CharSequenceOriginTest.java
@@ -72,10 +72,11 @@ public class CharSequenceOriginTest extends AbstractOriginTest<CharSequence, Cha
 
     @Test
     public void testGetReader_UTF16() throws IOException {
-        CharSequenceOrigin origin = new CharSequenceOrigin("This is a test");
-        Reader reader16 = origin.getReader(StandardCharsets.UTF_16);
-        Reader reader8 = origin.getReader(StandardCharsets.UTF_8);
+        // Because CharSequences are defined as characters, they don't depend on byte encoding.
+        final CharSequenceOrigin origin = new CharSequenceOrigin("This is a test");
+        final Reader reader16 = origin.getReader(StandardCharsets.UTF_16);
+        final Reader reader8 = origin.getReader(StandardCharsets.UTF_8);
         assertEquals(reader8.read(), reader16.read());
     }
-    
+
 }


### PR DESCRIPTION
The bug occurs when the default character set is different than the specified character set. Since we don't know the default character set in which the test runs a priori, test two incompatible character sets against each other. They can't both be the default character set. 