### PR TITLE
[javadoc] Rename parameter of `ProxyOutputStream.write(int)`

### DIFF
--- a/src/main/java/org/apache/commons/io/output/ProxyOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ProxyOutputStream.java
@@ -219,14 +219,14 @@ public class ProxyOutputStream extends FilterOutputStream {
 
     /**
      * Invokes the delegate's {@code write(int)} method.
-     * @param idx the byte to write
+     * @param b the byte to write
      * @throws IOException if an I/O error occurs.
      */
     @Override
-    public void write(final int idx) throws IOException {
+    public void write(final int b) throws IOException {
         try {
             beforeWrite(1);
-            out.write(idx);
+            out.write(b);
             afterWrite(1);
         } catch (final IOException e) {
             handleIOException(e);


### PR DESCRIPTION
Very trivial, but I noticed that the parameter of this method was named `idx`, which would usually be construed as an abbreviation for `index`, which in this context would be presumed to be an index into a `byte[]`. But that is not what it is; it is a byte (typed as `int` for what I suppose are historical reasons). The supertypes `OutputStream` and `FilterOutputStream` name the parameter `b`, which seems more intuitive.