### PR TITLE
Amend description to reflect correct named user result with trailing slash

### DIFF
--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -669,7 +669,7 @@ public class FilenameUtils {
      * ~            --&gt; ~
      * ~/           --&gt; ~
      * ~user        --&gt; ~user
-     * ~user/       --&gt; ~user
+     * ~user/       --&gt; ~user/
      * </pre>
      * <p>
      * The output will be the same irrespective of the machine that the code is running on.


### PR DESCRIPTION
Similar to #551, the trailing slash is actually preserved in the result here.

Confirmed to have this behaviour in 2.4 and latest 2.15.1