### PR TITLE
feat: add NIO channel support to `AbstractStreamBuilder`

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -62,6 +62,8 @@ The <action> type attribute can be add,update,fix,remove.
       <action dev="ggregory" type="add"                due-to="Gary Gregory">Add org.apache.commons.io.output.ProxyOutputStream.writeRepeat(int, long).</action>
       <action dev="pkarwasz" type="add"                due-to="Piotr P. Karwasz">Add length unit support in FileSystem limits.</action>
       <action dev="pkarwasz" type="add"                due-to="Piotr P. Karwasz">Add IOUtils.toByteArray(InputStream, int, int) for safer chunked reading with size validation.</action>
+      <action dev="pkarwasz" type="add"                due-to="Piotr P. Karwasz">Add ByteArrayChannel, a simple in-memory `SeekableByteChannel` implementation.</action>
+      <action dev="pkarwasz" type="add"                due-to="Piotr P. Karwasz">Add NIO channel support to `AbstractStreamBuilder`.</action>
       <!-- UPDATE -->
       <action type="update" dev="ggregory"             due-to="Gary Gregory, Dependabot">Bump org.apache.commons:commons-parent from 85 to 87 #774.</action>
       <action type="update" dev="ggregory"             due-to="Gary Gregory">[test] Bump commons-codec:commons-codec from 1.18.0 to 1.19.0.</action>

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -224,10 +224,11 @@ public class IOUtils {
     /**
      * The maximum size of an array in many Java VMs.
      * <p>
-     * The constant is copied from OpenJDK's {@link jdk.internal.util.ArraysSupport#SOFT_MAX_ARRAY_LENGTH}.
+     * The constant is copied from OpenJDK's {@code jdk.internal.util.ArraysSupport#SOFT_MAX_ARRAY_LENGTH}.
      * </p>
+     * @since 2.21.0
      */
-    private static final int SOFT_MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
+    public static final int SOFT_MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
 
     /**
      * Returns the given InputStream if it is already a {@link BufferedInputStream}, otherwise creates a

--- a/src/main/java/org/apache/commons/io/build/AbstractOriginSupplier.java
+++ b/src/main/java/org/apache/commons/io/build/AbstractOriginSupplier.java
@@ -24,11 +24,15 @@ import java.io.RandomAccessFile;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.URI;
+import java.nio.channels.Channel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.commons.io.IORandomAccessFile;
 import org.apache.commons.io.build.AbstractOrigin.ByteArrayOrigin;
+import org.apache.commons.io.build.AbstractOrigin.ChannelOrigin;
 import org.apache.commons.io.build.AbstractOrigin.CharSequenceOrigin;
 import org.apache.commons.io.build.AbstractOrigin.FileOrigin;
 import org.apache.commons.io.build.AbstractOrigin.IORandomAccessFileOrigin;
@@ -180,6 +184,10 @@ public abstract class AbstractOriginSupplier<T, B extends AbstractOriginSupplier
      */
     protected static WriterOrigin newWriterOrigin(final Writer origin) {
         return new WriterOrigin(origin);
+    }
+
+    private static ChannelOrigin newChannelOrigin(final Channel origin) {
+        return new ChannelOrigin(origin);
     }
 
     /**
@@ -367,5 +375,27 @@ public abstract class AbstractOriginSupplier<T, B extends AbstractOriginSupplier
      */
     public B setWriter(final Writer origin) {
         return setOrigin(newWriterOrigin(origin));
+    }
+
+    /**
+     * Sets a new origin.
+     *
+     * @param origin the new origin.
+     * @return {@code this} instance.
+     * @since 2.21.0
+     */
+    public B setReadableByteChannel(final ReadableByteChannel origin) {
+        return setOrigin(newChannelOrigin(origin));
+    }
+
+    /**
+     * Sets a new origin.
+     *
+     * @param origin the new origin.
+     * @return {@code this} instance.
+     * @since 2.21.0
+     */
+    public B setWritableByteChannel(final WritableByteChannel origin) {
+        return setOrigin(newChannelOrigin(origin));
     }
 }

