### PR TITLE
[IO-831] Support getInputStream() for https & http in URIOrigin

### DIFF
--- a/src/main/java/org/apache/commons/io/build/AbstractOrigin.java
+++ b/src/main/java/org/apache/commons/io/build/AbstractOrigin.java
@@ -409,15 +409,12 @@ public abstract class AbstractOrigin<T, B extends AbstractOrigin<T, B>> extends 
             final URI uri = get();
             final String scheme = uri.getScheme();
             final FileSystemProvider fileSystemProvider = FileSystemProviders.installed().getFileSystemProvider(scheme);
-
             if (fileSystemProvider != null) {
                 return Files.newInputStream(fileSystemProvider.getPath(uri), options);
             }
-
             if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
                 return get().toURL().openStream();
             }
-            
             return Files.newInputStream(getPath(), options);
         }
     }

--- a/src/main/java/org/apache/commons/io/build/AbstractOrigin.java
+++ b/src/main/java/org/apache/commons/io/build/AbstractOrigin.java
@@ -402,6 +402,13 @@ public abstract class AbstractOrigin<T, B extends AbstractOrigin<T, B>> extends 
             return Paths.get(get());
         }
 
+        @Override
+        public InputStream getInputStream(final OpenOption... options) throws IOException {
+            if ("http".equalsIgnoreCase(get().getScheme()) || "https".equalsIgnoreCase(get().getScheme())) {
+                return get().toURL().openStream();
+            }
+            return Files.newInputStream(getPath(), options);
+        }
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/build/AbstractOrigin.java
+++ b/src/main/java/org/apache/commons/io/build/AbstractOrigin.java
@@ -413,7 +413,7 @@ public abstract class AbstractOrigin<T, B extends AbstractOrigin<T, B>> extends 
                 return Files.newInputStream(fileSystemProvider.getPath(uri), options);
             }
             if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
-                return get().toURL().openStream();
+                return uri.toURL().openStream();
             }
             return Files.newInputStream(getPath(), options);
         }

--- a/src/main/java/org/apache/commons/io/build/AbstractOrigin.java
+++ b/src/main/java/org/apache/commons/io/build/AbstractOrigin.java
@@ -33,12 +33,14 @@ import java.nio.file.Files;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.spi.FileSystemProvider;
 import java.util.Arrays;
 import java.util.Objects;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.RandomAccessFileMode;
 import org.apache.commons.io.RandomAccessFiles;
+import org.apache.commons.io.file.spi.FileSystemProviders;
 import org.apache.commons.io.input.CharSequenceInputStream;
 import org.apache.commons.io.input.CharSequenceReader;
 import org.apache.commons.io.input.ReaderInputStream;
@@ -404,9 +406,18 @@ public abstract class AbstractOrigin<T, B extends AbstractOrigin<T, B>> extends 
 
         @Override
         public InputStream getInputStream(final OpenOption... options) throws IOException {
-            if ("http".equalsIgnoreCase(get().getScheme()) || "https".equalsIgnoreCase(get().getScheme())) {
+            final URI uri = get();
+            final String scheme = uri.getScheme();
+            final FileSystemProvider fileSystemProvider = FileSystemProviders.installed().getFileSystemProvider(scheme);
+
+            if (fileSystemProvider != null) {
+                return Files.newInputStream(fileSystemProvider.getPath(uri), options);
+            }
+
+            if ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme)) {
                 return get().toURL().openStream();
             }
+            
             return Files.newInputStream(getPath(), options);
         }
     }

--- a/src/test/java/org/apache/commons/io/build/AbstractOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/AbstractOriginTest.java
@@ -18,7 +18,6 @@ package org.apache.commons.io.build;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
@@ -26,7 +25,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
-import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -45,7 +43,6 @@ public abstract class AbstractOriginTest<T, B extends AbstractOrigin<T, B>> {
     protected static final String FILE_RES_RO = "/org/apache/commons/io/test-file-20byteslength.bin";
     protected static final String FILE_NAME_RO = "src/test/resources" + FILE_RES_RO;
     protected static final String FILE_NAME_RW = "target/" + AbstractOriginTest.class.getSimpleName() + ".txt";
-    protected static final String URI_HTTPS = "https://commons.apache.org/proper/commons-io";
 
     protected AbstractOrigin<T, B> originRo;
     protected AbstractOrigin<T, B> originRw;
@@ -134,11 +131,4 @@ public abstract class AbstractOriginTest<T, B extends AbstractOrigin<T, B>> {
         assertEquals(Files.size(Paths.get(FILE_NAME_RO)), getOriginRo().getByteArray().length);
     }
 
-    @Test
-    public void testURI() throws Exception {
-        final AbstractOrigin.URIOrigin origin = new AbstractOrigin.URIOrigin(new URI(URI_HTTPS));
-        try (final InputStream in = origin.getInputStream()) {
-            assertNotEquals(-1, in.read());
-        }
-    }
 }

