### PR TITLE
Amend getFullPathNoEndSeparator description for trailing slash home path behaviour

### DIFF
--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -667,7 +667,7 @@ public class FilenameUtils {
      * C:           --&gt; C:
      * C:\          --&gt; C:\
      * ~            --&gt; ~
-     * ~/           --&gt; ~
+     * ~/           --&gt; ~/
      * ~user        --&gt; ~user
      * ~user/       --&gt; ~user
      * </pre>


### PR DESCRIPTION
The description says it will remove the trailing slash from a home path (relative path starting with tilde).

A simple

```java
        @Test void returnsHomeWithTrailingSlash_forHomeWithTrailingSlash() {
            assertThat(FileHelper.getParent("~/")).isEqualTo("~/");
        }
```

proves otherwise.

This fixes the description accordingly.