### PR TITLE
ThresholdingOutputStream: a negative threshold should behave like a zero threshold and trigger the event on the first write

### DIFF
--- a/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
@@ -98,7 +98,6 @@ public class ThresholdingOutputStream extends OutputStream {
     /**
      * Checks to see if writing the specified number of bytes would cause the configured threshold to be exceeded. If
      * so, triggers an event to allow a concrete implementation to take action on this.
-     * If the count is not positive, the check is skipped.
      *
      * @param count The number of bytes about to be written to the underlying output stream.
      *

--- a/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
@@ -104,7 +104,7 @@ public class ThresholdingOutputStream extends OutputStream {
      * @throws IOException if an error occurs.
      */
     protected void checkThreshold(final int count) throws IOException {
-        // thresholdReached is no bytes are to be actually written
+        // thresholdReached is not called if no bytes are to be actually written
         // this check handles the case of a negative threshold
         if (!thresholdExceeded && count > 0 && written + count > threshold) {
             thresholdExceeded = true;

--- a/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
@@ -189,7 +189,7 @@ public class ThresholdingOutputStream extends OutputStream {
      * @return {@code true} if the threshold has been reached; {@code false} otherwise.
      */
     public boolean isThresholdExceeded() {
-        return written > threshold;
+        return thresholdExceeded;
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
@@ -92,19 +92,21 @@ public class ThresholdingOutputStream extends OutputStream {
         this.threshold = threshold;
         this.thresholdConsumer = thresholdConsumer == null ? IOConsumer.noop() : thresholdConsumer;
         this.outputStreamGetter = outputStreamGetter == null ? NOOP_OS_GETTER : outputStreamGetter;
-        this.thresholdExceeded = threshold < 0;
     }
 
     /**
      * Checks to see if writing the specified number of bytes would cause the configured threshold to be exceeded. If
      * so, triggers an event to allow a concrete implementation to take action on this.
+     * If the count is not positive, the check is skipped.
      *
      * @param count The number of bytes about to be written to the underlying output stream.
      *
      * @throws IOException if an error occurs.
      */
     protected void checkThreshold(final int count) throws IOException {
-        if (!thresholdExceeded && written + count > threshold) {
+        // thresholdReached is no bytes are to be actually written
+        // this check handles the case of a negative threshold
+        if (!thresholdExceeded && count > 0 && written + count > threshold) {
             thresholdExceeded = true;
             thresholdReached();
         }

--- a/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
@@ -81,6 +81,7 @@ public class ThresholdingOutputStream extends OutputStream {
 
     /**
      * Constructs an instance of this class which will trigger an event at the specified threshold.
+     * A negative threshold has no meaning and will be treated as 0
      *
      * @param threshold The number of bytes at which to trigger an event.
      * @param thresholdConsumer Accepts reaching the threshold.
@@ -89,7 +90,7 @@ public class ThresholdingOutputStream extends OutputStream {
      */
     public ThresholdingOutputStream(final int threshold, final IOConsumer<ThresholdingOutputStream> thresholdConsumer,
         final IOFunction<ThresholdingOutputStream, OutputStream> outputStreamGetter) {
-        this.threshold = threshold;
+        this.threshold = threshold < 0 ? 0 : threshold;
         this.thresholdConsumer = thresholdConsumer == null ? IOConsumer.noop() : thresholdConsumer;
         this.outputStreamGetter = outputStreamGetter == null ? NOOP_OS_GETTER : outputStreamGetter;
     }
@@ -104,9 +105,7 @@ public class ThresholdingOutputStream extends OutputStream {
      * @throws IOException if an error occurs.
      */
     protected void checkThreshold(final int count) throws IOException {
-        // thresholdReached is not called if no bytes are to be actually written
-        // this check handles the case of a negative threshold
-        if (!thresholdExceeded && count > 0 && written + count > threshold) {
+        if (!thresholdExceeded && written + count > threshold) {
             thresholdExceeded = true;
             thresholdReached();
         }
@@ -189,7 +188,7 @@ public class ThresholdingOutputStream extends OutputStream {
      * @return {@code true} if the threshold has been reached; {@code false} otherwise.
      */
     public boolean isThresholdExceeded() {
-        return thresholdExceeded;
+        return written > threshold;
     }
 
     /**

--- a/src/test/java/org/apache/commons/io/output/DeferredFileOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/DeferredFileOutputStreamTest.java
@@ -105,6 +105,28 @@ public class DeferredFileOutputStreamTest extends AbstractTempDirTest {
     }
 
     /**
+     * Tests the case where the threshold is negative, and therefore the data is always written to disk. The actual data
+     * written to disk is verified, as is the file itself.
+     */
+    @ParameterizedTest(name = "initialBufferSize = {0}")
+    @MethodSource("data")
+    public void testThresholdNegative(final int initialBufferSize) throws IOException {
+        final File testFile = Files.createTempFile(tempDirPath, "testThresholdNegative", "dat").toFile();
+        try (DeferredFileOutputStream dfos = DeferredFileOutputStream.builder()
+                .setThreshold(-1)
+                .setBufferSize(initialBufferSize)
+                .setOutputFile(testFile)
+                .get()) {
+            dfos.write(testBytes, 0, testBytes.length);
+            dfos.close();
+            assertFalse(dfos.isInMemory());
+            assertNull(dfos.getData());
+            assertEquals(testFile.length(), dfos.getByteCount());
+            verifyResultFile(testFile);
+        }
+    }
+
+    /**
      * Tests the case where the amount of data is exactly the same as the threshold. The behavior should be the same as
      * that for the amount of data being below (i.e. not exceeding) the threshold.
      */

--- a/src/test/java/org/apache/commons/io/output/ThresholdingOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/ThresholdingOutputStreamTest.java
@@ -32,10 +32,43 @@ import org.junit.jupiter.api.Test;
  */
 public class ThresholdingOutputStreamTest {
 
+    /**
+     * Tests the case where the threshold is negative.
+     * The threshold is not reached until something is written to the stream.
+     */
     @Test
     public void testThresholdLessThanZero() throws IOException {
-        try (final ThresholdingOutputStream out = new ThresholdingOutputStream(-1)) {
+        final AtomicBoolean reached = new AtomicBoolean();
+        try (final ThresholdingOutputStream out = new ThresholdingOutputStream(-1) {
+            @Override
+            protected void thresholdReached() throws IOException {
+                reached.set(true);
+            }
+        }) {
+            out.write(new byte[0]);
+            assertFalse(reached.get());
+            out.write(89);
+            assertTrue(reached.get());
             assertTrue(out.isThresholdExceeded());
+        }
+    }
+
+    /**
+     * Tests the case where no bytes are written.
+     * The threshold is not reached until something is written to the stream.
+     */
+    @Test
+    public void testThresholdZeroWrite() throws IOException {
+        final AtomicBoolean reached = new AtomicBoolean();
+        try (final ThresholdingOutputStream out = new ThresholdingOutputStream(7) {
+            @Override
+            protected void thresholdReached() throws IOException {
+                reached.set(true);
+            }
+        }) {
+            assertFalse(reached.get());
+            out.write(new byte[0]);
+            assertFalse(reached.get());
         }
     }
 

--- a/src/test/java/org/apache/commons/io/output/ThresholdingOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/ThresholdingOutputStreamTest.java
@@ -45,7 +45,6 @@ public class ThresholdingOutputStreamTest {
                 reached.set(true);
             }
         }) {
-            out.write(new byte[0]);
             assertFalse(reached.get());
             out.write(89);
             assertTrue(reached.get());

--- a/src/test/java/org/apache/commons/io/output/ThresholdingOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/ThresholdingOutputStreamTest.java
@@ -66,8 +66,10 @@ public class ThresholdingOutputStreamTest {
                 reached.set(true);
             }
         }) {
+            assertFalse(out.isThresholdExceeded());
             assertFalse(reached.get());
             out.write(new byte[0]);
+            assertFalse(out.isThresholdExceeded());
             assertFalse(reached.get());
         }
     }


### PR DESCRIPTION
#587 introduces a change in behavior regarding cases where a `ThresholdingOutputStream` is initialized with a negative threshold.

Previously, the `thresholdConsumer` would be notified upon the first write, now it is not.

The previous behavior was relied upon at least by the `DeferredFileOutputStream` implementation.
In this implementation the underlying `currentBuffer` isn't switched from the memory one until the threshold exceeded callback is triggered.
If the thresholding output stream has already exceeded the threshold on initialization, the switch never happens. This causes the writes to go to the wrong buffer.

I'm not sure what the right approach for a fix would be. On one hand the `isThresholdExceeded` method was incorrect. On the other hand, even if we fix `DeferredFileOutputStream`, other implementations could still rely on the previous behavior.

DeferredFileOutputStream is used by commons-fileupload, that is broken when used with commons-io 2.16.0.

@elharo @garydgregory, can I ask your opinion on this? 