### PR TITLE
Add `Closeable` to `AbstractOrigin`

### DIFF
--- a/src/main/java/org/apache/commons/io/build/AbstractStreamBuilder.java
+++ b/src/main/java/org/apache/commons/io/build/AbstractStreamBuilder.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.io.build;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -121,7 +122,15 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
     }
 
     /**
-     * Gets a Channel from the origin with OpenOption[].
+     * Gets the origin as a {@link Channel} of the given type, if supported.
+     *
+     * <p>If the origin is not already open, it will be opened using the options provided by
+     * {@link #getOpenOptions()}.</p>
+     *
+     * <p>Calling this method transfers ownership of the underlying resource to the caller.
+     * The caller is responsible for closing the returned stream once it is no longer needed.
+     * If the origin itself implements {@link Closeable}, closing the returned stream will
+     * also close the underlying origin resource.</p>
      *
      * @param channelType The channel type, not null.
      * @return A channel of the specified type.
@@ -133,6 +142,7 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
      * @see #getOpenOptions()
      * @since 2.21.0
      */
+    @SuppressWarnings("resource")
     public <C extends Channel> C getChannel(final Class<C> channelType) throws IOException {
         return checkOrigin().getChannel(channelType, getOpenOptions());
     }
@@ -147,6 +157,7 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
      * @see AbstractOrigin#getCharSequence(Charset)
      * @since 2.13.0
      */
+    @SuppressWarnings("resource")
     public CharSequence getCharSequence() throws IOException {
         return checkOrigin().getCharSequence(getCharset());
     }
@@ -178,12 +189,21 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
      * @see AbstractOrigin#getPath()
      * @since 2.18.0
      */
+    @SuppressWarnings("resource")
     public File getFile() {
         return checkOrigin().getFile();
     }
 
     /**
-     * Gets an InputStream from the origin with OpenOption[].
+     * Gets the origin as an {@link InputStream}, if supported.
+     *
+     * <p>If the origin is not already open, it will be opened using the options provided by
+     * {@link #getOpenOptions()}.</p>
+     *
+     * <p>Calling this method transfers ownership of the underlying resource to the caller.
+     * The caller is responsible for closing the returned stream once it is no longer needed.
+     * If the origin itself implements {@link Closeable}, closing the returned stream will
+     * also close the underlying origin resource.</p>
      *
      * @return An input stream
      * @throws IllegalStateException         if the {@code origin} is {@code null}.
@@ -193,6 +213,7 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
      * @see #getOpenOptions()
      * @since 2.13.0
      */
+    @SuppressWarnings("resource")
     public InputStream getInputStream() throws IOException {
         return checkOrigin().getInputStream(getOpenOptions());
     }
@@ -207,7 +228,15 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
     }
 
     /**
-     * Gets an OutputStream from the origin with OpenOption[].
+     * Gets the origin as an {@link OutputStream}, if supported.
+     *
+     * <p>If the origin is not already open, it will be opened using the options provided by
+     * {@link #getOpenOptions()}.</p>
+     *
+     * <p>Calling this method transfers ownership of the underlying resource to the caller.
+     * The caller is responsible for closing the returned stream once it is no longer needed.
+     * If the origin itself implements {@link Closeable}, closing the returned stream will
+     * also close the underlying origin resource.</p>
      *
      * @return An OutputStream
      * @throws IllegalStateException         if the {@code origin} is {@code null}.
@@ -217,6 +246,7 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
      * @see #getOpenOptions()
      * @since 2.13.0
      */
+    @SuppressWarnings("resource")
     public OutputStream getOutputStream() throws IOException {
         return checkOrigin().getOutputStream(getOpenOptions());
     }
@@ -230,12 +260,21 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
      * @see AbstractOrigin#getPath()
      * @since 2.13.0
      */
+    @SuppressWarnings("resource")
     public Path getPath() {
         return checkOrigin().getPath();
     }
 
     /**
-     * Gets a RandomAccessFile from the origin.
+     * Gets the origin as an {@link OutputStream}, if supported.
+     *
+     * <p>If the origin is not already open, it will be opened using the options provided by
+     * {@link #getOpenOptions()}.</p>
+     *
+     * <p>Calling this method transfers ownership of the underlying resource to the caller.
+     * The caller is responsible for closing the returned stream once it is no longer needed.
+     * If the origin itself implements {@link Closeable}, closing the returned stream will
+     * also close the underlying origin resource.</p>
      *
      * @return A RandomAccessFile
      * @throws IllegalStateException         if the {@code origin} is {@code null}.
@@ -243,12 +282,21 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
      * @throws IOException                   if an I/O error occurs.
      * @since 2.18.0
      */
