### PR TITLE
Amend description to reflect empty string result for windows drive

### DIFF
--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -664,7 +664,7 @@ public class FilenameUtils {
      * a.txt        --&gt; ""
      * a/b/c        --&gt; a/b
      * a/b/c/       --&gt; a/b/c
-     * C:           --&gt; C:
+     * C:           --&gt; ""
      * C:\          --&gt; C:\
      * ~            --&gt; ~
      * ~/           --&gt; ~


### PR DESCRIPTION
Not sure if this is is a bug or a feature – what i can confirm is that in v2.4 it worked as it said in the description:

```java
@Test void returnsHomeWithTrailingSlash_forHomeWithTrailingSlash() {
    assertThat(FilenameUtils.getFullPathNoEndSeparator("C:")).isEqualTo("C:");
}
```

After upgrading to 2.15.1, i realized my test suite failed, the behaviour is now:
```java
@Test void returnsHomeWithTrailingSlash_forHomeWithTrailingSlash() {
    assertThat(FilenameUtils.getFullPathNoEndSeparator("C:")).isEqualTo("");
}
```

This PR proposes to reflect this change in the javadoc.