### PR TITLE
IO-870: PathUtils.copyFileToDirectory

### DIFF
--- a/src/main/java/org/apache/commons/io/file/PathUtils.java
+++ b/src/main/java/org/apache/commons/io/file/PathUtils.java
@@ -322,8 +322,8 @@ public final class PathUtils {
      */
     public static Path copyFileToDirectory(final Path sourceFile, final Path targetDirectory, final CopyOption... copyOptions) throws IOException {
         // Path.resolve() naturally won't work across FileSystem unless we convert to a String
-        Path sourceFileName = sourceFile.getFileName();
-        Path targetFile;
+        final Path sourceFileName = sourceFile.getFileName();
+        final Path targetFile;
         if (sourceFileName.getFileSystem() == targetDirectory.getFileSystem()) {
             targetFile = targetDirectory.resolve(sourceFileName);
         } else {

--- a/src/main/java/org/apache/commons/io/file/PathUtils.java
+++ b/src/main/java/org/apache/commons/io/file/PathUtils.java
@@ -323,6 +323,9 @@ public final class PathUtils {
     public static Path copyFileToDirectory(final Path sourceFile, final Path targetDirectory, final CopyOption... copyOptions) throws IOException {
         // Path.resolve() naturally won't work across FileSystem unless we convert to a String
         final Path sourceFileName = sourceFile.getFileName();
+        if (sourceFileName == null) {
+            throw new IllegalArgumentException("must have a file name: " + sourceFile);
+        }
         final Path targetFile;
         if (sourceFileName.getFileSystem() == targetDirectory.getFileSystem()) {
             targetFile = targetDirectory.resolve(sourceFileName);

--- a/src/main/java/org/apache/commons/io/file/PathUtils.java
+++ b/src/main/java/org/apache/commons/io/file/PathUtils.java
@@ -321,7 +321,15 @@ public final class PathUtils {
      * @see Files#copy(Path, Path, CopyOption...)
      */
     public static Path copyFileToDirectory(final Path sourceFile, final Path targetDirectory, final CopyOption... copyOptions) throws IOException {
-        return Files.copy(sourceFile, targetDirectory.resolve(sourceFile.getFileName()), copyOptions);
+        // Path.resolve() naturally won't work across FileSystem unless we convert to a String
+        Path sourceFileName = sourceFile.getFileName();
+        Path targetFile;
+        if (sourceFileName.getFileSystem() == targetDirectory.getFileSystem()) {
+            targetFile = targetDirectory.resolve(sourceFileName);
+        } else {
+            targetFile = targetDirectory.resolve(sourceFileName.toString());
+        }
+        return Files.copy(sourceFile, targetFile, copyOptions);
     }
 
     /**

--- a/src/test/java/org/apache/commons/io/file/PathUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/file/PathUtilsTest.java
@@ -179,6 +179,16 @@ public class PathUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
+    public void testCopyFileTwoFileSystem() throws IOException {
+        try (FileSystem archive = openArchive(Paths.get(TEST_JAR_PATH), false)) {
+            final Path sourceFile = archive.getPath("next/dir/test.log");
+            final Path targetFile = PathUtils.copyFileToDirectory(sourceFile, tempDirPath);
+            assertTrue(Files.exists(targetFile));
+            assertEquals(Files.size(sourceFile), Files.size(targetFile));
+        }
+    }
+
+    @Test
     public void testCopyURL() throws IOException {
         final Path sourceFile = Paths.get("src/test/resources/org/apache/commons/io/dirs-1-file-size-1/file-size-1.bin");
         final URL url = new URL("file:///" + FilenameUtils.getPath(sourceFile.toAbsolutePath().toString()) + sourceFile.getFileName());


### PR DESCRIPTION
span FileSystem.

https://issues.apache.org/jira/browse/IO-870

> PathUtils.copyFileToDirectory is a simple method calling Files.copy, the latter of which supports cross-FileSystem copy.  But copyFileToDirectory gets the file name from the source as a Path and then resolves this against the target, which is invalid.  It needs to get the string form of the source file name.

This problem was encountered in Apache Solr which uses Apache Lucene's extensive test infrastructure, including custom FileSystem impls that emulate various behaviors to help tests see things that some users might experience.