+    @SuppressWarnings("resource")
     public RandomAccessFile getRandomAccessFile() throws IOException {
         return checkOrigin().getRandomAccessFile(getOpenOptions());
     }
 
     /**
-     * Gets a Reader from the origin with a Charset.
+     * Gets the origin as an {@link OutputStream}, if supported.
+     *
+     * <p>If the origin is not already open, it will be opened using the options provided by
+     * {@link #getOpenOptions()}.</p>
+     *
+     * <p>Calling this method transfers ownership of the underlying resource to the caller.
+     * The caller is responsible for closing the returned stream once it is no longer needed.
+     * If the origin itself implements {@link Closeable}, closing the returned stream will
+     * also close the underlying origin resource.</p>
      *
      * @return A Reader
      * @throws IllegalStateException         if the {@code origin} is {@code null}.
@@ -258,12 +306,21 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
      * @see #getCharset()
      * @since 2.16.0
      */
+    @SuppressWarnings("resource")
     public Reader getReader() throws IOException {
         return checkOrigin().getReader(getCharset());
     }
 
     /**
-     * Gets a Writer from the origin with an OpenOption[].
+     * Gets the origin as an {@link OutputStream}, if supported.
+     *
+     * <p>If the origin is not already open, it will be opened using the options provided by
+     * {@link #getOpenOptions()}.</p>
+     *
+     * <p>Calling this method transfers ownership of the underlying resource to the caller.
+     * The caller is responsible for closing the returned stream once it is no longer needed.
+     * If the origin itself implements {@link Closeable}, closing the returned stream will
+     * also close the underlying origin resource.</p>
      *
      * @return An writer.
      * @throws IllegalStateException         if the {@code origin} is {@code null}.
@@ -273,6 +330,7 @@ public abstract class AbstractStreamBuilder<T, B extends AbstractStreamBuilder<T
      * @see #getOpenOptions()
      * @since 2.13.0
      */
+    @SuppressWarnings("resource")
     public Writer getWriter() throws IOException {
         return checkOrigin().getWriter(getCharset(), getOpenOptions());
     }

--- a/src/test/java/org/apache/commons/io/build/AbstractRandomAccessFileOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/AbstractRandomAccessFileOriginTest.java
@@ -17,17 +17,14 @@
 
 package org.apache.commons.io.build;
 
-import java.io.IOException;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.RandomAccessFile;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 
 import org.apache.commons.io.IORandomAccessFile;
 import org.apache.commons.io.build.AbstractOrigin.AbstractRandomAccessFileOrigin;
 import org.apache.commons.io.build.AbstractOrigin.IORandomAccessFileOrigin;
 import org.apache.commons.io.build.AbstractOrigin.RandomAccessFileOrigin;
