### PR TITLE
[io-279] fixing macos-x-13-java8 unstable test due to posix file time…

### DIFF
--- a/src/test/java/org/apache/commons/io/test/TestUtils.java
+++ b/src/test/java/org/apache/commons/io/test/TestUtils.java
@@ -252,6 +252,19 @@ public abstract class TestUtils {
     }
 
     /**
+     * Sleeps till the next full second.
+     *
+     * This method is useful when you want to set a guaranteed newer file system timestamp.
+     * Posix file systems only guarantee one second resolution, and e.g.
+     * some mac os x filesystems only offer that.
+     *
+     * @throws InterruptedException if interrupted.
+     */
+    public static void sleepTillNextFullSecond() throws InterruptedException {
+        sleep(1001 - (System.currentTimeMillis() % 1000));
+    }
+
+    /**
      * Sleeps and swallows InterruptedException.
      *
      * @param millis the number of milliseconds to sleep.


### PR DESCRIPTION
… resolution is only 1s. Adding TestUtils.sleepTillNextFullSecond()

@garydgregory 
followup to PR https://github.com/apache/commons-io/pull/757 . The test was unstable, as the java.nio.file.Files.getLastModifiedTime() on macosx-13-java8 only has a time resolution of 1s (and it is used in Tailer.TailablePath.lastModifiedFIleTIme). 

Note: it seems, that java.io.File.lastModified() has  millisecond resolution on that platform, but it doesn't make sense to change the real code for everyone because of an odd platform.

So tests are now adapated, that the file date is updated after the curent second has passed to comply with posix standard Additionaly the waittime is shortened a little by polling instead of waiting max time.

see https://github.com/JoergBudi/commons-io/actions/runs/16092357707/job/45410764092 for passed test.