### PR TITLE
`FileUtils#byteCountToDisplaySize` supports Zettabyte, Yottabyte, Ronnabyte and Quettabyte

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -194,12 +194,22 @@ public class FileUtils {
     /**
      * The number of bytes in a zettabyte.
      */
-    public static final BigInteger ONE_ZB = BigInteger.valueOf(ONE_KB).multiply(BigInteger.valueOf(ONE_EB));
+    public static final BigInteger ONE_ZB = ONE_KB_BI.multiply(ONE_EB_BI);
 
     /**
      * The number of bytes in a yottabyte.
      */
     public static final BigInteger ONE_YB = ONE_KB_BI.multiply(ONE_ZB);
+
+    /**
+     * The number of bytes in a ronnabyte.
+     */
+    public static final BigInteger ONE_RB = ONE_KB_BI.multiply(ONE_YB);
+
+    /**
+     * The number of bytes in a quettabyte.
+     */
+    public static final BigInteger ONE_QB = ONE_KB_BI.multiply(ONE_RB);
 
     /**
      * An empty array of type {@link File}.
@@ -227,7 +237,15 @@ public class FileUtils {
         Objects.requireNonNull(size, "size");
         final String displaySize;
 
-        if (size.divide(ONE_EB_BI).compareTo(BigInteger.ZERO) > 0) {
+        if (size.divide(ONE_QB).compareTo(BigInteger.ZERO) > 0) {
+            displaySize = size.divide(ONE_QB) + " QB";
+        } else if (size.divide(ONE_RB).compareTo(BigInteger.ZERO) > 0) {
+            displaySize = size.divide(ONE_RB) + " RB";
+        } else if (size.divide(ONE_YB).compareTo(BigInteger.ZERO) > 0) {
+            displaySize = size.divide(ONE_YB) + " YB";
+        } else if (size.divide(ONE_ZB).compareTo(BigInteger.ZERO) > 0) {
+            displaySize = size.divide(ONE_ZB) + " ZB";
+        } else if (size.divide(ONE_EB_BI).compareTo(BigInteger.ZERO) > 0) {
             displaySize = size.divide(ONE_EB_BI) + " EB";
         } else if (size.divide(ONE_PB_BI).compareTo(BigInteger.ZERO) > 0) {
             displaySize = size.divide(ONE_PB_BI) + " PB";

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -38,7 +38,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
-import java.nio.file.FileTreeWalker;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -204,11 +204,15 @@ public class FileUtils {
 
     /**
      * The number of bytes in a ronnabyte.
+     *
+     * @since 2.21.0
      */
     public static final BigInteger ONE_RB = ONE_KB_BI.multiply(ONE_YB);
 
     /**
      * The number of bytes in a quettabyte.
+     *
+     * @since 2.21.0
      */
     public static final BigInteger ONE_QB = ONE_KB_BI.multiply(ONE_RB);
 

--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -38,6 +38,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileTreeWalker;
 import java.nio.file.FileVisitOption;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -227,7 +228,7 @@ public class FileUtils {
      * </p>
      *
      * @param size the number of bytes
-     * @return a human-readable display value (includes units - EB, PB, TB, GB, MB, KB or bytes)
+     * @return a human-readable display value (includes units - QB, RB, YB, ZB, EB, PB, TB, GB, MB, KB or bytes)
      * @throws NullPointerException if the given {@link BigInteger} is {@code null}.
      * @see <a href="https://issues.apache.org/jira/browse/IO-226">IO-226 - should the rounding be changed?</a>
      * @since 2.4

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -370,6 +370,10 @@ class FileUtilsTest extends AbstractTempDirTest {
         final BigInteger TB1 = GB1.multiply(KB1);
         final BigInteger PB1 = TB1.multiply(KB1);
         final BigInteger EB1 = PB1.multiply(KB1);
+        final BigInteger ZB1 = EB1.multiply(KB1);
+        final BigInteger YB1 = ZB1.multiply(KB1);
+        final BigInteger RB1 = YB1.multiply(KB1);
+        final BigInteger QB1 = RB1.multiply(KB1);
         assertEquals("0 bytes", FileUtils.byteCountToDisplaySize(BigInteger.ZERO));
         assertEquals("1 bytes", FileUtils.byteCountToDisplaySize(BigInteger.ONE));
         assertEquals("1023 bytes", FileUtils.byteCountToDisplaySize(b1023));
@@ -386,6 +390,10 @@ class FileUtilsTest extends AbstractTempDirTest {
         assertEquals("1 TB", FileUtils.byteCountToDisplaySize(TB1));
         assertEquals("1 PB", FileUtils.byteCountToDisplaySize(PB1));
         assertEquals("1 EB", FileUtils.byteCountToDisplaySize(EB1));
+        assertEquals("1 ZB", FileUtils.byteCountToDisplaySize(ZB1));
+        assertEquals("1 YB", FileUtils.byteCountToDisplaySize(YB1));
+        assertEquals("1 RB", FileUtils.byteCountToDisplaySize(RB1));
+        assertEquals("1 QB", FileUtils.byteCountToDisplaySize(QB1));
         assertEquals("7 EB", FileUtils.byteCountToDisplaySize(Long.MAX_VALUE));
         // Other MAX_VALUEs
         assertEquals("63 KB", FileUtils.byteCountToDisplaySize(BigInteger.valueOf(Character.MAX_VALUE)));


### PR DESCRIPTION
Add support for Zettabyte (ZB), Yottabyte (YB), Ronnabyte (RB) and Quettabyte (QB) in `FileUtils#byteCountToDisplaySize`

In November 2022 the International Bureau of Weights and Measures (BIPM) added the prefixes `ronna‑` (10²⁷) and `quetta‑` (10³⁰) 
[source](https://www.bipm.org/en/measurement-units/si-prefixes).

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