-import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Tests {@link RandomAccessFileOrigin} and {@link IORandomAccessFileOrigin}.
@@ -39,11 +36,8 @@ import org.apache.commons.lang3.ArrayUtils;
  */
 public abstract class AbstractRandomAccessFileOriginTest<T extends RandomAccessFile, B extends AbstractRandomAccessFileOrigin<T, B>>
         extends AbstractOriginTest<T, B> {
-
     @Override
-    protected void resetOriginRw() throws IOException {
-        // Reset the file
-        final Path rwPath = tempPath.resolve(FILE_NAME_RW);
-        Files.write(rwPath, ArrayUtils.EMPTY_BYTE_ARRAY, StandardOpenOption.CREATE);
+    protected void assertOpen(AbstractOrigin<T, B> origin) {
+        assertTrue(origin.get().getChannel().isOpen(), "RandomAccessFile not open");
     }
 }

--- a/src/test/java/org/apache/commons/io/build/ChannelOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/ChannelOriginTest.java
@@ -18,6 +18,7 @@ package org.apache.commons.io.build;
 
 import static java.nio.file.StandardOpenOption.READ;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 
 import java.io.IOException;
@@ -26,7 +27,6 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
 import java.nio.file.Files;
 import java.nio.file.OpenOption;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardOpenOption;
 import java.util.Arrays;
@@ -34,12 +34,16 @@ import java.util.Collections;
 import java.util.HashSet;
 
 import org.apache.commons.io.build.AbstractOrigin.ChannelOrigin;
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 class ChannelOriginTest extends AbstractOriginTest<Channel, ChannelOrigin> {
+    @Override
+    protected void assertOpen(AbstractOrigin<Channel, ChannelOrigin> origin) {
+        assertTrue(origin.get().isOpen(), "Channel not open");
+    }
+
     @Override
     protected ChannelOrigin newOriginRo() throws IOException {
         return new ChannelOrigin(Files.newByteChannel(Paths.get(FILE_NAME_RO), Collections.singleton(READ)));
@@ -47,16 +51,8 @@ class ChannelOriginTest extends AbstractOriginTest<Channel, ChannelOrigin> {
 
     @Override
     protected ChannelOrigin newOriginRw() throws IOException {
-        return new ChannelOrigin(Files.newByteChannel(
-                tempPath.resolve(FILE_NAME_RW),
-                new HashSet<>(Arrays.asList(StandardOpenOption.READ, StandardOpenOption.WRITE))));
-    }
-
-    @Override
-    protected void resetOriginRw() throws IOException {
-        // Reset the file
-        final Path rwPath = tempPath.resolve(FILE_NAME_RW);
-        Files.write(rwPath, ArrayUtils.EMPTY_BYTE_ARRAY, StandardOpenOption.CREATE);
+        return new ChannelOrigin(Files.newByteChannel(tempPath.resolve(FILE_NAME_RW), new HashSet<>(Arrays.asList(StandardOpenOption.READ,
+                StandardOpenOption.WRITE, StandardOpenOption.CREATE))));
     }
 
     @Override

--- a/src/test/java/org/apache/commons/io/build/CharSequenceOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/CharSequenceOriginTest.java
@@ -94,7 +94,7 @@ class CharSequenceOriginTest extends AbstractOriginTest<CharSequence, CharSequen
     @Test
     void testGetReaderIgnoreCharset() throws IOException {
         // The CharSequenceOrigin ignores the given Charset.
-        try (Reader reader = getOriginRo().getReader(StandardCharsets.UTF_16LE)) {
+        try (Reader reader = newOriginRo().getReader(StandardCharsets.UTF_16LE)) {
             assertNotNull(reader);
             assertEquals(getFixtureStringFromFile(), IOUtils.toString(reader));
         }
@@ -103,7 +103,7 @@ class CharSequenceOriginTest extends AbstractOriginTest<CharSequence, CharSequen
     @Test
     void testGetReaderIgnoreCharsetNull() throws IOException {
         // The CharSequenceOrigin ignores the given Charset.
-        try (Reader reader = getOriginRo().getReader(null)) {
+        try (Reader reader = newOriginRo().getReader(null)) {
             assertNotNull(reader);
             assertEquals(getFixtureStringFromFile(), IOUtils.toString(reader));
         }

--- a/src/test/java/org/apache/commons/io/build/FileOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/FileOriginTest.java
@@ -18,12 +18,9 @@ package org.apache.commons.io.build;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.build.AbstractOrigin.FileOrigin;
-import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Tests {@link FileOrigin}.
@@ -41,13 +38,9 @@ class FileOriginTest extends AbstractOriginTest<File, FileOrigin> {
 
     @Override
     protected FileOrigin newOriginRw() throws IOException {
-        return new FileOrigin(tempPath.resolve(FILE_NAME_RW).toFile());
+        final File file = tempPath.resolve(FILE_NAME_RW).toFile();
+        FileUtils.touch(file);
+        return new FileOrigin(file);
     }
 
-    @Override
-    protected void resetOriginRw() throws IOException {
-        // Reset the file
-        final Path rwPath = tempPath.resolve(FILE_NAME_RW);
-        Files.write(rwPath, ArrayUtils.EMPTY_BYTE_ARRAY, StandardOpenOption.CREATE);
-    }
 }

--- a/src/test/java/org/apache/commons/io/build/OutputStreamOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/OutputStreamOriginTest.java
@@ -17,9 +17,14 @@
 package org.apache.commons.io.build;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 
@@ -46,6 +51,21 @@ class OutputStreamOriginTest extends AbstractOriginTest<OutputStream, OutputStre
     @Override
     protected OutputStreamOrigin newOriginRw() {
         return new OutputStreamOrigin(new ByteArrayOutputStream());
+    }
+
+    @Test
+    void testClosesOrigin() throws IOException {
+        final OutputStream resource = mock(OutputStream.class);
+        final OutputStreamOrigin origin = new OutputStreamOrigin(resource);
+
+        origin.getOutputStream().close();
+        verify(resource, times(1)).close();
+
+        origin.getWriter(StandardCharsets.UTF_8).close();
+        verify(resource, times(2)).close();
+
+        origin.getChannel(WritableByteChannel.class).close();
+        verify(resource, times(3)).close();
     }
 
     @Override

--- a/src/test/java/org/apache/commons/io/build/PathOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/PathOriginTest.java
@@ -17,13 +17,11 @@
 package org.apache.commons.io.build;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.build.AbstractOrigin.PathOrigin;
-import org.apache.commons.lang3.ArrayUtils;
 
 /**
  * Tests {@link PathOrigin}.
@@ -41,13 +39,9 @@ class PathOriginTest extends AbstractOriginTest<Path, PathOrigin> {
 
     @Override
     protected PathOrigin newOriginRw() throws IOException {
-        return new PathOrigin(tempPath.resolve(FILE_NAME_RW));
+        final Path path = tempPath.resolve(FILE_NAME_RW);
+        FileUtils.touch(path.toFile());
+        return new PathOrigin(path);
     }
 
-    @Override
-    protected void resetOriginRw() throws IOException {
-        // Reset the file
-        final Path rwPath = tempPath.resolve(FILE_NAME_RW);
-        Files.write(rwPath, ArrayUtils.EMPTY_BYTE_ARRAY, StandardOpenOption.CREATE);
-    }
 }

--- a/src/test/java/org/apache/commons/io/build/URIOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/URIOriginTest.java
@@ -21,13 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.build.AbstractOrigin.URIOrigin;
-import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -47,15 +45,10 @@ class URIOriginTest extends AbstractOriginTest<URI, URIOrigin> {
     }
 
     @Override
-    protected URIOrigin newOriginRw() {
-        return new URIOrigin(tempPath.resolve(FILE_NAME_RW).toUri());
-    }
-
-    @Override
-    protected void resetOriginRw() throws IOException {
-        // Reset the file
-        final Path rwPath = tempPath.resolve(FILE_NAME_RW);
-        Files.write(rwPath, ArrayUtils.EMPTY_BYTE_ARRAY, StandardOpenOption.CREATE);
+    protected URIOrigin newOriginRw() throws IOException {
+        final Path path = tempPath.resolve(FILE_NAME_RW);
+        FileUtils.touch(path.toFile());
+        return new URIOrigin(path.toUri());
     }
 
     @ParameterizedTest
@@ -72,8 +65,7 @@ class URIOriginTest extends AbstractOriginTest<URI, URIOrigin> {
 
     @Test
     void testGetInputStreamFileURI() throws Exception {
-        final AbstractOrigin.URIOrigin origin = getOriginRo().asThis();
-        try (InputStream in = origin.getInputStream()) {
+        try (InputStream in = newOriginRo().getInputStream()) {
             assertNotEquals(-1, in.read());
         }
     }

--- a/src/test/java/org/apache/commons/io/build/WriterStreamOriginTest.java
+++ b/src/test/java/org/apache/commons/io/build/WriterStreamOriginTest.java
@@ -17,10 +17,15 @@
 package org.apache.commons.io.build;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.channels.WritableByteChannel;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.OpenOption;
 import java.nio.file.StandardOpenOption;
 
@@ -46,6 +51,21 @@ class WriterStreamOriginTest extends AbstractOriginTest<Writer, WriterOrigin> {
     @Override
     protected WriterOrigin newOriginRw() {
         return new WriterOrigin(new StringWriter());
+    }
+
+    @Test
+    void testClosesOrigin() throws IOException {
+        final Writer resource = mock(Writer.class);
+        final WriterOrigin origin = new WriterOrigin(resource);
+
+        origin.getOutputStream().close();
+        verify(resource, times(1)).close();
+
+        origin.getWriter(StandardCharsets.UTF_8).close();
+        verify(resource, times(2)).close();
+
+        origin.getChannel(WritableByteChannel.class).close();
+        verify(resource, times(3)).close();
     }
 
     @Override


### PR DESCRIPTION
This change makes `AbstractOrigin` implement `Closeable` and updates the Javadoc of all “getter” methods that return `Closeable` resources. The Javadoc now explicitly warns that:

* Closing the returned resource will also close the underlying `AbstractOrigin`.
* Ownership of the underlying resource is transferred to the caller.

### Rationale

* Callers must always close the returned resource. Some implementations create a new resource on each call, which must be released explicitly.
* Other implementations return the underlying origin directly, making it impossible to guarantee a close-shielded wrapper.
* The primary usage of `AbstractOrigin` is within `AbstractStreamBuilder`, whose implementations typically wrap closeable resources.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to generate the Javadoc.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best-practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
