### PR TITLE
[IO-783] Remove NTFS ADS separator check in FilenameUtils.getExtension

### DIFF
--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -988,13 +988,6 @@ public class FilenameUtils {
         if (fileName == null) {
             return NOT_FOUND;
         }
-        if (isSystemWindows()) {
-            // Special handling for NTFS ADS: Don't accept colon in the file name.
-            final int offset = fileName.indexOf(':', getAdsCriticalOffset(fileName));
-            if (offset != -1) {
-                throw new IllegalArgumentException("NTFS ADS separator (':') in file name is forbidden.");
-            }
-        }
         final int extensionPos = fileName.lastIndexOf(EXTENSION_SEPARATOR);
         final int lastSeparator = indexOfLastSeparator(fileName);
         return lastSeparator > extensionPos ? NOT_FOUND : extensionPos;

--- a/src/test/java/org/apache/commons/io/FilenameUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FilenameUtilsTest.java
@@ -247,15 +247,7 @@ public class FilenameUtilsTest {
         assertEquals("", FilenameUtils.getExtension("a\\b\\c"));
         assertEquals("", FilenameUtils.getExtension("C:\\temp\\foo.bar\\README"));
         assertEquals("ext", FilenameUtils.getExtension("../filename.ext"));
-
-        if (FilenameUtils.isSystemWindows()) {
-            // Special case handling for NTFS ADS names
-            final IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> FilenameUtils.getExtension("foo.exe:bar.txt"));
-            assertEquals("NTFS ADS separator (':') in file name is forbidden.", e.getMessage());
-        } else {
-            // Upwards compatibility:
-            assertEquals("txt", FilenameUtils.getExtension("foo.exe:bar.txt"));
-        }
+        assertEquals("txt", FilenameUtils.getExtension("foo.exe:bar.txt"));
     }
 
     @Test


### PR DESCRIPTION
### Summary
This PR addresses issue [IO-783](https://issues.apache.org/jira/browse/IO-783) by removing the NTFS ADS separator (colon) check from the `FilenameUtils.getExtension` method to ensure OS independence.

### Changes
- Removed the NTFS ADS separator (colon) validation from the `indexOfExtension` method in `FilenameUtils`.
- Updated the `FilenameUtils.getExtension` method to process filenames regardless of the operating system.