### PR TITLE
Modify Builder.get error condition

### DIFF
--- a/src/main/java/org/apache/commons/io/input/RandomAccessFileInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/RandomAccessFileInputStream.java
@@ -73,12 +73,17 @@ public class RandomAccessFileInputStream extends InputStream {
         @SuppressWarnings("resource") // Caller closes depending on settings
         @Override
         public RandomAccessFileInputStream get() throws IOException {
+            if (randomAccessFile == null && getOrigin() == null) {
+                throw new UnsupportedOperationException("Neither RandomAccessFile nor origin is set.");
+            }
+            if (randomAccessFile != null && getOrigin() != null) {
+                throw new IllegalStateException(String.format("Only set one of RandomAccessFile (%s) or origin (%s)", randomAccessFile, getOrigin()));
+            }
+
             if (randomAccessFile != null) {
-                if (getOrigin() != null) {
-                    throw new IllegalStateException(String.format("Only set one of RandomAccessFile (%s) or origin (%s)", randomAccessFile, getOrigin()));
-                }
                 return new RandomAccessFileInputStream(randomAccessFile, closeOnClose);
             }
+
             return new RandomAccessFileInputStream(RandomAccessFileMode.READ_ONLY.create(getOrigin().getFile()), closeOnClose);
         }
 

--- a/src/test/java/org/apache/commons/io/input/RandomAccessFileInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/RandomAccessFileInputStreamTest.java
@@ -113,6 +113,14 @@ public class RandomAccessFileInputStreamTest {
 
     @SuppressWarnings("resource") // instance variable access
     @Test
+    public void testBuilderNoFileNoOrigin() throws IOException {
+        assertThrows(UnsupportedOperationException.class, () -> {
+            RandomAccessFileInputStream.builder().get();
+        });
+    }
+
+    @SuppressWarnings("resource") // instance variable access
+    @Test
     public void testConstructorCloseOnCloseFalse() throws IOException {
         try (RandomAccessFile file = createRandomAccessFile()) {
             try (RandomAccessFileInputStream inputStream = new RandomAccessFileInputStream(file, false)) {


### PR DESCRIPTION
The `Builder.get` method claims to throw an `UnsupportedOperationException` if its origin is invalid. However, it actually throws a `NullPointerException` if the origin is `null`.
This commit changes the workflow to take care of cases where neither `RandomAccessFile` nor origin is set.