### PR TITLE
[IO-875] CopyDirectoryVisitor ignores fileFilter

### DIFF
--- a/src/main/java/org/apache/commons/io/file/CopyDirectoryVisitor.java
+++ b/src/main/java/org/apache/commons/io/file/CopyDirectoryVisitor.java
@@ -45,7 +45,7 @@ public class CopyDirectoryVisitor extends CountingPathVisitor {
     private final Path targetDirectory;
 
     /**
-     * Constructs a instance that copies all files.
+     * Constructs an instance that copies all files.
      *
      * @param pathCounter How to count visits.
      * @param sourceDirectory The source directory
@@ -60,7 +60,7 @@ public class CopyDirectoryVisitor extends CountingPathVisitor {
     }
 
     /**
-     * Constructs a instance that copies files matching the given file and directory filters.
+     * Constructs an instance that copies files matching the given file and directory filters.
      *
      * @param pathCounter How to count visits.
      * @param fileFilter How to filter file paths.

--- a/src/main/java/org/apache/commons/io/file/CopyDirectoryVisitor.java
+++ b/src/main/java/org/apache/commons/io/file/CopyDirectoryVisitor.java
@@ -45,7 +45,7 @@ public class CopyDirectoryVisitor extends CountingPathVisitor {
     private final Path targetDirectory;
 
     /**
-     * Constructs a instance that deletes files except for the files and directories explicitly given.
+     * Constructs a instance that copies all files.
      *
      * @param pathCounter How to count visits.
      * @param sourceDirectory The source directory
@@ -60,7 +60,7 @@ public class CopyDirectoryVisitor extends CountingPathVisitor {
     }
 
     /**
-     * Constructs a instance that deletes files except for the files and directories explicitly given.
+     * Constructs a instance that copies files matching the given file and directory filters.
      *
      * @param pathCounter How to count visits.
      * @param fileFilter How to filter file paths.
@@ -171,8 +171,11 @@ public class CopyDirectoryVisitor extends CountingPathVisitor {
     @Override
     public FileVisitResult visitFile(final Path sourceFile, final BasicFileAttributes attributes) throws IOException {
         final Path targetFile = resolveRelativeAsString(sourceFile);
-        copy(sourceFile, targetFile);
-        return super.visitFile(targetFile, attributes);
+        if (accept(sourceFile, attributes)) {
+            copy(sourceFile, targetFile);
+            updateFileCounters(targetFile, attributes);
+        }
+        return FileVisitResult.CONTINUE;
     }
 
 }

--- a/src/main/java/org/apache/commons/io/file/CountingPathVisitor.java
+++ b/src/main/java/org/apache/commons/io/file/CountingPathVisitor.java
@@ -291,6 +291,18 @@ public class CountingPathVisitor extends SimplePathVisitor {
     }
 
     /**
+     * Returns true to copy the given file, false if not.
+     *
+     * @param file       the visited file.
+     * @param attributes the visited file attributes.
+     * @return true to copy the given file, false if not.
+     */
+    protected boolean accept(final Path file, final BasicFileAttributes attributes) {
+        // Note: A file can be a symbolic link to a directory.
+        return Files.exists(file) && fileFilter.accept(file, attributes) == FileVisitResult.CONTINUE;
+    }
+
+    /**
      * Updates the counters for visiting the given file.
      *
      * @param file       the visited file.
@@ -303,10 +315,10 @@ public class CountingPathVisitor extends SimplePathVisitor {
 
     @Override
     public FileVisitResult visitFile(final Path file, final BasicFileAttributes attributes) throws IOException {
-        // Note: A file can be a symbolic link to a directory.
-        if (Files.exists(file) && fileFilter.accept(file, attributes) == FileVisitResult.CONTINUE) {
+        if (accept(file, attributes)) {
             updateFileCounters(file, attributes);
         }
         return FileVisitResult.CONTINUE;
     }
+
 }

--- a/src/test/java/org/apache/commons/io/file/CopyDirectoryVisitorTest.java
+++ b/src/test/java/org/apache/commons/io/file/CopyDirectoryVisitorTest.java
@@ -63,11 +63,16 @@ public class CopyDirectoryVisitorTest extends TestArguments {
             assertEquals(sourceDir.get(), ((AbstractPathWrapper) visitFileTree.getSourceDirectory()).get());
             assertEquals(sourceDir, visitFileTree.getSourceDirectory());
             assertEquals(targetDir, visitFileTree.getTargetDirectory());
-            assertEquals(targetDir, visitFileTree.getTargetDirectory());
-            //
+            // Tests equals and hashCode
             assertEquals(visitFileTree, supplier.get());
             assertEquals(visitFileTree.hashCode(), supplier.get().hashCode());
+            assertEquals(visitFileTree, visitFileTree);
             assertEquals(visitFileTree.hashCode(), visitFileTree.hashCode());
+            assertNotEquals(visitFileTree, "not");
+            assertNotEquals(visitFileTree, new DeletingPathVisitor(pathCounters));
+            assertNotEquals(visitFileTree, new CopyDirectoryVisitor(pathCounters, sourceDir, targetDir));
+            assertNotEquals(visitFileTree, new CopyDirectoryVisitor(pathCounters, sourceDir, sourceDir, EXPECTED_COPY_OPTIONS));
+            assertNotEquals(visitFileTree, new CopyDirectoryVisitor(pathCounters, targetDir, sourceDir, EXPECTED_COPY_OPTIONS));
             assertNotEquals(visitFileTree, CountingPathVisitor.withLongCounters());
         }
     }
@@ -86,9 +91,10 @@ public class CopyDirectoryVisitorTest extends TestArguments {
             assertArrayEquals(EXPECTED_COPY_OPTIONS, visitFileTree.getCopyOptions());
             assertEquals(sourceDir, visitFileTree.getSourceDirectory());
             assertEquals(targetDir, visitFileTree.getTargetDirectory());
-            //
+            // Tests equals and hashCode
             assertEquals(visitFileTree, supplier.get());
             assertEquals(visitFileTree.hashCode(), supplier.get().hashCode());
+            assertEquals(visitFileTree, visitFileTree);
             assertEquals(visitFileTree.hashCode(), visitFileTree.hashCode());
         }
     }
@@ -101,10 +107,10 @@ public class CopyDirectoryVisitorTest extends TestArguments {
     public void testCopyDirectoryFilters(final PathCounters pathCounters) throws IOException {
         final Path sourceDir = Paths.get("src/test/resources/org/apache/commons/io/dirs-2-file-size-4");
         final CopyDirectoryVisitor visitFileTree = PathUtils.visitFileTree(new CopyDirectoryVisitor(pathCounters, new NameFileFilter("file-size-1.bin"),
-            new NameFileFilter("dirs-2-file-size-4", "dirs-a-file-size-1"), sourceDir, targetDir, EXPECTED_COPY_OPTIONS),
+            new NameFileFilter("dirs-2-file-size-4", "dirs-a-file-size-1"), sourceDir, targetDir, null),
             sourceDir);
         assertCounts(2, 1, 2, visitFileTree);
-        assertArrayEquals(EXPECTED_COPY_OPTIONS, visitFileTree.getCopyOptions());
+        assertArrayEquals(PathUtils.EMPTY_COPY_OPTIONS, visitFileTree.getCopyOptions());
         assertEquals(sourceDir, visitFileTree.getSourceDirectory());
         assertEquals(targetDir, visitFileTree.getTargetDirectory());
         assertTrue(Files.exists(targetDir.resolve("dirs-a-file-size-1/file-size-1.bin")));
@@ -127,7 +133,7 @@ public class CopyDirectoryVisitorTest extends TestArguments {
         assertEquals(sourceDir, visitFileTree.getSourceDirectory());
         assertEquals(targetDir, visitFileTree.getTargetDirectory());
         assertTrue(Files.exists(targetDir.resolve("file-size-0.bin")));
-        //
+        // Tests equals and hashCode
         assertEquals(visitFileTree, supplier.get());
         assertEquals(visitFileTree.hashCode(), supplier.get().hashCode());
         assertEquals(visitFileTree.hashCode(), visitFileTree.hashCode());


### PR DESCRIPTION
- Fix [IO-875](https://issues.apache.org/jira/browse/IO-875)
- Fix javadoc
- Added assertions for the copied files and to get a 100% coverage