### PR TITLE
fix: correct `BoundedInputStream.getRemaining()` for unbounded streams

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,6 +50,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="fix" dev="ggregory"                due-to="Gary Gregory">When testing on Java 21 and up, enable -XX:+EnableDynamicAgentLoading.</action>
       <action type="fix" dev="ggregory"                due-to="Gary Gregory">When testing on Java 24 and up, don't fail FileUtilsListFilesTest for a different behavior in the JRE.</action>
       <action type="fix" dev="ggregory"                due-to="Stanislav Fort, Gary Gregory">ValidatingObjectInputStream does not validate dynamic proxy interfaces.</action>
+      <action type="fix" dev="pkarwasz"                due-to="Piotr P. Karwasz">BoundedInputStream.getRemaining() now reports Long.MAX_VALUE instead of 0 when no limit is set.</action>
       <!-- ADD -->
       <action dev="ggregory" type="add"                due-to="strangelookingnerd, Gary Gregory">FileUtils#byteCountToDisplaySize() supports Zettabyte, Yottabyte, Ronnabyte and Quettabyte #763.</action>
       <action dev="ggregory" type="add"                due-to="strangelookingnerd, Gary Gregory">Add org.apache.commons.io.FileUtils.ONE_RB #763.</action>

--- a/src/main/java/org/apache/commons/io/input/BoundedInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BoundedInputStream.java
@@ -405,9 +405,9 @@ public class BoundedInputStream extends ProxyInputStream {
     }
 
     /**
-     * Gets the max count of bytes to read.
+     * Returns the maximum number of bytes this stream is allowed to read.
      *
-     * @return The max count of bytes to read.
+     * @return the maximum number of bytes permitted, or {@value IOUtils#EOF} if unbounded.
      * @since 2.16.0
      */
     public long getMaxCount() {
@@ -427,13 +427,19 @@ public class BoundedInputStream extends ProxyInputStream {
     }
 
     /**
-     * Gets how many bytes remain to read.
+     * Returns the bytes remaining before the configured read limit is reached.
      *
-     * @return bytes how many bytes remain to read.
+     * <p>This method does <strong>not</strong> report the bytes available in the
+     * underlying stream; it only reflects the remaining allowance imposed by this
+     * {@code BoundedInputStream}.</p>
+     *
+     * @return the number of bytes left until the read limit is reached,
+     *         or {@link Long#MAX_VALUE} if no limit is set.
      * @since 2.16.0
      */
     public long getRemaining() {
-        return Math.max(0, getMaxCount() - getCount());
+        final long maxCount = getMaxCount();
+        return maxCount == EOF ? Long.MAX_VALUE : Math.max(0, maxCount - getCount());
     }
 
     private boolean isMaxCount() {


### PR DESCRIPTION
`BoundedInputStream.getRemaining()` previously returned `0` when no read limit was set, which was misleading. It now returns `Long.MAX_VALUE` to more clearly represent an unbounded stream.

The Javadoc was also updated to clarify that the method reflects only the configured limit and does **not** report the actual number of bytes available in the underlying stream.

Although `Long.MAX_VALUE` represents almost 8 EiB, the behavior of `getMaxCount()` is unchanged: it still returns `EOF` (`-1`) to signal an unbounded stream. The Javadoc was updated to make this explicit, and new unit tests were added to clearly differentiate an unbounded stream from one explicitly limited to `Long.MAX_VALUE`:

* When `getMaxCount()` returns `-1`, `getRemaining()` always reports `Long.MAX_VALUE`, regardless of how many bytes have been read.
* When `getMaxCount()` returns `Long.MAX_VALUE`, `getRemaining()` begins at `Long.MAX_VALUE` but decreases as bytes are consumed.

Before you push a pull request, review this list:

- [x] I used AI to create Javadoc and unit test comments.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
