### PR TITLE
[IO-842] deprecate writeLines methods without a charset

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -3297,7 +3297,9 @@ public class FileUtils {
      * @param lines the lines to write, {@code null} entries produce blank lines
      * @throws IOException in case of an I/O error
      * @since 1.3
+     * @deprecated use {@link #writeLines(File, String, Collection)} instead (and specify the appropriate encoding)
      */
+    @Deprecated
     public static void writeLines(final File file, final Collection<?> lines) throws IOException {
         writeLines(file, null, lines, null, false);
     }
@@ -3313,7 +3315,9 @@ public class FileUtils {
      *               end of the file rather than overwriting
      * @throws IOException in case of an I/O error
      * @since 2.1
+     * @deprecated use {@link #writeLines(File, String, Collection, boolean)} instead (and specify the appropriate encoding)
      */
+    @Deprecated
     public static void writeLines(final File file, final Collection<?> lines, final boolean append) throws IOException {
         writeLines(file, null, lines, null, append);
     }
@@ -3328,7 +3332,9 @@ public class FileUtils {
      * @param lineEnding the line separator to use, {@code null} is system default
      * @throws IOException in case of an I/O error
      * @since 1.3
+     * @deprecated use {@link #writeLines(File, String, Collection, String)} instead (and specify the appropriate encoding)
      */
+    @Deprecated
     public static void writeLines(final File file, final Collection<?> lines, final String lineEnding) throws IOException {
         writeLines(file, null, lines, lineEnding, false);
     }
@@ -3345,7 +3351,9 @@ public class FileUtils {
      *                   end of the file rather than overwriting
      * @throws IOException in case of an I/O error
      * @since 2.1
+     * @deprecated use {@link #writeLines(File, String, Collection, boolean)} instead and specify the appropriate encoding
      */
+    @Deprecated
     public static void writeLines(final File file, final Collection<?> lines, final String lineEnding, final boolean append) throws IOException {
         writeLines(file, null, lines, lineEnding, append);
     }
@@ -3363,7 +3371,7 @@ public class FileUtils {
      * @param charsetName the name of the requested charset, {@code null} means platform default
      * @param lines    the lines to write, {@code null} entries produce blank lines
      * @throws IOException                          in case of an I/O error
-     * @throws java.io.UnsupportedEncodingException if the encoding is not supported by the VM
+     * @throws java.nio.charset.UnsupportedCharsetException if the encoding is not supported by the VM
      * @since 1.1
      */
     public static void writeLines(final File file, final String charsetName, final Collection<?> lines) throws IOException {
@@ -3381,7 +3389,7 @@ public class FileUtils {
      * @param append   if {@code true}, then the lines will be added to the
      *                 end of the file rather than overwriting
      * @throws IOException                          in case of an I/O error
-     * @throws java.io.UnsupportedEncodingException if the encoding is not supported by the VM
+     * @throws java.nio.charset.UnsupportedCharsetException if the encoding is not supported by the VM
      * @since 2.1
      */
     public static void writeLines(final File file, final String charsetName, final Collection<?> lines, final boolean append) throws IOException {
@@ -3402,7 +3410,7 @@ public class FileUtils {
      * @param lines      the lines to write, {@code null} entries produce blank lines
      * @param lineEnding the line separator to use, {@code null} is system default
      * @throws IOException                          in case of an I/O error
-     * @throws java.io.UnsupportedEncodingException if the encoding is not supported by the VM
+     * @throws java.nio.charset.UnsupportedCharsetException if the encoding is not supported by the VM
      * @since 1.1
      */
     public static void writeLines(final File file, final String charsetName, final Collection<?> lines, final String lineEnding) throws IOException {
@@ -3421,7 +3429,7 @@ public class FileUtils {
      * @param append     if {@code true}, then the lines will be added to the
      *                   end of the file rather than overwriting
      * @throws IOException                          in case of an I/O error
-     * @throws java.io.UnsupportedEncodingException if the encoding is not supported by the VM
+     * @throws java.nio.charset.UnsupportedCharsetException if the encoding is not supported by the VM
      * @since 2.1
      */
     public static void writeLines(final File file, final String charsetName, final Collection<?> lines, final String lineEnding, final boolean append)

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -3876,9 +3876,7 @@ public class IOUtils {
      * @param charsetName the name of the requested charset, null means platform default
      * @throws NullPointerException                         if the output is null
      * @throws IOException                                  if an I/O error occurs
-     * @throws java.nio.charset.UnsupportedCharsetException thrown instead of {@link java.io
-     *                                                      .UnsupportedEncodingException} in version 2.2 if the
-     *                                                      encoding is not supported.
+     * @throws java.nio.charset.UnsupportedCharsetException if the encoding is not supported
      * @since 1.1
      */
     public static void writeLines(final Collection<?> lines, final String lineEnding,

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -3161,6 +3161,14 @@ public class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
+    public void testWriteLinesUnsupportedCharset() throws Exception {
+        final File file = TestUtils.newFile(tempDirFile, "lines.txt");
+
+        final List<String> lines = Arrays.asList("my first line", "The second Line");
+        assertThrows(UnsupportedCharsetException.class, () -> FileUtils.writeLines(file, "there_is_no_such_charset", lines));
+    }
+
+    @Test
     public void testWriteStringToFile_WithAppendOptionFalse_ShouldDeletePreviousFileLines() throws Exception {
         final File file = TestUtils.newFile(tempDirFile, "lines.txt");
         FileUtils.writeStringToFile(file, "This line was there before you...");


### PR DESCRIPTION
Also corrects Javadoc about which exception is thrown when the charset is not recognized and adds test for same. Note that the exception thrown is not changed here. I brought the documentation into sync with the actual pre-existing behavior. @garydgregory 