### PR TITLE
More specific catch clause in FileUtils.decodeUrl()

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1184,7 +1184,7 @@ public class FileUtils {
                             i += 3;
                         } while (i < n && url.charAt(i) == '%');
                         continue;
-                    } catch (final RuntimeException ignored) {
+                    } catch (final IndexOutOfBoundsException | NumberFormatException ignored) {
                         // malformed percent-encoded octet, fall through and
                         // append characters literally
                     } finally {


### PR DESCRIPTION
These are the only two exception that signal a badly encoded percent octet. A runtime exception from the byte buffer would indicate a bug in this code. @garydgregory 