### PR TITLE
[IO-845] test links to targets outside the source directory

### DIFF
--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -778,7 +778,7 @@ public class FileUtilsTest extends AbstractTempDirTest {
         final String actual = FileUtils.readFileToString(copiedLink, "UTF8");
         assertEquals("HELLO WORLD", actual);
 
-        Path source = Files.readSymbolicLink(copiedLink.toPath());
+        final Path source = Files.readSymbolicLink(copiedLink.toPath());
         assertEquals(content.toPath(), source);
     }
 

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -751,6 +751,38 @@ public class FileUtilsTest extends AbstractTempDirTest {
     }
 
     /**
+     * Test what happens when copyDirectory copies a directory that contains a symlink
+     * to a file outside the copied directory.
+     */
+    @Test
+    public void testCopyDirectory_symLinkExternalFile() throws Exception {
+        // make a file
+        final File content = new File(tempDirFile, "hello.txt");
+        FileUtils.writeStringToFile(content, "HELLO WORLD", "UTF8");
+
+        // Make a directory
+        final File realDirectory = new File(tempDirFile, "real_directory");
+        realDirectory.mkdir();
+
+        // Make a symlink to the file
+        final Path linkPath = realDirectory.toPath().resolve("link_to_file");
+        Files.createSymbolicLink(linkPath, content.toPath());
+
+        // Now copy the directory
+        final File destination = new File(tempDirFile, "destination");
+        FileUtils.copyDirectory(realDirectory, destination);
+
+        // test that the copied directory contains a link to the original file
+        final File copiedLink = new File(destination, "link_to_file");
+        assertTrue(Files.isSymbolicLink(copiedLink.toPath()));
+        final String actual = FileUtils.readFileToString(copiedLink, "UTF8");
+        assertEquals("HELLO WORLD", actual);
+
+        Path source = Files.readSymbolicLink(copiedLink.toPath());
+        assertEquals(content.toPath(), source);
+    }
+
+    /**
      * See what happens when copyDirectory copies a directory that is a symlink
      * to another directory containing non-symlinked files.
      * This is a characterization test to explore current behavior, and arguably


### PR DESCRIPTION
Another characterization test, but this one is for behavior I expect we'll want to keep. Specifically it tests that when a link inside the source directory points to a file outside the source directory, the newly copied link still points to that same file. 

I do think we should separate this case from the case where the target of the link is inside the source directory. In that case, I think we'll want to repoint the link to aim at the new copy of the target rather than the original target. That change is not made in this PR. 

Note that this might lock in the breakage that Google reported with their test resource files. However, the more I think about that the more I'm convinced that resolving all aliases to actual files is surprising behavior. Consider a case where a single file is linked to from three different places. Copying the directory would change the graph and replace one file with four independent copies. 

@garydgregory @eamonnmcmanus 