### PR TITLE
[IO-874] FileUtils.forceDelete can delete a broken symlink again

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -294,7 +294,7 @@ public class FileUtils {
      */
     private static void checkExists(final File file, final boolean strict) throws FileNotFoundException {
         Objects.requireNonNull(file, PROTOCOL_FILE);
-        if (strict && !file.exists()) {
+        if (strict && !file.exists() && !isSymlink(file)) {
             throw new FileNotFoundException(file.toString());
         }
     }

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -1762,6 +1762,39 @@ class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
+    public void testForceDeleteBrokenSymlink() throws Exception {
+        final ImmutablePair<Path, Path> pair = createTempSymbolicLinkedRelativeDir();
+        final Path symlinkedDir = pair.getLeft();
+        final Path targetDir = pair.getRight();
+
+        Files.delete(targetDir);
+        assertFalse(Files.exists(symlinkedDir));
+        assertTrue(Files.isSymbolicLink(symlinkedDir));
+
+        FileUtils.forceDelete(symlinkedDir.toFile());
+
+        assertFalse(Files.exists(symlinkedDir));
+        assertFalse(Files.isSymbolicLink(symlinkedDir));
+    }
+    
+    @Test
+    public void testForceDeleteSymlink() throws Exception {
+        final ImmutablePair<Path, Path> pair = createTempSymbolicLinkedRelativeDir();
+        final Path symlinkedDir = pair.getLeft();
+        final Path targetDir = pair.getRight();
+
+        assertTrue(Files.exists(symlinkedDir));
+        assertTrue(Files.isSymbolicLink(symlinkedDir));
+        assertTrue(Files.exists(targetDir));
+
+        FileUtils.forceDelete(symlinkedDir.toFile());
+
+        assertFalse(Files.exists(symlinkedDir));
+        assertFalse(Files.isSymbolicLink(symlinkedDir));
+        assertTrue(Files.exists(targetDir));
+    }
+
+    @Test
     void testForceMkdir() throws Exception {
         // Tests with existing directory
         FileUtils.forceMkdir(tempDirFile);

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -1773,10 +1773,11 @@ class FileUtilsTest extends AbstractTempDirTest {
 
         FileUtils.forceDelete(symlinkedDir.toFile());
 
+        // check targeted symlink is gone
         assertFalse(Files.exists(symlinkedDir));
         assertFalse(Files.isSymbolicLink(symlinkedDir));
     }
-    
+
     @Test
     public void testForceDeleteSymlink() throws Exception {
         final ImmutablePair<Path, Path> pair = createTempSymbolicLinkedRelativeDir();
@@ -1789,8 +1790,10 @@ class FileUtilsTest extends AbstractTempDirTest {
 
         FileUtils.forceDelete(symlinkedDir.toFile());
 
+        // check targeted symlink is gone
         assertFalse(Files.exists(symlinkedDir));
         assertFalse(Files.isSymbolicLink(symlinkedDir));
+        // dir targeted by symlink is not deleted
         assertTrue(Files.exists(targetDir));
     }
 


### PR DESCRIPTION
The fix for https://issues.apache.org/jira/browse/IO-859 introduced this regression bug https://issues.apache.org/jira/browse/IO-874, which is triggered when a broken/dangling symlink is tried to be deleted.
Before 2.16.1, FileUtils.forceDelete() deleted broken/dangling symbolic links successfully, since then it throws FileNotFoundException. With this fix a FileNotFoundException is only thrown, when the target file does not exist AND is not a symlink. 2 tests have been added to check that a  broken link is deleted and that an ok link only deletes the link but not the file itself (increase test coverage).

Note: This is my first contribution. I just signed the ICLA as JoergBudi@gmx.de, shared it with secretary@apache.org and got a receipt, but haven't got an apacheid yet (my preferred apacheid would be jbudi , but I am in no hurry in case that is handed out only after more contribs).