### PR TITLE
Fix infinite loop in AbstractByteArrayOutputStream.

### DIFF
--- a/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/AbstractByteArrayOutputStream.java
@@ -92,7 +92,7 @@ public abstract class AbstractByteArrayOutputStream<T extends AbstractByteArrayO
     private byte[] currentBuffer;
 
     /** The index of the current buffer. */
-    private int currentBufferIndex;
+    private int currentBufferIndex = -1;
 
     /** The total count of bytes in all the filled buffers. */
     private int filledBufferSum;
@@ -147,7 +147,8 @@ public abstract class AbstractByteArrayOutputStream<T extends AbstractByteArrayO
             // Creating new buffer
             final int newBufferSize;
             if (currentBuffer == null) {
-                newBufferSize = newCount;
+                // prevents 0 size buffers
+                newBufferSize = newCount > 0 ? newCount : DEFAULT_SIZE;
                 filledBufferSum = 0;
             } else {
                 newBufferSize = Math.max(currentBuffer.length << 1, newCount - filledBufferSum);


### PR DESCRIPTION
Fix infinite loop in AbstractByteArrayOutputStream.
When an AbstractByteArrayOutputStream is initialized with a 0 size buffer and writeImpl(InputStream) is called an infinite loop may occur and eventually cause an OOM exception.
This is due to passing 0 as the maximum bytes to read in InputStream#read which returns 0, then a new 0 size buffer is created, and then InputStream#read is called again therefore repeating the loop forever.
Fix this infinite loop by updating needNewBuffer to use DEFAULT_SIZE as the initial buffer size instead of 0.
This will allow InputStream#read to properly populate the buffer as expected and terminate the loop when EOF is reached.
Set initial value of currentBufferIndex to -1 so it is properly initialized to 0 when needNewBuffer is called; unrelated to the infinite loop bug.