--- a/src/main/java/org/apache/commons/io/build/AbstractStreamBuilder.java
+++ b/src/main/java/org/apache/commons/io/build/AbstractStreamBuilder.java
@@ -24,6 +24,8 @@ import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
@@ -256,6 +258,36 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
      */
     public Writer getWriter() throws IOException {
         return checkOrigin().getWriter(getCharset(), getOpenOptions());
+    }
+
+    /**
+     * Gets a ReadableByteChannel from the origin with OpenOption[].
+     *
+     * @return A ReadableByteChannel.
+     * @throws IllegalStateException         if the {@code origin} is {@code null}.
+     * @throws UnsupportedOperationException if the origin cannot be converted to a {@link ReadableByteChannel}.
+     * @throws IOException                   if an I/O error occurs.
+     * @see AbstractOrigin#getReadableByteChannel(OpenOption...)
+     * @see #getOpenOptions()
+     * @since 2.21.0
+     */
+    public ReadableByteChannel getReadableByteChannel() throws IOException {
+        return checkOrigin().getReadableByteChannel(getOpenOptions());
+    }
+
+    /**
+     * Gets a WritableByteChannel from the origin with OpenOption[].
+     *
+     * @return A WritableByteChannel.
+     * @throws IllegalStateException         if the {@code origin} is {@code null}.
+     * @throws UnsupportedOperationException if the origin cannot be converted to a {@link WritableByteChannel}.
+     * @throws IOException                   if an I/O error occurs.
+     * @see AbstractOrigin#getWritableByteChannel(OpenOption...)
+     * @see #getOpenOptions()
+     * @since 2.21.0
+     */
+    public WritableByteChannel getWritableByteChannel() throws IOException {
+        return checkOrigin().getWritableByteChannel(getOpenOptions());
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/channels/ByteArrayChannel.java
+++ b/src/main/java/org/apache/commons/io/channels/ByteArrayChannel.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.channels;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.SeekableByteChannel;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.commons.io.IOUtils;
+
+/**
+ * An in-memory {@link SeekableByteChannel} backed by a growable {@code byte[]} buffer.
+ *
+ * @since 2.21.0
+ */
+public class ByteArrayChannel implements SeekableByteChannel {
+
+    private static final int DEFAULT_INITIAL_CAPACITY = 32;
+
+    /**
+     * Constructs a channel that wraps the given byte array.
+     * <p>
+     * The resulting channel will share the given array as its buffer, until a write operation
+     * requires a larger capacity.
+     * The initial size of the channel is the length of the given array, and the initial position is 0.
+     * </p>
+     * @param bytes The byte array to wrap; must not be {@code null}.
+     * @return A new channel that wraps the given byte array; never {@code null}.
+     * @throws NullPointerException If the byte array is {@code null}.
+     */
+    public static ByteArrayChannel wrap(byte[] bytes) {
+        Objects.requireNonNull(bytes, "bytes");
+        return new ByteArrayChannel(bytes, bytes.length);
+    }
+
+    // package-private for testing
+    byte[] data;
+    private int position;
+    private int count;
+    private volatile boolean closed;
+    private final ReentrantLock lock = new ReentrantLock();
+
+    /**
+     * Constructs a channel with the default initial capacity.
+     * <p>
+     * The initial size is 0, and the initial position is 0.
+     * </p>
+     */
+    public ByteArrayChannel() {
+        this(DEFAULT_INITIAL_CAPACITY);
+    }
+
+    /**
+     * Constructs a channel with the given initial capacity.
+     * <p>
+     * The initial size is 0, and the initial position is 0.
+     * </p>
+     * @param initialCapacity The initial capacity; must be non-negative.
+     * @throws IllegalArgumentException If the initial capacity is negative.
+     */
+    public ByteArrayChannel(int initialCapacity) {
+        this(byteArray(initialCapacity), 0);
+    }
+
+    private static byte[] byteArray(int value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("Size must be non-negative");
+        }
+        return new byte[value];
+    }
+
+    private ByteArrayChannel(byte[] data, int count) {
+        this.data = data;
+        this.position = 0;
+        this.count = count;
+    }
+
+    @Override
+    public int read(ByteBuffer dst) throws IOException {
+        ensureOpen();
+        lock.lock();
+        try {
+            final int remaining = dst.remaining();
+            if (remaining == 0) {
+                return 0;
+            }
+            if (position >= count) {
+                return -1; // EOF
+            }
+            final int n = Math.min(count - position, remaining);
+            dst.put(data, position, n);
+            position += n;
+            return n;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        ensureOpen();
+        lock.lock();
+        try {
+            final int remaining = src.remaining();
+            if (remaining == 0) {
+                return 0;
+            }
+            final int newPosition = position + remaining;
+            ensureCapacity(newPosition);
+            src.get(data, position, remaining);
+            position = newPosition;
+            if (newPosition > count) {
+                count = newPosition;
+            }
+            return remaining;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public long position() throws IOException {
+        ensureOpen();
+        lock.lock();
+        try {
+            return position;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public SeekableByteChannel position(long newPosition) throws IOException {
+        if (newPosition < 0L || newPosition > IOUtils.SOFT_MAX_ARRAY_LENGTH) {
+            throw new IOException("position must be in range [0, " + IOUtils.SOFT_MAX_ARRAY_LENGTH + "]");
+        }
+        ensureOpen();
+        lock.lock();
+        try {
+            this.position = (int) newPosition; // allowed to be > count; reads will return -1
+            return this;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public long size() throws IOException {
+        ensureOpen();
+        lock.lock();
+        try {
+            return count;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public SeekableByteChannel truncate(long size) throws IOException {
+        if (size < 0L || size > IOUtils.SOFT_MAX_ARRAY_LENGTH) {
+            throw new IOException("size must be in range [0, " + IOUtils.SOFT_MAX_ARRAY_LENGTH + "]");
+        }
+        ensureOpen();
+        lock.lock();
+        try {
+            final int newSize = (int) size;
+            if (newSize < count) {
+                // shrink logical size; do not allocate
+                count = newSize;
+
+            }
+            if (newSize < position) {
+                position = newSize;
+            }
+            // if newSize >= count: no effect
+            return this;
+        } finally {
+            lock.unlock();
+        }
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    private void ensureOpen() throws ClosedChannelException {
+        if (closed) {
+            throw new ClosedChannelException();
+        }
+    }
+
+    private void ensureCapacity(int minCapacity) {
+        // Guard against integer overflow and against exceeding the soft maximum.
+        // Negative values signal overflow in the (position + remaining) arithmetic.
+        if (minCapacity < 0 || minCapacity > IOUtils.SOFT_MAX_ARRAY_LENGTH) {
+            throw new OutOfMemoryError("required array size " + minCapacity + " too large");
+        }
+        // The current buffer is already big enough.
+        if (minCapacity <= data.length) {
+            return;
+        }
+        // Increase capacity geometrically (double the current size) to reduce reallocation cost.
+        // Always honor the requested minimum; if doubling overflows, use the minimum instead.
+        final int newCapacity = Math.max(data.length << 1, minCapacity);
+        // If geometric growth overshoots the soft maximum (but still fits in int),
+        // clamp to the soft maximum. minCapacity has already been validated to be ≤ soft max.
+        data = Arrays.copyOf(data, Math.min(newCapacity, IOUtils.SOFT_MAX_ARRAY_LENGTH));
+    }
+
+    /**
+     * Returns a copy of the logical contents.
+     * @return A copy of the logical contents, never {@code null}.
+     */
+    public byte[] toByteArray() {
+        return Arrays.copyOf(data, count);
+    }
+}

--- a/src/test/java/org/apache/commons/io/build/AbstractRandomAccessFileOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/AbstractRandomAccessFileOriginTest.java
@@ -17,12 +17,17 @@
 
 package org.apache.commons.io.build;
 
+import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 import org.apache.commons.io.IORandomAccessFile;
 import org.apache.commons.io.build.AbstractOrigin.AbstractRandomAccessFileOrigin;
 import org.apache.commons.io.build.AbstractOrigin.IORandomAccessFileOrigin;
 import org.apache.commons.io.build.AbstractOrigin.RandomAccessFileOrigin;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Tests {@link RandomAccessFileOrigin} and {@link IORandomAccessFileOrigin}.
@@ -35,4 +40,10 @@ import org.apache.commons.io.build.AbstractOrigin.RandomAccessFileOrigin;
 public abstract class AbstractRandomAccessFileOriginTest<T extends RandomAccessFile, B extends AbstractRandomAccessFileOrigin<T, B>>
         extends AbstractOriginTest<T, B> {
 
+    @Override
+    protected void resetOriginRw() throws IOException {
+        // Reset the file
+        final Path rwPath = tempPath.resolve(FILE_NAME_RW);
+        Files.write(rwPath, ArrayUtils.EMPTY_BYTE_ARRAY, StandardOpenOption.CREATE);
+    }
 }

--- a/src/test/java/org/apache/commons/io/build/AbstractStreamBuilderTest.java
+++ b/src/test/java/org/apache/commons/io/build/AbstractStreamBuilderTest.java
@@ -17,13 +17,31 @@
 
 package org.apache.commons.io.build;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.FileInputStream;
+import java.io.RandomAccessFile;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Stream;
 
+import org.apache.commons.io.function.IOConsumer;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests {@link AbstractStreamBuilder}.
@@ -64,5 +82,53 @@ class AbstractStreamBuilderTest {
         assertResult(builder.setBufferSizeMax(2).setBufferSizeMax(0).setBufferSize(3).get(), 3);
         // resize
         assertResult(builder().setBufferSizeMax(2).setBufferSizeChecker(i -> 100).setBufferSize(3).get(), 100);
+    }
+
+    private static Stream<IOConsumer<Builder>> fileBasedConfigurers() throws URISyntaxException {
+        final URI uri = Objects.requireNonNull(
+                        AbstractStreamBuilderTest.class.getResource(AbstractOriginTest.FILE_RES_RO))
+                .toURI();
+        final Path path = Paths.get(AbstractOriginTest.FILE_NAME_RO);
+        return Stream.of(
+                b -> b.setByteArray(ArrayUtils.EMPTY_BYTE_ARRAY),
+                b -> b.setFile(AbstractOriginTest.FILE_NAME_RO),
+                b -> b.setFile(path.toFile()),
+                b -> b.setPath(AbstractOriginTest.FILE_NAME_RO),
+                b -> b.setPath(path),
+                b -> b.setRandomAccessFile(new RandomAccessFile(AbstractOriginTest.FILE_NAME_RO, "r")),
+                // We can convert FileInputStream to ReadableByteChannel, but not the reverse.
+                // Therefore, we don't use Files.newInputStream.
+                b -> b.setInputStream(new FileInputStream(AbstractOriginTest.FILE_NAME_RO)),
+                b -> b.setReadableByteChannel(Files.newByteChannel(path)),
+                b -> b.setURI(uri));
+    }
+
+    /**
+     * Tests various ways to obtain a {@link java.io.InputStream}.
+     *
+     * @param configurer Lambda to configure the builder.
+     */
+    @ParameterizedTest
+    @MethodSource("fileBasedConfigurers")
+    void testGetInputStream(IOConsumer<Builder> configurer) throws Exception {
+        final Builder builder = builder();
+            configurer.accept(builder);
+        assertNotNull(builder.getInputStream());
+    }
+
+    /**
+     * Tests various ways to obtain a {@link SeekableByteChannel}.
+     *
+     * @param configurer Lambda to configure the builder.
+     */
+    @ParameterizedTest
+    @MethodSource("fileBasedConfigurers")
+    void getGetSeekableByteChannel(IOConsumer<Builder> configurer) throws Exception {
+        final Builder builder = builder();
+        configurer.accept(builder);
+        try (ReadableByteChannel channel = assertDoesNotThrow(builder::getReadableByteChannel)) {
+            assertTrue(channel.isOpen());
+            assertInstanceOf(SeekableByteChannel.class, channel);
+        }
     }
 }

--- a/src/test/java/org/apache/commons/io/build/ByteArrayOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/ByteArrayOriginTest.java
@@ -55,13 +55,6 @@ class ByteArrayOriginTest extends AbstractOriginTest<byte[], ByteArrayOrigin> {
 
     @Override
     @Test
-    void testGetOutputStream() {
-        // Cannot convert a byte[] to an OutputStream.
-        assertThrows(UnsupportedOperationException.class, super::testGetOutputStream);
-    }
-
-    @Override
-    @Test
     void testGetPath() {
         // Cannot convert a byte[] to a Path.
         assertThrows(UnsupportedOperationException.class, super::testGetPath);
@@ -84,9 +77,22 @@ class ByteArrayOriginTest extends AbstractOriginTest<byte[], ByteArrayOrigin> {
 
     @Override
     @Test
+    void testGetOutputStream() {
+        // Cannot convert a byte[] to an OutputStream.
+        assertThrows(UnsupportedOperationException.class, super::testGetOutputStream);
+    }
+
+    @Override
+    @Test
     void testGetWriter() {
         // Cannot convert a byte[] to a Writer.
         assertThrows(UnsupportedOperationException.class, super::testGetWriter);
     }
 
+    @Override
+    @Test
+    void testGetWritableByteChannel() throws IOException {
+        // Cannot convert a byte[] to a WritableByteChannel.
+        assertThrows(UnsupportedOperationException.class, super::testGetWritableByteChannel);
+    }
 }

--- a/src/test/java/org/apache/commons/io/build/ChannelOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/ChannelOriginTest.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.build;
+
+import static java.nio.file.StandardOpenOption.READ;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import java.nio.channels.Channel;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+
+import org.apache.commons.io.build.AbstractOrigin.ChannelOrigin;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class ChannelOriginTest extends AbstractOriginTest<Channel, ChannelOrigin> {
+    @Override
+    protected ChannelOrigin newOriginRo() throws IOException {
+        return new ChannelOrigin(Files.newByteChannel(Paths.get(FILE_NAME_RO), Collections.singleton(READ)));
+    }
+
+    @Override
+    protected ChannelOrigin newOriginRw() throws IOException {
+        return new ChannelOrigin(Files.newByteChannel(
+                tempPath.resolve(FILE_NAME_RW),
+                new HashSet<>(Arrays.asList(StandardOpenOption.READ, StandardOpenOption.WRITE))));
+    }
+
+    @Override
+    protected void resetOriginRw() throws IOException {
+        // Reset the file
+        final Path rwPath = tempPath.resolve(FILE_NAME_RW);
+        Files.write(rwPath, ArrayUtils.EMPTY_BYTE_ARRAY, StandardOpenOption.CREATE);
+    }
+
+    @Override
+    @Test
+    void testGetFile() {
+        // A FileByteChannel cannot be converted into a File.
+        assertThrows(UnsupportedOperationException.class, super::testGetFile);
+    }
+
+    @Override
+    @Test
+    void testGetPath() {
+        // A FileByteChannel cannot be converted into a Path.
+        assertThrows(UnsupportedOperationException.class, super::testGetPath);
+    }
+
+    @Override
+    @Test
+    void testGetRandomAccessFile() {
+        // A FileByteChannel cannot be converted into a RandomAccessFile.
+        assertThrows(UnsupportedOperationException.class, super::testGetRandomAccessFile);
+    }
+
+    @Override
+    @ParameterizedTest
+    @EnumSource(StandardOpenOption.class)
+    void testGetRandomAccessFile(OpenOption openOption) {
+        // A FileByteChannel cannot be converted into a RandomAccessFile.
+        assertThrows(UnsupportedOperationException.class, () -> super.testGetRandomAccessFile(openOption));
+    }
+
+    @Test
+    void testUnsupportedOperations_ReadableByteChannel() {
+        final ReadableByteChannel channel = mock(ReadableByteChannel.class);
+        final ChannelOrigin origin = new ChannelOrigin(channel);
+        assertThrows(UnsupportedOperationException.class, origin::getOutputStream);
+        assertThrows(UnsupportedOperationException.class, () -> origin.getWriter(null));
+        assertThrows(UnsupportedOperationException.class, origin::getWritableByteChannel);
+    }
+
+    @Test
+    void testUnsupportedOperations_WritableByteChannel() {
+        final Channel channel = mock(WritableByteChannel.class);
+        final ChannelOrigin origin = new ChannelOrigin(channel);
+        assertThrows(UnsupportedOperationException.class, origin::getInputStream);
+        assertThrows(UnsupportedOperationException.class, () -> origin.getReader(null));
+        assertThrows(UnsupportedOperationException.class, origin::getReadableByteChannel);
+    }
+}

--- a/src/test/java/org/apache/commons/io/build/CharSequenceOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/CharSequenceOriginTest.java
@@ -64,13 +64,6 @@ class CharSequenceOriginTest extends AbstractOriginTest<CharSequence, CharSequen
 
     @Override
     @Test
-    void testGetOutputStream() {
-        // Cannot convert a CharSequence to an OutputStream.
-        assertThrows(UnsupportedOperationException.class, super::testGetOutputStream);
-    }
-
-    @Override
-    @Test
     void testGetPath() {
         // Cannot convert a CharSequence to a Path.
         assertThrows(UnsupportedOperationException.class, super::testGetPath);
@@ -91,6 +84,27 @@ class CharSequenceOriginTest extends AbstractOriginTest<CharSequence, CharSequen
         assertThrows(UnsupportedOperationException.class, () -> super.testGetRandomAccessFile(openOption));
     }
 
+    @Override
+    @Test
+    void testGetOutputStream() {
+        // Cannot convert a CharSequence to an OutputStream.
+        assertThrows(UnsupportedOperationException.class, super::testGetOutputStream);
+    }
+
+    @Override
+    @Test
+    void testGetWriter() {
+        // Cannot convert a CharSequence to a Writer.
+        assertThrows(UnsupportedOperationException.class, super::testGetWriter);
+    }
+
+    @Override
+    @Test
+    void testGetWritableByteChannel() throws IOException {
+        // Cannot convert a CharSequence to a WritableByteChannel.
+        assertThrows(UnsupportedOperationException.class, super::testGetWritableByteChannel);
+    }
+
     @Test
     void testGetReaderIgnoreCharset() throws IOException {
         // The CharSequenceOrigin ignores the given Charset.
@@ -107,13 +121,6 @@ class CharSequenceOriginTest extends AbstractOriginTest<CharSequence, CharSequen
             assertNotNull(reader);
             assertEquals(getFixtureStringFromFile(), IOUtils.toString(reader));
         }
-    }
-
-    @Override
-    @Test
-    void testGetWriter() {
-        // Cannot convert a CharSequence to a Writer.
-        assertThrows(UnsupportedOperationException.class, super::testGetWriter);
     }
 
 }

--- a/src/test/java/org/apache/commons/io/build/FileOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/FileOriginTest.java
@@ -17,8 +17,13 @@
 package org.apache.commons.io.build;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 
 import org.apache.commons.io.build.AbstractOrigin.FileOrigin;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Tests {@link FileOrigin}.
@@ -35,8 +40,14 @@ class FileOriginTest extends AbstractOriginTest<File, FileOrigin> {
     }
 
     @Override
-    protected FileOrigin newOriginRw() {
-        return new FileOrigin(new File(FILE_NAME_RW));
+    protected FileOrigin newOriginRw() throws IOException {
+        return new FileOrigin(tempPath.resolve(FILE_NAME_RW).toFile());
     }
 
+    @Override
+    protected void resetOriginRw() throws IOException {
+        // Reset the file
+        final Path rwPath = tempPath.resolve(FILE_NAME_RW);
+        Files.write(rwPath, ArrayUtils.EMPTY_BYTE_ARRAY, StandardOpenOption.CREATE);
+    }
 }

--- a/src/test/java/org/apache/commons/io/build/IORandomAccessFileOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/IORandomAccessFileOriginTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.io.build;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.RandomAccessFile;
 
 import org.apache.commons.io.IORandomAccessFile;
@@ -38,8 +39,7 @@ class IORandomAccessFileOriginTest extends AbstractOriginTest<IORandomAccessFile
 
     @SuppressWarnings("resource")
     @Override
-    protected IORandomAccessFileOrigin newOriginRw() throws FileNotFoundException {
-        return new IORandomAccessFileOrigin(RandomAccessFileMode.READ_WRITE.io(FILE_NAME_RW));
+    protected IORandomAccessFileOrigin newOriginRw() throws IOException {
+        return new IORandomAccessFileOrigin(RandomAccessFileMode.READ_WRITE.io(tempPath.resolve(FILE_NAME_RW).toFile().getPath()));
     }
-
 }

--- a/src/test/java/org/apache/commons/io/build/InputStreamOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/InputStreamOriginTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
@@ -60,13 +61,6 @@ class InputStreamOriginTest extends AbstractOriginTest<InputStream, InputStreamO
 
     @Override
     @Test
-    void testGetOutputStream() {
-        // Cannot convert a InputStream to an OutputStream.
-        assertThrows(UnsupportedOperationException.class, super::testGetOutputStream);
-    }
-
-    @Override
-    @Test
     void testGetPath() {
         // Cannot convert a InputStream to a Path.
         assertThrows(UnsupportedOperationException.class, super::testGetPath);
@@ -89,9 +83,22 @@ class InputStreamOriginTest extends AbstractOriginTest<InputStream, InputStreamO
 
     @Override
     @Test
+    void testGetOutputStream() {
+        // Cannot convert a InputStream to an OutputStream.
+        assertThrows(UnsupportedOperationException.class, super::testGetOutputStream);
+    }
+
+    @Override
+    @Test
     void testGetWriter() {
         // Cannot convert a InputStream to a Writer.
         assertThrows(UnsupportedOperationException.class, super::testGetWriter);
     }
 
+    @Override
+    @Test
+    void testGetWritableByteChannel() throws IOException {
+        // Cannot convert a InputStream to a WritableByteChannel.
+        assertThrows(UnsupportedOperationException.class, super::testGetWritableByteChannel);
+    }
 }

--- a/src/test/java/org/apache/commons/io/build/OutputStreamOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/OutputStreamOriginTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.io.build;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
@@ -91,13 +92,6 @@ class OutputStreamOriginTest extends AbstractOriginTest<OutputStream, OutputStre
 
     @Override
     @Test
-    void testGetInputStream() {
-        // Cannot convert a OutputStream to an InputStream.
-        assertThrows(UnsupportedOperationException.class, super::testGetInputStream);
-    }
-
-    @Override
-    @Test
     void testGetPath() {
         // Cannot convert a OutputStream to a Path.
         assertThrows(UnsupportedOperationException.class, super::testGetPath);
@@ -120,9 +114,28 @@ class OutputStreamOriginTest extends AbstractOriginTest<OutputStream, OutputStre
 
     @Override
     @Test
+    void testGetInputStream() {
+        // Cannot convert a OutputStream to an InputStream.
+        assertThrows(UnsupportedOperationException.class, super::testGetInputStream);
+    }
+
+    @Override
+    @Test
     void testGetReader() {
         // Cannot convert a OutputStream to a Reader.
         assertThrows(UnsupportedOperationException.class, super::testGetReader);
+    }
+
+    @Override
+    @Test
+    void testGetReadableByteChannel() throws IOException {
+        // Cannot convert a OutputStream to a ReadableByteChannel.
+        assertThrows(UnsupportedOperationException.class, super::testGetReadableByteChannel);
+    }
+
+    @Override
+    void testGetWritableByteChannel() throws IOException {
+        super.testGetWritableByteChannel(false);
     }
 
     @Override

--- a/src/test/java/org/apache/commons/io/build/PathOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/PathOriginTest.java
@@ -16,10 +16,14 @@
  */
 package org.apache.commons.io.build;
 
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 
 import org.apache.commons.io.build.AbstractOrigin.PathOrigin;
+import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Tests {@link PathOrigin}.
@@ -36,8 +40,14 @@ class PathOriginTest extends AbstractOriginTest<Path, PathOrigin> {
     }
 
     @Override
-    protected PathOrigin newOriginRw() {
-        return new PathOrigin(Paths.get(FILE_NAME_RW));
+    protected PathOrigin newOriginRw() throws IOException {
+        return new PathOrigin(tempPath.resolve(FILE_NAME_RW));
     }
 
+    @Override
+    protected void resetOriginRw() throws IOException {
+        // Reset the file
+        final Path rwPath = tempPath.resolve(FILE_NAME_RW);
+        Files.write(rwPath, ArrayUtils.EMPTY_BYTE_ARRAY, StandardOpenOption.CREATE);
+    }
 }

--- a/src/test/java/org/apache/commons/io/build/RandomAccessFileOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/RandomAccessFileOriginTest.java
@@ -20,6 +20,7 @@ package org.apache.commons.io.build;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.RandomAccessFile;
 
 import org.apache.commons.io.RandomAccessFileMode;
@@ -41,8 +42,8 @@ class RandomAccessFileOriginTest extends AbstractRandomAccessFileOriginTest<Rand
 
     @SuppressWarnings("resource")
     @Override
-    protected RandomAccessFileOrigin newOriginRw() throws FileNotFoundException {
-        return new RandomAccessFileOrigin(RandomAccessFileMode.READ_WRITE.create(FILE_NAME_RW));
+    protected RandomAccessFileOrigin newOriginRw() throws IOException {
+        return new RandomAccessFileOrigin(RandomAccessFileMode.READ_WRITE.create(tempPath.resolve(FILE_NAME_RW)));
     }
 
     @Override

--- a/src/test/java/org/apache/commons/io/build/ReaderOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/ReaderOriginTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.FileNotFoundException;
 import java.io.FileReader;
+import java.io.IOException;
 import java.io.Reader;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
@@ -58,13 +59,6 @@ class ReaderOriginTest extends AbstractOriginTest<Reader, ReaderOrigin> {
 
     @Override
     @Test
-    void testGetOutputStream() {
-        // Cannot convert a Reader to an OutputStream.
-        assertThrows(UnsupportedOperationException.class, super::testGetOutputStream);
-    }
-
-    @Override
-    @Test
     void testGetPath() {
         // Cannot convert a Reader to a Path.
         assertThrows(UnsupportedOperationException.class, super::testGetPath);
@@ -87,9 +81,22 @@ class ReaderOriginTest extends AbstractOriginTest<Reader, ReaderOrigin> {
 
     @Override
     @Test
+    void testGetOutputStream() {
+        // Cannot convert a Reader to an OutputStream.
+        assertThrows(UnsupportedOperationException.class, super::testGetOutputStream);
+    }
+
+    @Override
+    @Test
     void testGetWriter() {
         // Cannot convert a Reader to a Writer.
         assertThrows(UnsupportedOperationException.class, super::testGetWriter);
     }
 
+    @Override
+    @Test
+    void testGetWritableByteChannel() throws IOException {
+        // Cannot convert a InputStream to a WritableByteChannel.
+        assertThrows(UnsupportedOperationException.class, super::testGetWritableByteChannel);
+    }
 }

--- a/src/test/java/org/apache/commons/io/build/URIOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/URIOriginTest.java
@@ -18,11 +18,16 @@ package org.apache.commons.io.build;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 
 import org.apache.commons.io.build.AbstractOrigin.URIOrigin;
+import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -43,7 +48,14 @@ class URIOriginTest extends AbstractOriginTest<URI, URIOrigin> {
 
     @Override
     protected URIOrigin newOriginRw() {
-        return new URIOrigin(Paths.get(FILE_NAME_RW).toUri());
+        return new URIOrigin(tempPath.resolve(FILE_NAME_RW).toUri());
+    }
+
+    @Override
+    protected void resetOriginRw() throws IOException {
+        // Reset the file
+        final Path rwPath = tempPath.resolve(FILE_NAME_RW);
+        Files.write(rwPath, ArrayUtils.EMPTY_BYTE_ARRAY, StandardOpenOption.CREATE);
     }
 
     @ParameterizedTest

--- a/src/test/java/org/apache/commons/io/build/WriterStreamOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/WriterStreamOriginTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.io.build;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.file.OpenOption;
@@ -91,13 +92,6 @@ class WriterStreamOriginTest extends AbstractOriginTest<Writer, WriterOrigin> {
 
     @Override
     @Test
-    void testGetInputStream() {
-        // Cannot convert a Writer to an InputStream.
-        assertThrows(UnsupportedOperationException.class, super::testGetInputStream);
-    }
-
-    @Override
-    @Test
     void testGetPath() {
         // Cannot convert a Writer to a Path.
         assertThrows(UnsupportedOperationException.class, super::testGetPath);
@@ -120,9 +114,27 @@ class WriterStreamOriginTest extends AbstractOriginTest<Writer, WriterOrigin> {
 
     @Override
     @Test
+    void testGetInputStream() {
+        // Cannot convert a Writer to an InputStream.
+        assertThrows(UnsupportedOperationException.class, super::testGetInputStream);
+    }
+
+    @Override
+    @Test
     void testGetReader() {
         // Cannot convert a Writer to a Reader.
         assertThrows(UnsupportedOperationException.class, super::testGetReader);
+    }
+
+    @Override
+    void testGetReadableByteChannel() throws IOException {
+        // Cannot convert a Writer to a ReadableByteChannel.
+        assertThrows(UnsupportedOperationException.class, super::testGetReadableByteChannel);
+    }
+
+    @Override
+    void testGetWritableByteChannel() throws IOException {
+        super.testGetWritableByteChannel(false);
     }
 
     @Override

--- a/src/test/java/org/apache/commons/io/channels/ByteArrayChannelTest.java
+++ b/src/test/java/org/apache/commons/io/channels/ByteArrayChannelTest.java
@@ -1,0 +1,241 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.channels;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.commons.lang3.ArrayUtils.EMPTY_BYTE_ARRAY;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.util.stream.Stream;
+
+import org.apache.commons.io.function.IOConsumer;
+import org.apache.commons.io.function.IOSupplier;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class ByteArrayChannelTest {
+
+    private static final byte[] testData = "Some data".getBytes(UTF_8);
+
+    private static byte[] getTestData() {
+        return testData.clone();
+    }
+
+    static Stream<Arguments> testConstructor() {
+        return Stream.of(
+                Arguments.of((IOSupplier<ByteArrayChannel>) ByteArrayChannel::new, EMPTY_BYTE_ARRAY, 32),
+                Arguments.of((IOSupplier<ByteArrayChannel>) () -> new ByteArrayChannel(8), EMPTY_BYTE_ARRAY, 8),
+                Arguments.of((IOSupplier<ByteArrayChannel>) () -> new ByteArrayChannel(16), EMPTY_BYTE_ARRAY, 16),
+                Arguments.of(
+                        (IOSupplier<ByteArrayChannel>) () -> ByteArrayChannel.wrap(EMPTY_BYTE_ARRAY), EMPTY_BYTE_ARRAY, 0),
+                Arguments.of((IOSupplier<ByteArrayChannel>) () -> ByteArrayChannel.wrap(getTestData()), getTestData(), testData.length));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testConstructor(IOSupplier<ByteArrayChannel> supplier, byte[] expected, int capacity) throws IOException {
+        try (ByteArrayChannel channel = supplier.get()) {
+            assertEquals(0, channel.position());
+            assertEquals(expected.length, channel.size());
+            assertEquals(capacity, channel.data.length);
+            assertArrayEquals(expected, channel.toByteArray());
+        }
+    }
+
+    @Test
+    void testConstructorInvalid() {
+        assertThrows(IllegalArgumentException.class, () -> new ByteArrayChannel(-1));
+        assertThrows(NullPointerException.class, () -> ByteArrayChannel.wrap(null));
+    }
+
+    @Test
+    void testCloseIdempotent() {
+        final ByteArrayChannel channel = new ByteArrayChannel();
+        channel.close();
+        assertFalse(channel.isOpen());
+        channel.close();
+        assertFalse(channel.isOpen());
+    }
+
+    static Stream<IOConsumer<ByteArrayChannel>> testThrowsAfterClose() {
+        return Stream.of(
+                channel -> channel.read(ByteBuffer.allocate(1)),
+                channel -> channel.write(ByteBuffer.allocate(1)),
+                ByteArrayChannel::position,
+                channel -> channel.position(0),
+                ByteArrayChannel::size,
+                channel -> channel.truncate(0));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testThrowsAfterClose(IOConsumer<ByteArrayChannel> consumer) {
+        final ByteArrayChannel channel = new ByteArrayChannel();
+        channel.close();
+        assertThrows(ClosedChannelException.class, () -> consumer.accept(channel));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 4, 9, 15})
+    void testPosition(long expected) throws Exception {
+        try (ByteArrayChannel channel = ByteArrayChannel.wrap(getTestData())) {
+            assertEquals(0, channel.position(), "initial position");
+            channel.position(expected);
+            assertEquals(expected, channel.position(), "set position");
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(longs = {-1, Integer.MAX_VALUE - 7, Integer.MAX_VALUE + 1L})
+    void testPositionInvalid(long position) {
+        try (ByteArrayChannel channel = ByteArrayChannel.wrap(getTestData())) {
+            assertThrows(IOException.class, () -> channel.position(position), "position " + position);
+        }
+    }
+
+    static Stream<Arguments> testRead() {
+        return Stream.of(
+                Arguments.of(0, 0, "", 0),
+                Arguments.of(0, 4, "Some", 4),
+                Arguments.of(5, 9, "data", 4),
+                Arguments.of(0, 9, "Some data", 9),
+                // buffer larger than data
+                Arguments.of(0, 10, "Some data", 9),
+                // offset beyond end
+                Arguments.of(10, 10, "", -1));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testRead(int offset, int bufferSize, String expected, int expectedRead) throws Exception {
+        try (ByteArrayChannel channel = ByteArrayChannel.wrap(getTestData())) {
+            channel.position(offset);
+            final ByteBuffer buffer = ByteBuffer.allocate(bufferSize);
+            final int read = channel.read(buffer);
+            assertEquals(expectedRead, read, "read");
+            assertEquals(expected, new String(buffer.array(), 0, Math.max(0, read), UTF_8), "data");
+            assertEquals(offset + Math.max(0, expectedRead), channel.position(), "position");
+        }
+    }
+
+    @Test
+    void testMultipleRead() throws Exception {
+        try (ByteArrayChannel channel = ByteArrayChannel.wrap(getTestData())) {
+            final ByteBuffer buffer = ByteBuffer.allocate(4);
+            int read = channel.read(buffer);
+            assertEquals(4, read, "first read");
+            assertEquals("Some", new String(buffer.array(), 0, read, UTF_8), "first data");
+            assertEquals(4, channel.position(), "first position");
+
+            buffer.clear();
+            read = channel.read(buffer);
+            assertEquals(4, read, "second read");
+            assertEquals(" dat", new String(buffer.array(), 0, read, UTF_8), "second data");
+            assertEquals(8, channel.position(), "second position");
+
+            buffer.clear();
+            read = channel.read(buffer);
+            assertEquals(1, read, "third read");
+            assertEquals("a", new String(buffer.array(), 0, read, UTF_8), "third data");
+            assertEquals(9, channel.position(), "third position");
+
+            buffer.clear();
+            read = channel.read(buffer);
+            assertEquals(-1, read, "fourth read");
+            assertEquals(9, channel.position(), "fourth position");
+        }
+    }
+
+    static Stream<Arguments> testWrite() {
+        return Stream.of(
+                Arguments.of(1, "", 0, "Some data"),
+                Arguments.of(0, "More", 4, "More data"),
+                Arguments.of(5, "doll", 4, "Some doll"),
+                // extend
+                Arguments.of(9, "!", 1, "Some data!"),
+                // offset beyond end
+                Arguments.of(12, "!!!", 3, "Some data\0\0\0!!!"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testWrite(int offset, String toWrite, int expectedWritten, String expectedData) throws Exception {
+        try (ByteArrayChannel channel = ByteArrayChannel.wrap(getTestData())) {
+            channel.position(offset);
+            final ByteBuffer buffer = ByteBuffer.wrap(toWrite.getBytes(UTF_8));
+            final int written = channel.write(buffer);
+            assertEquals(expectedWritten, written, "written");
+            assertEquals(expectedData, new String(channel.toByteArray(), UTF_8), "data");
+            assertEquals(offset + expectedWritten, channel.position(), "position");
+        }
+    }
+
+    @Test
+    void testSize() throws Exception {
+        try (ByteArrayChannel channel = ByteArrayChannel.wrap(getTestData())) {
+            assertEquals(testData.length, channel.size(), "size");
+            channel.position(testData.length + 10);
+            assertEquals(testData.length, channel.size(), "size after position beyond end");
+            channel.write(ByteBuffer.wrap("More".getBytes(UTF_8)));
+            assertEquals(testData.length + 10 + 4, channel.size(), "size after write beyond end");
+        }
+    }
+
+    static Stream<Arguments> testTruncate() {
+        return Stream.of(
+                Arguments.of(0, 0, ""),
+                Arguments.of(0, 4, ""),
+                Arguments.of(4, 0, "Some"),
+                Arguments.of(4, 5, "Some"),
+                Arguments.of(9, 0, "Some data"),
+                Arguments.of(9, 10, "Some data"),
+                // extend - no effect
+                Arguments.of(15, 0, "Some data"),
+                Arguments.of(15, 20, "Some data"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void testTruncate(int size, int initialPosition, String expectedData) throws Exception {
+        try (ByteArrayChannel channel = ByteArrayChannel.wrap(getTestData())) {
+            channel.position(initialPosition);
+            channel.truncate(size);
+            assertEquals(expectedData, new String(channel.toByteArray(), UTF_8), "data");
+            // Size changes only if size < initial size
+            assertEquals(Math.min(size, testData.length), channel.size(), "size");
+            // Position changes only if size < initial position
+            assertEquals(Math.min(size, initialPosition), channel.position(), "position");
+        }
+    }
+
+    @Test
+    void testTruncateInvalid() {
+        try (ByteArrayChannel channel = ByteArrayChannel.wrap(getTestData())) {
+            assertThrows(IOException.class, () -> channel.truncate(-1));
+            assertThrows(IOException.class, () -> channel.truncate((long) Integer.MAX_VALUE + 1));
+        }
+    }
+}


### PR DESCRIPTION
Some builders derived from `AbstractStreamBuilder` (for example, `SevenZFile.Builder` in Commons Compress) need to produce a `SeekableByteChannel` as their data source. Until now this required ad-hoc `instanceof` switches across different origin types.

This change integrates channel support directly into the origin/builder abstraction, leading to a cleaner and more object-oriented design.

### Key changes

* Add `getReadableByteChannel()` and `getWritableByteChannel()` to `AbstractOrigin` and propagate to `AbstractStreamBuilder`.
* Introduce `ChannelOrigin`, an `AbstractOrigin` implementation backed by an existing `ReadableByteChannel`/`WritableByteChannel`.
* Add `ByteArrayChannel`, a simple in-memory `SeekableByteChannel` implementation.
* Extend unit tests to cover the new methods and types.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to improve the PR description.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
