### PR TITLE
Fix inconsistent exception in `IOUtils.toByteArray`

### DIFF
--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -2957,6 +2957,7 @@ public class IOUtils {
      * @param input the input to read, not null.
      * @param size the size of the input to read, where 0 &lt; {@code size} &lt;= length of input.
      * @return byte [] of length {@code size}.
+     * @throws EOFException if the end of the input is reached before reading {@code size} bytes.
      * @throws IOException if an I/O error occurs or input length is smaller than parameter {@code size}.
      * @throws IllegalArgumentException if {@code size} is less than zero.
      */
@@ -2974,7 +2975,7 @@ public class IOUtils {
             offset += read;
         }
         if (offset != size) {
-            throw new IOException("Unexpected read size, current: " + offset + ", expected: " + size);
+            throw new EOFException("Unexpected read size, current: " + offset + ", expected: " + size);
         }
         return data;
     }

--- a/src/test/java/org/apache/commons/io/IOUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/IOUtilsTest.java
@@ -158,7 +158,9 @@ class IOUtilsTest {
                 Arguments.of(-1, 128, IllegalArgumentException.class),
                 // Invalid buffer size
                 Arguments.of(0, 0, IllegalArgumentException.class),
-                // Huge size: should not cause OutOfMemoryError
+                // Truncation with requested size < chunk size
+                Arguments.of(64, 128, EOFException.class),
+                // Truncation with requested size > chunk size
                 Arguments.of(Integer.MAX_VALUE, 128, EOFException.class));
     }
 
@@ -1754,6 +1756,13 @@ class IOUtilsTest {
             assertEquals(0, fin.available(), "Not all bytes were read");
             assertEquals(FILE_SIZE, out.length, "Wrong output size: out.length=" + out.length + "!=" + FILE_SIZE);
             TestUtils.assertEqualContent(out, testFile);
+        }
+    }
+
+    @Test
+    void testToByteArray_InputStream_Size_Truncated() throws Exception {
+        try (InputStream in = new NullInputStream(0)) {
+            assertThrows(EOFException.class, () -> IOUtils.toByteArray(in, 1), "Should have failed with EOFException");
         }
     }
 


### PR DESCRIPTION
The implementation of `IOUtils.toByteArray(InputStream, int, int)` added in #776 throws different exceptions depending on the requested size:

* For request sizes larger than the internal chunk size, it correctly throws an `EOFException`.
* For smaller requests, it incorrectly throws a generic `IOException`.

This PR makes the behavior consistent by always throwing an `EOFException` when the stream ends prematurely.

> [!NOTE]
> This also affects `RandomAccessFiles.read`. Its previous truncation behavior was undocumented and inconsistent with `RandomAccessFile.read` (which reads as much as possible). The new behavior is not explicitly documented here either, since it is unclear whether throwing on truncation is actually desirable.