--- a/src/test/java/org/apache/commons/io/build/AbstractOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/AbstractOriginTest.java
@@ -130,5 +130,4 @@ public abstract class AbstractOriginTest<T, B extends AbstractOrigin<T, B>> {
     public void testSize() throws IOException {
         assertEquals(Files.size(Paths.get(FILE_NAME_RO)), getOriginRo().getByteArray().length);
     }
-
 }

--- a/src/test/java/org/apache/commons/io/build/AbstractOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/AbstractOriginTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.io.build;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
@@ -25,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -43,6 +45,7 @@ public abstract class AbstractOriginTest<T, B extends AbstractOrigin<T, B>> {
     protected static final String FILE_RES_RO = "/org/apache/commons/io/test-file-20byteslength.bin";
     protected static final String FILE_NAME_RO = "src/test/resources" + FILE_RES_RO;
     protected static final String FILE_NAME_RW = "target/" + AbstractOriginTest.class.getSimpleName() + ".txt";
+    protected static final String URI_HTTPS = "https://commons.apache.org/proper/commons-io";
 
     protected AbstractOrigin<T, B> originRo;
     protected AbstractOrigin<T, B> originRw;
@@ -129,5 +132,13 @@ public abstract class AbstractOriginTest<T, B extends AbstractOrigin<T, B>> {
     @Test
     public void testSize() throws IOException {
         assertEquals(Files.size(Paths.get(FILE_NAME_RO)), getOriginRo().getByteArray().length);
+    }
+
+    @Test
+    public void testURI() throws Exception {
+        final AbstractOrigin.URIOrigin origin = new AbstractOrigin.URIOrigin(new URI(URI_HTTPS));
+        try (final InputStream in = origin.getInputStream()) {
+            assertNotEquals(-1, in.read());
+        }
     }
 }

--- a/src/test/java/org/apache/commons/io/build/URIOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/URIOriginTest.java
@@ -16,11 +16,15 @@
  */
 package org.apache.commons.io.build;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Paths;
 
 import org.apache.commons.io.build.AbstractOrigin.URIOrigin;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link URIOrigin}.
@@ -35,4 +39,21 @@ public class URIOriginTest extends AbstractOriginTest<URI, URIOrigin> {
         setOriginRw(new URIOrigin(Paths.get(FILE_NAME_RW).toUri()));
     }
 
+    @Test
+    void testGetInputStreamHttpURI() throws Exception {
+        final String uri = "https://example.com";
+        final AbstractOrigin.URIOrigin origin = new AbstractOrigin.URIOrigin(new URI(uri));
+        try (final InputStream in = origin.getInputStream()) {
+            assertNotEquals(-1, in.read());
+        }
+    }
+
+    @Test
+    void testGetInputStreamHttps() throws Exception {
+        final String uri = "https://example.com";
+        final AbstractOrigin.URIOrigin origin = new AbstractOrigin.URIOrigin(new URI(uri));
+        try (final InputStream in = origin.getInputStream()) {
+            assertNotEquals(-1, in.read());
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/io/build/URIOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/URIOriginTest.java
@@ -25,6 +25,8 @@ import java.nio.file.Paths;
 import org.apache.commons.io.build.AbstractOrigin.URIOrigin;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests {@link URIOrigin}.
@@ -39,9 +41,12 @@ public class URIOriginTest extends AbstractOriginTest<URI, URIOrigin> {
         setOriginRw(new URIOrigin(Paths.get(FILE_NAME_RW).toUri()));
     }
 
-    @Test
-    void testGetInputStreamHttpURI() throws Exception {
-        final String uri = "https://example.com";
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "http://example.com",
+            "https://example.com"
+    })
+    void testGetInputStream(String uri) throws Exception {
         final AbstractOrigin.URIOrigin origin = new AbstractOrigin.URIOrigin(new URI(uri));
         try (final InputStream in = origin.getInputStream()) {
             assertNotEquals(-1, in.read());
@@ -49,9 +54,8 @@ public class URIOriginTest extends AbstractOriginTest<URI, URIOrigin> {
     }
 
     @Test
-    void testGetInputStreamHttps() throws Exception {
-        final String uri = "https://example.com";
-        final AbstractOrigin.URIOrigin origin = new AbstractOrigin.URIOrigin(new URI(uri));
+    void testGetInputStreamFileURI() throws Exception {
+        final AbstractOrigin.URIOrigin origin = getOriginRo().asThis();
         try (final InputStream in = origin.getInputStream()) {
             assertNotEquals(-1, in.read());
         }


### PR DESCRIPTION
#### Summary
This PR addresses issue IO-831, support `http` and `https`

#### Changes
Handle in case uri are `http` or `https`