### PR TITLE
[IO-279] Add Tailer ignoreTouch option 

### DIFF
--- a/src/main/java/org/apache/commons/io/input/Tailer.java
+++ b/src/main/java/org/apache/commons/io/input/Tailer.java
@@ -323,6 +323,7 @@ public class Tailer implements Runnable, AutoCloseable {
          *        ignoreTouch=true does nothing in that case.
          *
          * @return {@code this} instance.
+         * @since 2.20.0
          */
         public Builder setIgnoreTouch(final boolean ignoreTouch) {
             this.ignoreTouch = ignoreTouch;

--- a/src/main/java/org/apache/commons/io/input/Tailer.java
+++ b/src/main/java/org/apache/commons/io/input/Tailer.java
@@ -714,7 +714,7 @@ public class Tailer implements Runnable, AutoCloseable {
     private volatile boolean run = true;
 
     private boolean ignoreTouch = DEFAULT_IGNORE_TOUCH;
-    
+
     /**
      * Creates a Tailer for the given file, with a specified buffer size.
      *
@@ -827,6 +827,7 @@ public class Tailer implements Runnable, AutoCloseable {
      * @param delayDuration the delay between checks of the file for new content in milliseconds.
      * @param end Set to true to tail from the end of the file, false to tail from the beginning of the file.
      * @param reOpen if true, close and reopen the file between reading chunks
+     * @param ignoreTouch if true, file timestamp changes without content change get ignored
      * @param bufferSize Buffer size
      */
     private Tailer(final Tailable tailable, final Charset charset, final TailerListener listener, final Duration delayDuration, final boolean end,
@@ -1019,7 +1020,7 @@ public class Tailer implements Runnable, AutoCloseable {
                     /*
                      * This can happen if the file
                      * - is overwritten with the exact same length of information
-                     * - gets "touched" 
+                     * - gets "touched"
                      * - Files.getLastModifiedTime returns a new timestamp but newer data is not yet there (
                      *   was reported to happen on busy systems or samba network shares, see IO-279)
                      * The default behaviour is to replay the whole file. If this is unsdesired in your usecase,
@@ -1028,7 +1029,7 @@ public class Tailer implements Runnable, AutoCloseable {
                     if (!ignoreTouch) {
                         position = 0;
                         reader.seek(position); // cannot be null here
-                        
+
                         // Now we can read new lines
                         position = readLines(reader);
                     }


### PR DESCRIPTION
…oose to ignore touching of watched file

So I got late to the old io-279 Tailer issue. In the long history, some changes were already made long ago.
However from reading the last comments, some users want to avoid to get the whole file replayed 
when the timestamp of the watched file changes without a content update. I added an ignoreTouch option, the default is false and resembles current behaviour (file gets replayed) (inspired from the  2015 patch by gh user myyron).
When changed to true via the Builder pattern, a newertimestamp with constant content gets ignored.
That makes the Tailer more similar to "tail -f" (issuing touch on the watched file is ignored then), but note that subtle differences remain. When you copy the identical file onto watched  file, "tail -f" realizes that and replays the whole file. With ignoreTouch=true, the Tailer ignores that, as it looks identical to touching. 

Added 2 Junit tests to verify both behaviours explictly. 