### PR TITLE
Inline private field `ProxyInputStream.exceptionHandler`

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,6 +50,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="fix" dev="ggregory"                due-to="Gary Gregory">When testing on Java 21 and up, enable -XX:+EnableDynamicAgentLoading.</action>
       <action type="fix" dev="ggregory"                due-to="Gary Gregory">When testing on Java 24 and up, don't fail FileUtilsListFilesTest for a different behavior in the JRE.</action>
       <action type="fix" dev="ggregory"                due-to="Stanislav Fort, Gary Gregory">ValidatingObjectInputStream does not validate dynamic proxy interfaces.</action>
+      <action type="fix" dev="pkarwasz"                due-to="Piotr P. Karwasz">Inline constant ProxyInputStream.exceptionHandler field.</action>
       <!-- ADD -->
       <action dev="ggregory" type="add"                due-to="strangelookingnerd, Gary Gregory">FileUtils#byteCountToDisplaySize() supports Zettabyte, Yottabyte, Ronnabyte and Quettabyte #763.</action>
       <action dev="ggregory" type="add"                due-to="strangelookingnerd, Gary Gregory">Add org.apache.commons.io.FileUtils.ONE_RB #763.</action>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -50,7 +50,6 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="fix" dev="ggregory"                due-to="Gary Gregory">When testing on Java 21 and up, enable -XX:+EnableDynamicAgentLoading.</action>
       <action type="fix" dev="ggregory"                due-to="Gary Gregory">When testing on Java 24 and up, don't fail FileUtilsListFilesTest for a different behavior in the JRE.</action>
       <action type="fix" dev="ggregory"                due-to="Stanislav Fort, Gary Gregory">ValidatingObjectInputStream does not validate dynamic proxy interfaces.</action>
-      <action type="fix" dev="pkarwasz"                due-to="Piotr P. Karwasz">Inline constant ProxyInputStream.exceptionHandler field.</action>
       <!-- ADD -->
       <action dev="ggregory" type="add"                due-to="strangelookingnerd, Gary Gregory">FileUtils#byteCountToDisplaySize() supports Zettabyte, Yottabyte, Ronnabyte and Quettabyte #763.</action>
       <action dev="ggregory" type="add"                due-to="strangelookingnerd, Gary Gregory">Add org.apache.commons.io.FileUtils.ONE_RB #763.</action>
@@ -61,7 +60,9 @@ The <action> type attribute can be add,update,fix,remove.
       <!-- UPDATE -->
       <action type="update" dev="ggregory"             due-to="Gary Gregory, Dependabot">Bump org.apache.commons:commons-parent from 85 to 87 #774.</action>
       <action type="update" dev="ggregory"             due-to="Gary Gregory">[test] Bump commons-codec:commons-codec from 1.18.0 to 1.19.0.</action>
-      <action type="update" dev="ggregory"             due-to="Gary Gregory">[test] Bump commons.bytebuddy.version from 1.17.6 to 1.17.7 #769.</action> 
+      <action type="update" dev="ggregory"             due-to="Gary Gregory">[test] Bump commons.bytebuddy.version from 1.17.6 to 1.17.7 #769.</action>
+      <!-- REMOVE -->
+      <action type="remove" dev="pkarwasz"             due-to="Piotr P. Karwasz">Inline private constant field ProxyInputStream.exceptionHandler #780.</action>
   </release>
     <release version="2.20.0" date="2025-07-13" description="Version 2.20.0: Java 8 or later is required.">
       <!-- FIX -->

--- a/src/main/java/org/apache/commons/io/input/ProxyInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/ProxyInputStream.java
@@ -24,8 +24,6 @@ import java.io.InputStream;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.build.AbstractStreamBuilder;
-import org.apache.commons.io.function.Erase;
-import org.apache.commons.io.function.IOConsumer;
 import org.apache.commons.io.function.IOIntConsumer;
 
 /**
@@ -102,11 +100,6 @@ public abstract class ProxyInputStream extends FilterInputStream {
      */
     private volatile boolean closed;
 
-    /**
-     * Handles exceptions.
-     */
-    private final IOConsumer<IOException> exceptionHandler;
-
     private final IOIntConsumer afterRead;
 
     /**
@@ -130,7 +123,6 @@ public abstract class ProxyInputStream extends FilterInputStream {
     public ProxyInputStream(final InputStream proxy) {
         // the delegate is stored in a protected superclass variable named 'in'.
         super(proxy);
-        this.exceptionHandler = Erase::rethrow;
         this.afterRead = IOIntConsumer.NOOP;
     }
 
@@ -144,7 +136,6 @@ public abstract class ProxyInputStream extends FilterInputStream {
     protected ProxyInputStream(final InputStream proxy, final AbstractBuilder<?, ?> builder) {
         // the delegate is stored in a protected superclass instance variable named 'in'.
         super(proxy);
-        this.exceptionHandler = Erase::rethrow;
         this.afterRead = builder.getAfterRead() != null ? builder.getAfterRead() : IOIntConsumer.NOOP;
     }
 
@@ -245,7 +236,7 @@ public abstract class ProxyInputStream extends FilterInputStream {
      * @since 2.0
      */
     protected void handleIOException(final IOException e) throws IOException {
-        exceptionHandler.accept(e);
+        throw e;
     }
 
     /**


### PR DESCRIPTION
The private, final field `exceptionHandler` was always set to `Erase::rethrow` and had no way to be changed (no setter provided). By inlining its single usage, `handleIOException` becomes simpler and its behavior is clearly fixed, with changes only possible through subclassing.
