### PR TITLE
feat: add length unit support in FileSystem limits

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -57,6 +57,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action dev="ggregory" type="add"                due-to="Gary Gregory">Add org.apache.commons.io.output.ProxyOutputStream.writeRepeat(byte[], int, int, long).</action>
       <action dev="ggregory" type="add"                due-to="Gary Gregory">Add org.apache.commons.io.output.ProxyOutputStream.writeRepeat(byte[], long).</action>
       <action dev="ggregory" type="add"                due-to="Gary Gregory">Add org.apache.commons.io.output.ProxyOutputStream.writeRepeat(int, long).</action>
+      <action dev="pkarwasz" type="add"                due-to="Piotr P. Karwasz">Add length unit support in FileSystem limits.</action>
       <!-- UPDATE -->
       <action type="update" dev="ggregory"             due-to="Gary Gregory, Dependabot">Bump org.apache.commons:commons-parent from 85 to 87 #774.</action>
       <action type="update" dev="ggregory"             due-to="Gary Gregory">[test] Bump commons-codec:commons-codec from 1.18.0 to 1.19.0.</action>

--- a/src/main/java/org/apache/commons/io/FileSystem.java
+++ b/src/main/java/org/apache/commons/io/FileSystem.java
@@ -424,7 +424,8 @@ public enum FileSystem {
     /**
      * Gets the maximum length for file paths (may include folders).
      *
-     * <p>This may include folder names as well as the file name.</p>
+     * <p>This value is inclusive of all path components and separators.
+     * For a limit of each path component see {@link #getMaxFileNameLength()}.</p>
      *
      * <p>The value is expressed in Java {@code char} units (UTF-16 code units)
      * and represents the longest path that can be safely passed to Java

--- a/src/main/java/org/apache/commons/io/FileSystem.java
+++ b/src/main/java/org/apache/commons/io/FileSystem.java
@@ -676,10 +676,8 @@ public enum FileSystem {
 
             private int safeCutPoint(final CharSequence value, final int limit) {
                 // Ensure we do not cut a surrogate pair in half.
-                if (Character.isHighSurrogate(value.charAt(limit - 1))) {
-                    if (Character.isLowSurrogate(value.charAt(limit))) {
-                        return limit - 1;
-                    }
+                if (Character.isHighSurrogate(value.charAt(limit - 1)) && Character.isLowSurrogate(value.charAt(limit))) {
+                    return limit - 1;
                 }
                 return limit;
             }

--- a/src/main/java/org/apache/commons/io/FileSystem.java
+++ b/src/main/java/org/apache/commons/io/FileSystem.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.io;
 
+import static java.nio.charset.StandardCharsets.UTF_16;
+
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.charset.CharacterCodingException;
@@ -653,6 +655,11 @@ public enum FileSystem {
 
             @Override
             CharSequence truncate(final CharSequence value, final int limit, final Charset charset) {
+                if (!UTF_16.newEncoder().canEncode(value)) {
+                    throw new IllegalArgumentException(
+                            "The value " + value + " can not be encoded using " + UTF_16.name());
+                }
+
                 // Fast path: no truncation needed.
                 if (value.length() <= limit) {
                     return value;
@@ -675,7 +682,7 @@ public enum FileSystem {
 
             private int safeCutPoint(final CharSequence value, final int limit) {
                 // Ensure we do not cut a surrogate pair in half.
-                if (Character.isHighSurrogate(value.charAt(limit - 1)) && Character.isLowSurrogate(value.charAt(limit))) {
+                if (Character.isHighSurrogate(value.charAt(limit - 1))) {
                     return limit - 1;
                 }
                 return limit;

--- a/src/main/java/org/apache/commons/io/FileSystem.java
+++ b/src/main/java/org/apache/commons/io/FileSystem.java
@@ -212,7 +212,7 @@ public enum FileSystem {
         }
     }
 
-    /**
+    /*
      * Finds the index of the first dot in a CharSequence.
      */
     private static int indexOfFirstDot(final CharSequence cs) {

--- a/src/main/java/org/apache/commons/io/FileSystem.java
+++ b/src/main/java/org/apache/commons/io/FileSystem.java
@@ -660,10 +660,9 @@ public enum FileSystem {
                 // Slow path: truncate to limit.
                 // 1. Compute length of extension in chars (if any).
                 final int extensionStart = indexOfFirstDot(value);
-                final boolean hasExtension = extensionStart > 0;
-                final int extensionLength = hasExtension ? value.length() - extensionStart : 0;
+                final int extensionLength = extensionStart > 0 ? value.length() - extensionStart : 0;
                 // 2. Truncate the non-extension part and append the extension (if any).
-                if (hasExtension && extensionLength >= limit) {
+                if (extensionLength >= limit) {
                     // Extension itself does not fit
                     throw new IllegalArgumentException("The extension of " + value + " is too long to fit within " + limit + " characters");
                 }

--- a/src/main/java/org/apache/commons/io/FileSystem.java
+++ b/src/main/java/org/apache/commons/io/FileSystem.java
@@ -73,7 +73,7 @@ public enum FileSystem {
             '/',
              ':'
             // @formatter:on
-    }, new String[] {}, false, false, '/', NameLengthStrategy.UTF16_CODE_UNITS),
+    }, new String[] {}, false, false, '/', NameLengthStrategy.BYTES),
 
     /**
      * Windows file system.

--- a/src/main/java/org/apache/commons/io/FileSystem.java
+++ b/src/main/java/org/apache/commons/io/FileSystem.java
@@ -73,7 +73,7 @@ public enum FileSystem {
             '/',
              ':'
             // @formatter:on
-    }, new String[] {}, false, false, '/', NameLengthStrategy.UTF16_CHARS),
+    }, new String[] {}, false, false, '/', NameLengthStrategy.UTF16_CODE_UNITS),
 
     /**
      * Windows file system.
@@ -107,7 +107,7 @@ public enum FileSystem {
                     "LPT1", "LPT2", "LPT3", "LPT4", "LPT5", "LPT6", "LPT7", "LPT8", "LPT9",
                     "LPT\u00b2", "LPT\u00b3", "LPT\u00b9", // Superscript 2 3 1 in that order
                     "NUL", "PRN"
-            }, true, true, '\\', NameLengthStrategy.UTF16_CHARS);
+            }, true, true, '\\', NameLengthStrategy.UTF16_CODE_UNITS);
     // @formatter:on
 
     /**
@@ -645,7 +645,7 @@ public enum FileSystem {
         },
 
         /** Length measured as UTF-16 code units (i.e., {@code CharSequence.length()}). */
-        UTF16_CHARS {
+        UTF16_CODE_UNITS {
             @Override
             int getLength(final CharSequence value, final Charset charset) {
                 return value.length();

--- a/src/main/java/org/apache/commons/io/FileSystem.java
+++ b/src/main/java/org/apache/commons/io/FileSystem.java
@@ -269,8 +269,7 @@ public enum FileSystem {
     private final boolean supportsDriveLetter;
     private final char nameSeparator;
     private final char nameSeparatorOther;
-    // package-private for testing
-    final NameLengthStrategy nameLengthStrategy;
+    private final NameLengthStrategy nameLengthStrategy;
 
     /**
      * Constructs a new instance.

--- a/src/test/java/org/apache/commons/io/FileSystemTest.java
+++ b/src/test/java/org/apache/commons/io/FileSystemTest.java
@@ -194,11 +194,12 @@ class FileSystemTest {
     void testMaxNameLength_MatchesRealSystem(@TempDir Path tempDir) {
         final FileSystem fs = FileSystem.getCurrent();
         final String[] validNames;
-        switch (fs.nameLengthStrategy) {
-            case BYTES:
+        switch (fs) {
+            case LINUX:
                 validNames = new String[] { FILE_NAME_255_ASCII, FILE_NAME_255_UTF8_BYTES };
                 break;
-            case UTF16_CHARS:
+            case MAC_OSX:
+            case WINDOWS:
                 validNames = new String[] { FILE_NAME_255_ASCII, FILE_NAME_255_UTF16_CHARS };
                 break;
             default:

--- a/src/test/java/org/apache/commons/io/FileSystemTest.java
+++ b/src/test/java/org/apache/commons/io/FileSystemTest.java
@@ -46,7 +46,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests {@link FileSystem}.

--- a/src/test/java/org/apache/commons/io/FileSystemTest.java
+++ b/src/test/java/org/apache/commons/io/FileSystemTest.java
@@ -195,10 +195,10 @@ class FileSystemTest {
         final FileSystem fs = FileSystem.getCurrent();
         final String[] validNames;
         switch (fs) {
+            case MAC_OSX:
             case LINUX:
                 validNames = new String[] { FILE_NAME_255_ASCII, FILE_NAME_255_UTF8_BYTES };
                 break;
-            case MAC_OSX:
             case WINDOWS:
                 validNames = new String[] { FILE_NAME_255_ASCII, FILE_NAME_255_UTF16_CODE_UNITS};
                 break;

--- a/src/test/java/org/apache/commons/io/FileSystemTest.java
+++ b/src/test/java/org/apache/commons/io/FileSystemTest.java
@@ -203,7 +203,7 @@ class FileSystemTest {
                 validNames = new String[] { FILE_NAME_255_ASCII, FILE_NAME_255_UTF16_CHARS };
                 break;
             default:
-                throw new IllegalStateException("Unexpected value: " + fs.nameLengthStrategy);
+                throw new IllegalStateException("Unexpected value: " + fs);
         }
         for (final String fileName : validNames) {
             assertDoesNotThrow(() -> testFileName(tempDir, fileName), "OS accepts max length name");

--- a/src/test/java/org/apache/commons/io/FileSystemTest.java
+++ b/src/test/java/org/apache/commons/io/FileSystemTest.java
@@ -62,7 +62,7 @@ class FileSystemTest {
     private static final String FILE_NAME_255_UTF8_BYTES = StringUtils.repeat(UTF8_3BYTE_CHAR, 85);
 
     /** File name of 255 UTF-16 chars, each 3 bytes in UTF-8: total 765 bytes. */
-    private static final String FILE_NAME_255_UTF16_CHARS = StringUtils.repeat(UTF8_3BYTE_CHAR, 255);
+    private static final String FILE_NAME_255_UTF16_CODE_UNITS = StringUtils.repeat(UTF8_3BYTE_CHAR, 255);
 
     @Test
     void testGetBlockSize() {
@@ -114,9 +114,9 @@ class FileSystemTest {
                 Arguments.of(FileSystem.LINUX, FILE_NAME_255_ASCII, UTF_8),
                 Arguments.of(FileSystem.LINUX, FILE_NAME_255_UTF8_BYTES, UTF_8),
                 Arguments.of(FileSystem.MAC_OSX, FILE_NAME_255_ASCII, UTF_8),
-                Arguments.of(FileSystem.MAC_OSX, FILE_NAME_255_UTF16_CHARS, UTF_8),
+                Arguments.of(FileSystem.MAC_OSX, FILE_NAME_255_UTF8_BYTES, UTF_8),
                 Arguments.of(FileSystem.WINDOWS, FILE_NAME_255_ASCII, UTF_8),
-                Arguments.of(FileSystem.WINDOWS, FILE_NAME_255_UTF16_CHARS, UTF_8));
+                Arguments.of(FileSystem.WINDOWS, FILE_NAME_255_UTF16_CODE_UNITS, UTF_8));
     }
 
     @ParameterizedTest
@@ -200,7 +200,7 @@ class FileSystemTest {
                 break;
             case MAC_OSX:
             case WINDOWS:
-                validNames = new String[] { FILE_NAME_255_ASCII, FILE_NAME_255_UTF16_CHARS };
+                validNames = new String[] { FILE_NAME_255_ASCII, FILE_NAME_255_UTF16_CODE_UNITS};
                 break;
             default:
                 throw new IllegalStateException("Unexpected value: " + fs);
@@ -282,9 +282,9 @@ class FileSystemTest {
                 Arguments.of(
                         UTF16_CODE_UNITS,
                         255,
-                        FILE_NAME_255_UTF16_CHARS + ".txt",
-                        FILE_NAME_255_UTF16_CHARS.substring(0, 251) + ".txt"),
-                Arguments.of(UTF16_CODE_UNITS, 255, FILE_NAME_255_UTF16_CHARS + "aaaa", FILE_NAME_255_UTF16_CHARS),
+                        FILE_NAME_255_UTF16_CODE_UNITS + ".txt",
+                        FILE_NAME_255_UTF16_CODE_UNITS.substring(0, 251) + ".txt"),
+                Arguments.of(UTF16_CODE_UNITS, 255, FILE_NAME_255_UTF16_CODE_UNITS + "aaaa", FILE_NAME_255_UTF16_CODE_UNITS),
                 Arguments.of(
                         UTF16_CODE_UNITS,
                         7,

--- a/src/test/java/org/apache/commons/io/FileSystemTest.java
+++ b/src/test/java/org/apache/commons/io/FileSystemTest.java
@@ -273,7 +273,6 @@ class FileSystemTest {
 
             // OS behavior: may or may not reject.
             try {
-                // Some file systems do not enforce the limit, for example XFS on Linux
                 createAndDelete(tempDir, tooLongName);
             } catch (final Throwable e) {
                 failures++;
@@ -295,7 +294,7 @@ class FileSystemTest {
         // Because of this mismatch, depending on which filesystem is mounted,
         // either all or only FILE_NAME_255BYTES_UTF8_1B + "a" will be rejected.
         if (SystemUtils.IS_OS_MAC_OSX) {
-            assertTrue(failures == 1 || failures == 4, "At least one name too long was rejected");
+            assertTrue(failures >= 1, "Expected at least one too-long name rejected, got " + failures);
         } else {
             assertEquals(4, failures, "All too-long names were rejected");
         }

--- a/src/test/java/org/apache/commons/io/FileSystemTest.java
+++ b/src/test/java/org/apache/commons/io/FileSystemTest.java
@@ -17,20 +17,44 @@
 
 package org.apache.commons.io;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.FileSystem.LengthUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.SystemProperties;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledOnOs;
-import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests {@link FileSystem}.
  */
 class FileSystemTest {
+
+    // 255 UTF-8 bytes == 85 UTF-16 chars of 3-byte UTF-8
+    private static final String FILE_NAME_255_BYTES = StringUtils.repeat('★', 85);
+    // 255 UTF-16 chars == 3 * 85 UTF-8 chars
+    private static final String FILE_NAME_255_CHARS = StringUtils.repeat(FILE_NAME_255_BYTES, 3);
+    // 1020 UTF-8 bytes
+    private static final String FILE_NAME_1020_BYTES = StringUtils.repeat(FILE_NAME_255_BYTES, 4);
 
     @Test
     void testGetBlockSize() {
@@ -56,18 +80,54 @@ class FileSystemTest {
         assertNotSame(current.getIllegalFileNameChars(), current.getIllegalFileNameChars());
     }
 
+    @ParameterizedTest
+    @EnumSource(FileSystem.class)
+    void testGetLengthUnit(FileSystem fs) {
+        final LengthUnit expected =
+                fs == FileSystem.WINDOWS || fs == FileSystem.MAC_OSX ? LengthUnit.CHARS : LengthUnit.BYTES;
+        assertEquals(expected, fs.getLengthUnit());
+    }
+
     @Test
-    void testIsLegalName() {
-        for (final FileSystem fs : FileSystem.values()) {
-            assertFalse(fs.isLegalFileName(""), fs.name()); // Empty is always illegal
-            assertFalse(fs.isLegalFileName(null), fs.name()); // null is always illegal
-            assertFalse(fs.isLegalFileName("\0"), fs.name()); // Assume NUL is always illegal
-            assertTrue(fs.isLegalFileName("0"), fs.name()); // Assume simple name always legal
-            for (final String candidate : fs.getReservedFileNames()) {
-                // Reserved file names are not legal
-                assertFalse(fs.isLegalFileName(candidate), candidate);
-            }
+    void testGetNameSeparator() {
+        final FileSystem current = FileSystem.getCurrent();
+        assertEquals(SystemProperties.getFileSeparator(), Character.toString(current.getNameSeparator()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(FileSystem.class)
+    void testIsLegalName(final FileSystem fs) {
+        assertFalse(fs.isLegalFileName(""), fs.name()); // Empty is always illegal
+        assertFalse(fs.isLegalFileName(null), fs.name()); // null is always illegal
+        assertFalse(fs.isLegalFileName("\0"), fs.name()); // Assume NUL is always illegal
+        assertTrue(fs.isLegalFileName("0"), fs.name()); // Assume simple name always legal
+        for (final String candidate : fs.getReservedFileNames()) {
+            // Reserved file names are not legal
+            assertFalse(fs.isLegalFileName(candidate), candidate);
         }
+    }
+
+    static Stream<Arguments> testIsLegalName_Length() {
+        return Stream.of(
+                Arguments.of(FileSystem.GENERIC, FILE_NAME_1020_BYTES, UTF_8),
+                Arguments.of(FileSystem.LINUX, FILE_NAME_255_BYTES, UTF_8),
+                Arguments.of(FileSystem.MAC_OSX, FILE_NAME_255_CHARS, UTF_8),
+                Arguments.of(FileSystem.WINDOWS, FILE_NAME_255_CHARS, UTF_8)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testIsLegalName_Length(FileSystem fs, String nameAtLimit, Charset charset) {
+        assertTrue(fs.isLegalFileName(nameAtLimit, charset), fs.name() + " length at limit");
+        final String nameOverLimit = nameAtLimit + "a";
+        assertFalse(fs.isLegalFileName(nameOverLimit, charset), fs.name() + " length over limit");
+    }
+
+    @Test
+    void testIsLegalName_Encoding() {
+        assertFalse(FileSystem.GENERIC.isLegalFileName(FILE_NAME_255_BYTES, US_ASCII), "US-ASCII cannot represent all chars");
+        assertTrue(FileSystem.GENERIC.isLegalFileName(FILE_NAME_255_BYTES, UTF_8), "UTF-8 can represent all chars");
     }
 
     @Test
@@ -80,7 +140,6 @@ class FileSystemTest {
     }
 
     @Test
-    @EnabledOnOs(OS.WINDOWS)
     void testIsReservedFileNameOnWindows() {
         final FileSystem fs = FileSystem.WINDOWS;
         for (final String candidate : fs.getReservedFileNames()) {
@@ -129,6 +188,21 @@ class FileSystemTest {
     }
 
     @Test
+    void testMaxNameLength_MatchesRealSystem(@TempDir Path tempDir) {
+        final FileSystem fs = FileSystem.getCurrent();
+        final String fileName = fs.getLengthUnit() == LengthUnit.BYTES ? FILE_NAME_255_BYTES : FILE_NAME_255_CHARS;
+        // OS accepts a maximum length name
+        assertDoesNotThrow(() -> Files.createFile(tempDir.resolve(fileName)), "OS accepts max length name");
+        // OS rejects a too-long name
+        final String tooLongName = fileName + "a";
+        assertThrows(
+                IOException.class, () -> Files.createFile(tempDir.resolve(tooLongName)), "OS rejects too-long name");
+        // Commons IO agrees
+        assertTrue(fs.isLegalFileName(fileName, UTF_8), "Commons IO accepts max length name");
+        assertFalse(fs.isLegalFileName(tooLongName, UTF_8), "Commons IO rejects too-long name");
+    }
+
+    @Test
     void testSupportsDriveLetter() {
         assertTrue(FileSystem.WINDOWS.supportsDriveLetter());
         assertFalse(FileSystem.GENERIC.supportsDriveLetter());
@@ -156,5 +230,70 @@ class FileSystemTest {
         for (char i = '0'; i < '9'; i++) {
             assertEquals(i, fs.toLegalFileName(String.valueOf(i), replacement).charAt(0));
         }
+        // Null and empty
+        assertThrows(NullPointerException.class, () -> fs.toLegalFileName(null, '_'));
+        assertThrows(IllegalArgumentException.class, () -> fs.toLegalFileName("", '_'));
+        // Illegal replacement
+        assertThrows(IllegalArgumentException.class, () -> fs.toLegalFileName("test", '\0'));
+        assertThrows(IllegalArgumentException.class, () -> fs.toLegalFileName("test", ':'));
+    }
+
+    static Stream<Arguments> testTruncateFileName() {
+        return Stream.of(
+                Arguments.of(FileSystem.GENERIC, "simple.txt", "simple.txt"),
+                Arguments.of(FileSystem.GENERIC, FILE_NAME_1020_BYTES + ".txt", FILE_NAME_1020_BYTES),
+                Arguments.of(FileSystem.LINUX, "simple.txt", "simple.txt"),
+                Arguments.of(FileSystem.LINUX, FILE_NAME_255_BYTES + ".txt", FILE_NAME_255_BYTES),
+                Arguments.of(FileSystem.MAC_OSX, "simple.txt", "simple.txt"),
+                Arguments.of(FileSystem.MAC_OSX, FILE_NAME_255_CHARS + ".txt", FILE_NAME_255_CHARS),
+                Arguments.of(FileSystem.WINDOWS, "simple.txt", "simple.txt"),
+                Arguments.of(FileSystem.WINDOWS, FILE_NAME_255_CHARS + ".txt", FILE_NAME_255_CHARS));
+    }
+
+    @ParameterizedTest(name = "{index}: {0} truncates {1} to {2}")
+    @MethodSource
+    void testTruncateFileName(FileSystem fs, String input, String expected) {
+        final CharSequence out = fs.truncateFileName(input, UTF_8);
+        assertEquals(expected, out, fs.name());
+    }
+
+    static Stream<Arguments> testTruncateByBytes_Succeeds() {
+        return Stream.of(
+                // ASCII (UTF-8) — fits
+                Arguments.of("ASCII fits (UTF-8)", "hello", UTF_8, 5, "hello"),
+                // ASCII (UTF-8) — truncate
+                Arguments.of("ASCII truncated (UTF-8)", "hello", UTF_8, 4, "hell"),
+                // Empty input
+                Arguments.of("Empty input", "", UTF_8, 10, ""),
+                // Zero budget → empty
+                Arguments.of("Zero-byte limit", "anything", UTF_8, 0, ""),
+                // UTF-8: 2-byte char exact fit
+                Arguments.of("UTF-8: 2-byte char exact fit", "é", UTF_8, 2, "é"),
+                // UTF-8: 2-byte + ASCII; 3 fits both, 2 fits only 2-byte, 1 fits neither
+                Arguments.of("UTF-8: 2-byte + ASCII, both fit", "éa", UTF_8, 3, "éa"),
+                Arguments.of("UTF-8: 2-byte + ASCII, truncate before ASCII", "éa", UTF_8, 2, "é"),
+                Arguments.of("UTF-8: 2-byte + ASCII, truncate all", "éa", UTF_8, 1, ""),
+                // UTF-8: emoji + ASCII; 5 fits both, 4 fits only emoji, 3 fits neither
+                Arguments.of("UTF-8: emoji + ASCII, both fit", "😀a", UTF_8, 5, "😀a"),
+                Arguments.of("UTF-8: emoji + ASCII, truncate before ASCII", "😀a", UTF_8, 4, "😀"),
+                Arguments.of("UTF-8: emoji + ASCII, truncate all", "😀a", UTF_8, 3, ""),
+                // Large limit (fast-path should accept)
+                Arguments.of("Large limit fast-path (UTF-8)", "ok", UTF_8, 8, "ok"));
+    }
+
+    @ParameterizedTest(name = "{index}: {0}")
+    @MethodSource
+    void testTruncateByBytes_Succeeds(String caseName, String input, Charset charset, int maxBytes, String expected) {
+        final CharSequence out = FileSystem.truncateByBytes(input, charset, maxBytes);
+        // If your contract returns null for null input, this still works; otherwise adjust.
+        assertEquals(expected, Objects.toString(out, null), caseName);
+    }
+
+    @Test
+    void testTruncateByBytes_UnmappableAsciiThrows() {
+        final String in = "café"; // contains 'é' (not in ASCII)
+        final IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> FileSystem.truncateByBytes(in, US_ASCII, 100));
+        assertTrue(ex.getMessage().contains(US_ASCII.name()), "ex message contains charset name");
     }
 }

--- a/src/test/java/org/apache/commons/io/FileSystemTest.java
+++ b/src/test/java/org/apache/commons/io/FileSystemTest.java
@@ -20,7 +20,7 @@ package org.apache.commons.io;
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.commons.io.FileSystem.NameLengthStrategy.BYTES;
-import static org.apache.commons.io.FileSystem.NameLengthStrategy.UTF16_CHARS;
+import static org.apache.commons.io.FileSystem.NameLengthStrategy.UTF16_CODE_UNITS;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -274,25 +274,25 @@ class FileSystemTest {
                         255,
                         FILE_NAME_255_UTF8_BYTES + ".txt",
                         FILE_NAME_255_UTF8_BYTES.substring(0, 83) + ".txt"),
-                Arguments.of(UTF16_CHARS, 255, "simple.txt", "simple.txt"),
-                Arguments.of(UTF16_CHARS, 255, "." + FILE_NAME_255_ASCII, "." + FILE_NAME_255_ASCII.substring(0, 254)),
+                Arguments.of(UTF16_CODE_UNITS, 255, "simple.txt", "simple.txt"),
+                Arguments.of(UTF16_CODE_UNITS, 255, "." + FILE_NAME_255_ASCII, "." + FILE_NAME_255_ASCII.substring(0, 254)),
                 Arguments.of(
-                        UTF16_CHARS, 255, FILE_NAME_255_ASCII + ".txt", FILE_NAME_255_ASCII.substring(0, 251) + ".txt"),
-                Arguments.of(UTF16_CHARS, 255, FILE_NAME_255_ASCII + "aaaa", FILE_NAME_255_ASCII),
+                        UTF16_CODE_UNITS, 255, FILE_NAME_255_ASCII + ".txt", FILE_NAME_255_ASCII.substring(0, 251) + ".txt"),
+                Arguments.of(UTF16_CODE_UNITS, 255, FILE_NAME_255_ASCII + "aaaa", FILE_NAME_255_ASCII),
                 Arguments.of(
-                        UTF16_CHARS,
+                        UTF16_CODE_UNITS,
                         255,
                         FILE_NAME_255_UTF16_CHARS + ".txt",
                         FILE_NAME_255_UTF16_CHARS.substring(0, 251) + ".txt"),
-                Arguments.of(UTF16_CHARS, 255, FILE_NAME_255_UTF16_CHARS + "aaaa", FILE_NAME_255_UTF16_CHARS),
+                Arguments.of(UTF16_CODE_UNITS, 255, FILE_NAME_255_UTF16_CHARS + "aaaa", FILE_NAME_255_UTF16_CHARS),
                 Arguments.of(
-                        UTF16_CHARS,
+                        UTF16_CODE_UNITS,
                         7,
                         "😀😀.txt" // each emoji is 2 UTF-16 chars
                         ,
                         "😀.txt"),
                 // High surrogate not followed by low surrogate (invalid UTF-16 sequence)
-                Arguments.of(UTF16_CHARS, 5, "\uD83Da.txt", "\uD83D.txt"));
+                Arguments.of(UTF16_CODE_UNITS, 5, "\uD83Da.txt", "\uD83D.txt"));
     }
 
     @ParameterizedTest(name = "{index}: {0} truncates {1} to {2}")


### PR DESCRIPTION
Different filesystems and operating systems measure file and path lengths in different units:

* <s>macOS and</s> Windows filesystems typically count **UTF-16 code units**.
* Linux and other UNIX filesystems typically count **bytes**.

This change introduces explicit unit support so these limits can be interpreted consistently.

### Key changes

* **New API**

  * <s>Added a `LengthUnit` enum and `FileSystem.getLengthUnit()` to expose the unit of measure used by `getMaxFileNameLength()` and `getMaxPathLength()`</s>.
  * Added new overloads for `isLegalFileName` and `toLegalFileName` that accept a `Charset`, making conversions between bytes and UTF-16 explicit.

* **Adjusted defaults**

  * Reduced the `GENERIC` filesystem defaults:

    * File name length → **1020 bytes** (covers 255 UTF-16 characters encoded as up to 3 UTF-8 bytes).
    * Path length → **1 MiB** (covers 32,767 UTF-16 code units, again at 3 UTF-8 bytes each).

* **Testing**

  * Added unit tests to validate the new API and updated limits.
