### PR TITLE
Replace deprecated constant FileFileFilter.FILE in Javadoc

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -584,7 +584,7 @@ public class FileUtils {
      * <pre>
      * // Create a filter for ".txt" files
      * IOFileFilter txtSuffixFilter = FileFilterUtils.suffixFileFilter(".txt");
-     * IOFileFilter txtFiles = FileFilterUtils.andFileFilter(FileFileFilter.FILE, txtSuffixFilter);
+     * IOFileFilter txtFiles = FileFilterUtils.andFileFilter(FileFileFilter.INSTANCE, txtSuffixFilter);
      *
      * // Create a filter for either directories or ".txt" files
      * FileFilter filter = FileFilterUtils.orFileFilter(DirectoryFileFilter.DIRECTORY, txtFiles);
@@ -635,7 +635,7 @@ public class FileUtils {
      * <pre>
      * // Create a filter for ".txt" files
      * IOFileFilter txtSuffixFilter = FileFilterUtils.suffixFileFilter(".txt");
-     * IOFileFilter txtFiles = FileFilterUtils.andFileFilter(FileFileFilter.FILE, txtSuffixFilter);
+     * IOFileFilter txtFiles = FileFilterUtils.andFileFilter(FileFileFilter.INSTANCE, txtSuffixFilter);
      *
      * // Create a filter for either directories or ".txt" files
      * FileFilter filter = FileFilterUtils.orFileFilter(DirectoryFileFilter.DIRECTORY, txtFiles);
@@ -686,7 +686,7 @@ public class FileUtils {
      * <pre>
      * // Create a filter for ".txt" files
      * IOFileFilter txtSuffixFilter = FileFilterUtils.suffixFileFilter(".txt");
-     * IOFileFilter txtFiles = FileFilterUtils.andFileFilter(FileFileFilter.FILE, txtSuffixFilter);
+     * IOFileFilter txtFiles = FileFilterUtils.andFileFilter(FileFileFilter.INSTANCE, txtSuffixFilter);
      *
      * // Create a filter for either directories or ".txt" files
      * FileFilter filter = FileFilterUtils.orFileFilter(DirectoryFileFilter.DIRECTORY, txtFiles);


### PR DESCRIPTION
`FileFileFilter.FILE` for `FileUtils` marked `@Deprecated`, but used in javadoc.
Replaced to `FileFileFilter.INSTANCE`