### PR TITLE
Add characterization test for copying a symlinked directory

### DIFF
--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -1129,10 +1129,10 @@ public class FileUtilsTest extends AbstractTempDirTest {
         FileUtils.writeStringToFile(content, "HELLO WORLD", "UTF8");
 
         // Make a symlink to the directory
-        final Path linkPath = realDirectory.toPath().resolve("link_to_directory");
+        final Path linkPath = tempDirFile.toPath().resolve("link_to_directory");
         Files.createSymbolicLink(linkPath, realDirectory.toPath());
 
-        // Now copy symlink to another directory
+        // Now copy symlink
         final File destination = new File(tempDirFile, "destination");
 
         // Is the copy a symlink or an actual directory?

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -1144,7 +1144,7 @@ public class FileUtilsTest extends AbstractTempDirTest {
 
         assertFalse(Files.isSymbolicLink(destination.toPath()));
         final File copied_content = new File(destination, "hello.txt");
-        String actual = FileUtils.readFileToString(copied_content, "UTF8");
+        final String actual = FileUtils.readFileToString(copied_content, "UTF8");
         assertEquals("HELLO WORLD", actual);
     }
 


### PR DESCRIPTION
See what happens when copyDirectory copies a directory that is a symlink to another directory containing non-symlinked files. This is a characterization test to explore current behavior, and arguably represents a bug. This behavior, and the test, is likely to change and should not be relied on.

FYI the second test added here that creates a symlink cycle would have exposed a bug that exists in the most recent release. (I rolled back a couple of months and the test failed then but not now) That bug was fixed by copying symlinks as symlinks rather than by following the links. If we decide to revert to the old follow links behavior, we will need to figure out what we want to do about symlink cycles like this.

@garydgregory @eamonnmcmanus

This is from the test as it fails in the release. At least it doesn't infinitely loop. It's a little worrisome that I can't explain why it loops for a while and then stops. It might be hitting an OS level MAXSYMLINKS limit or a maximum path length.

`java.io.FileNotFoundException: Source '/var/folders/nj/33bhgzxj5zb8xtzb5tfh_9y40000gn/T/junit4465446543506135552/FileUtilsTest5790156993778646647/topDirectory/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top/child_directory/link_to_top' does not exist
	at org.apache.commons.io.FileUtils.checkFileExists(FileUtils.java:300)
	at org.apache.commons.io.FileUtils.copyFile(FileUtils.java:829)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1333)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.doCopyDirectory(FileUtils.java:1331)
	at org.apache.commons.io.FileUtils.copyDirectory(FileUtils.java:713)
	at org.apache.commons.io.FileUtils.copyDirectory(FileUtils.java:644)
	at org.apache.commons.io.FileUtils.copyDirectory(FileUtils.java:545)
	at org.apache.commons.io.FileUtils.copyDirectory(FileUtils.java:516)
	at org.apache.commons.io.FileUtilsTest.testCopyDir_symLinkCycle(FileUtilsTest.java:433)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
	at java.util.ArrayList.forEach(ArrayList.java:1257)
`