### PR TITLE
IO-845 PathUtils.copyDirectory copies or follows symbolic links

### DIFF
--- a/src/main/java/org/apache/commons/io/file/CopyDirectoryVisitor.java
+++ b/src/main/java/org/apache/commons/io/file/CopyDirectoryVisitor.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import org.apache.commons.io.file.Counters.PathCounters;
+import org.apache.commons.io.filefilter.TrueFileFilter;
 
 /**
  * Copies a source directory to a target directory.
@@ -53,7 +54,7 @@ public class CopyDirectoryVisitor extends CountingPathVisitor {
      * @param copyOptions Specifies how the copying should be done.
      */
     public CopyDirectoryVisitor(final PathCounters pathCounter, final Path sourceDirectory, final Path targetDirectory, final CopyOption... copyOptions) {
-        super(pathCounter);
+        super(pathCounter, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
         this.sourceDirectory = sourceDirectory;
         this.targetDirectory = targetDirectory;
         this.copyOptions = toCopyOption(copyOptions);

--- a/src/main/java/org/apache/commons/io/file/CopyDirectoryVisitor.java
+++ b/src/main/java/org/apache/commons/io/file/CopyDirectoryVisitor.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.Objects;
 
 import org.apache.commons.io.file.Counters.PathCounters;
-import org.apache.commons.io.filefilter.TrueFileFilter;
 
 /**
  * Copies a source directory to a target directory.
@@ -54,7 +53,7 @@ public class CopyDirectoryVisitor extends CountingPathVisitor {
      * @param copyOptions Specifies how the copying should be done.
      */
     public CopyDirectoryVisitor(final PathCounters pathCounter, final Path sourceDirectory, final Path targetDirectory, final CopyOption... copyOptions) {
-        super(pathCounter, TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE);
+        super(pathCounter);
         this.sourceDirectory = sourceDirectory;
         this.targetDirectory = targetDirectory;
         this.copyOptions = toCopyOption(copyOptions);

--- a/src/main/java/org/apache/commons/io/file/CountingPathVisitor.java
+++ b/src/main/java/org/apache/commons/io/file/CountingPathVisitor.java
@@ -304,18 +304,20 @@ public class CountingPathVisitor extends SimplePathVisitor {
     }
 
     /**
-     * Updates the counters for visiting the given file.
+     * Updates the counters for visiting the given file, ignoring symbolic links.
+     * <p/>
+     * According to the JavaDoc, {@link BasicFileAttributes#size} is only well-defined for regular files.
+     * For symbolic links on Linux for example, it counts the # (charset dependent?) bytes in the inode name,
+     * which is <i>not</i>> what we want to count here.
+     * Intuitively, the appropriate check would be {@link Files#isRegularFile}.
+     * However, for symbolic links, {@code isRegularFile} returns {@code true} under a "follow links" regime.
+     * That would still not give us what we want, so instead we settle for a {@code !Files.isSymbolicLink} check.
      *
      * @param file       the visited file.
      * @param attributes the visited file attributes.
      */
     protected void updateFileCounters(final Path file, final BasicFileAttributes attributes) {
         pathCounters.getFileCounter().increment();
-        // According to the JavaDoc, BasicFileAttributes.size() is only well-defined for regular files.
-        // For symbolic links on Linux for example, it counts the # (charset dependent?) bytes in the inode name, which is NOT what we want to count here.
-        // Intuitively, the appropriate check would be Files.isRegularFile.
-        // However, for symbolic links, isRegularFile returns true under a "follow links" regime.
-        // That would still not give us what we want, so instead we settle for a !Files.isSymbolicLink check.
         if (!Files.isSymbolicLink(file)) {
             pathCounters.getByteCounter().add(attributes.size());
         }

--- a/src/main/java/org/apache/commons/io/file/CountingPathVisitor.java
+++ b/src/main/java/org/apache/commons/io/file/CountingPathVisitor.java
@@ -305,13 +305,14 @@ public class CountingPathVisitor extends SimplePathVisitor {
 
     /**
      * Updates the counters for visiting the given file, ignoring symbolic links.
-     * <p/>
+     * <p>
      * According to the JavaDoc, {@link BasicFileAttributes#size} is only well-defined for regular files.
      * For symbolic links on Linux for example, it counts the # (charset dependent?) bytes in the inode name,
-     * which is <i>not</i>> what we want to count here.
+     * which is <em>not</em> what we want to count here.
      * Intuitively, the appropriate check would be {@link Files#isRegularFile}.
      * However, for symbolic links, {@code isRegularFile} returns {@code true} under a "follow links" regime.
      * That would still not give us what we want, so instead we settle for a {@code !Files.isSymbolicLink} check.
+     * </p>
      *
      * @param file       the visited file.
      * @param attributes the visited file attributes.

--- a/src/main/java/org/apache/commons/io/file/PathUtils.java
+++ b/src/main/java/org/apache/commons/io/file/PathUtils.java
@@ -401,7 +401,7 @@ public final class PathUtils {
      */
     public static PathCounters copyDirectory(final Path sourceDirectory, final Path targetDirectory, final CopyOption... copyOptions) throws IOException {
         final Path absoluteSource = sourceDirectory.toAbsolutePath();
-        // CopyOption.NOFOLLOW_LINKS is the explicit option, "follow symlinks" the implicit default.
+        // LinkOption.NOFOLLOW_LINKS is the explicit option, "follow symlinks" the implicit default.
         // For FileVisitOption it's the other way around: FileVisitOption.FOLLOW_LINKS is the explicit option, and "do not follow symlinks" is the implicit
         // default.
         // If they're not in sync, the behavior is inconsistent, so we have to make sure they're in sync.

--- a/src/main/java/org/apache/commons/io/file/PathUtils.java
+++ b/src/main/java/org/apache/commons/io/file/PathUtils.java
@@ -401,7 +401,8 @@ public final class PathUtils {
     public static PathCounters copyDirectory(final Path sourceDirectory, final Path targetDirectory, final CopyOption... copyOptions) throws IOException {
         final Path absoluteSource = sourceDirectory.toAbsolutePath();
         // CopyOption.NOFOLLOW_LINKS is the explicit option, "follow symlinks" the implicit default.
-        // For FileVisitOption it's the other way around: FileVisitOption.FOLLOW_LINKS is the explicit option, and "do not follow symlinks" is the implicit default.
+        // For FileVisitOption it's the other way around: FileVisitOption.FOLLOW_LINKS is the explicit option, and "do not follow symlinks" is the implicit
+        // default.
         // If they're not in sync, the behavior is inconsistent, so we have to make sure they're in sync.
         // CopyOption is given by the caller, FileVisitOption is under our control here, so we sync the latter to the former.
         Set<FileVisitOption> fileVisitOptions = FOLLOW_LINKS_FILE_VISIT_OPTIONS;
@@ -413,7 +414,8 @@ public final class PathUtils {
                 }
             }
         }
-        return visitFileTree(new CopyDirectoryVisitor(Counters.longPathCounters(), absoluteSource, targetDirectory, copyOptions), absoluteSource, fileVisitOptions, Integer.MAX_VALUE)
+        return visitFileTree(new CopyDirectoryVisitor(Counters.longPathCounters(), absoluteSource, targetDirectory, copyOptions), absoluteSource,
+                fileVisitOptions, Integer.MAX_VALUE)
                 .getPathCounters();
     }
 

--- a/src/main/java/org/apache/commons/io/file/PathUtils.java
+++ b/src/main/java/org/apache/commons/io/file/PathUtils.java
@@ -371,19 +371,24 @@ public final class PathUtils {
 
     /**
      * Copies a directory to another directory.
+     * <p>
      * Symbolic links are either followed or copied, depending on the {@link LinkOption#NOFOLLOW_LINKS} option.
      * Non-symbolic links, aka. hard links, are always copied, given that they appear as regular files to Java.
      * {@code LinkOption} does not apply to hard links.
      * Symbolic links can link to files or directories, while non-symbolic links can only link to files.
      * Symbolic links can be (ab)used to create endlessly recursive directories.
+     * </p>
      *
-     * <h4>Without {@link LinkOption#NOFOLLOW_LINKS} option (the default)</h4>
+     * <strong>Without {@link LinkOption#NOFOLLOW_LINKS} option (the default)</strong>
+     * <p>
      * Given that Java defines {@link LinkOption#NOFOLLOW_LINKS} as an explicit option, the default is the absence of that option, which is to follow links.
      * Symbolic links in the source directory are followed, resulting in a target directory that has no symbolic links.
      * Cyclic symbolic links cause the copy operation to abort and throw a {@link java.nio.file.FileSystemLoopException}.
-     * Broken symbolic links are ignored, they are not copied.
+     * Broken symbolic links are ignored; they are not copied.
+     * </p>
      *
-     * <h4>With {@link LinkOption#NOFOLLOW_LINKS} option</h4>
+     * <strong>With {@link LinkOption#NOFOLLOW_LINKS} option</strong>
+     * <p>
      * Symbolic links in the source directory are copied to the target directory as symbolic links.
      * Symbolic links linking inside the source directory are copied as relative links, meaning that the target symbolic
      * link will link inside the target directory to a copied file or directory.
@@ -391,7 +396,8 @@ public final class PathUtils {
      * link will link outside the target directory to the same file or directory the link is linking to in the source directory.
      * Cyclic symbolic links are preserved as regular symbolic links.
      * Their cyclic nature is irrelevant to the copy operation.
-     * Broken symbolic links are ignored, they are not copied.
+     * Broken symbolic links are ignored; they are not copied.
+     * </p>
      *
      * @param sourceDirectory The source directory.
      * @param targetDirectory The target directory.

--- a/src/main/java/org/apache/commons/io/file/PathUtils.java
+++ b/src/main/java/org/apache/commons/io/file/PathUtils.java
@@ -82,6 +82,7 @@ import org.apache.commons.io.ThreadUtils;
 import org.apache.commons.io.file.Counters.PathCounters;
 import org.apache.commons.io.file.attribute.FileTimes;
 import org.apache.commons.io.filefilter.IOFileFilter;
+import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.io.function.IOFunction;
 import org.apache.commons.io.function.IOSupplier;
 
@@ -408,13 +409,13 @@ public final class PathUtils {
         Set<FileVisitOption> fileVisitOptions = FOLLOW_LINKS_FILE_VISIT_OPTIONS;
         if (copyOptions != null) {
             for (CopyOption copyOption : copyOptions) {
-                if (LinkOption.NOFOLLOW_LINKS.equals(copyOption)) {
+                if (copyOption == LinkOption.NOFOLLOW_LINKS) {
                     fileVisitOptions = Collections.emptySet();
                     break;
                 }
             }
         }
-        return visitFileTree(new CopyDirectoryVisitor(Counters.longPathCounters(), absoluteSource, targetDirectory, copyOptions), absoluteSource,
+        return visitFileTree(new CopyDirectoryVisitor(Counters.longPathCounters(), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE, absoluteSource, targetDirectory, copyOptions), absoluteSource,
                 fileVisitOptions, Integer.MAX_VALUE)
                 .getPathCounters();
     }

--- a/src/main/java/org/apache/commons/io/file/PathUtils.java
+++ b/src/main/java/org/apache/commons/io/file/PathUtils.java
@@ -415,8 +415,8 @@ public final class PathUtils {
                 }
             }
         }
-        return visitFileTree(new CopyDirectoryVisitor(Counters.longPathCounters(), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE, absoluteSource, targetDirectory, copyOptions), absoluteSource,
-                fileVisitOptions, Integer.MAX_VALUE)
+        return visitFileTree(new CopyDirectoryVisitor(Counters.longPathCounters(), TrueFileFilter.INSTANCE, TrueFileFilter.INSTANCE, absoluteSource,
+                targetDirectory, copyOptions), absoluteSource, fileVisitOptions, Integer.MAX_VALUE)
                 .getPathCounters();
     }
 

--- a/src/test/java/org/apache/commons/io/file/PathUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/file/PathUtilsTest.java
@@ -18,7 +18,6 @@
 package org.apache.commons.io.file;
 
 import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
-
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -730,8 +729,8 @@ class PathUtilsTest extends AbstractTempDirTest {
     @ArgumentsSource(CopyOptionsArgumentsProvider.class)
     void testCopyDirectoryIgnoresBrokenSymbolicLink(CopyOption... copyOptions) throws Exception {
         final Path sourceDir = Files.createDirectory(tempDirPath.resolve("source"));
-		final Path dir = Files.createDirectory(sourceDir.resolve("dir"));
-		Files.createSymbolicLink(dir.resolve("broken-symlink"), dir.relativize(sourceDir.resolve("file")));
+        final Path dir = Files.createDirectory(sourceDir.resolve("dir"));
+        Files.createSymbolicLink(dir.resolve("broken-symlink"), dir.relativize(sourceDir.resolve("file")));
         final Path targetDir = tempDirPath.resolve("target");
 
         PathUtils.copyDirectory(sourceDir, targetDir, copyOptions);

--- a/src/test/java/org/apache/commons/io/file/PathUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/file/PathUtilsTest.java
@@ -17,6 +17,8 @@
 
 package org.apache.commons.io.file;
 
+import static java.nio.file.LinkOption.NOFOLLOW_LINKS;
+
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -32,7 +34,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.CopyOption;
 import java.nio.file.DirectoryStream;
+import java.nio.file.FileSystemLoopException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.LinkOption;
@@ -43,8 +47,10 @@ import java.nio.file.attribute.FileTime;
 import java.nio.file.attribute.PosixFileAttributes;
 import java.util.GregorianCalendar;
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.file.Counters.PathCounters;
 import org.apache.commons.io.filefilter.NameFileFilter;
 import org.apache.commons.io.test.TestUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -52,6 +58,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemProperties;
 import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.junit.jupiter.params.support.ParameterDeclarations;
 
 /**
  * Tests {@link PathUtils}.
@@ -496,4 +508,282 @@ class PathUtilsTest extends AbstractTempDirTest {
         return file;
     }
 
+    /**
+     * Illustrates how copy with {@link LinkOption#NOFOLLOW_LINKS} preserves relative symlinks to directories.
+     * This simulates to the behavior of Linux {@code cp -r}.
+     * Given the source directory structure:
+     * <pre>{@code
+     * user@host:/tmp$ tree source/
+     * source/
+     * ├── dir1
+     * │   └── symlink -> ../dir2
+     * └── dir2
+     * }</pre>
+     * When doing {@code user@host:/tmp$ cp -r source target}, then the resulting target directory structure is:
+     * <pre>{@code
+     * user@host:/tmp$ tree target/
+     * target/
+     * ├── dir1
+     * │   └── symlink -> ../dir2
+     * └── dir2
+     * }</pre>
+     */
+    @Test
+    void testCopyDirectoryWithNoFollowLinksPreservesRelativeSymbolicLinkToDir() throws Exception {
+        // Given
+        final Path sourceDir = Files.createDirectory(tempDirPath.resolve("source"));
+        final Path dir1 = Files.createDirectory(sourceDir.resolve("dir1"));
+        final Path dir2 = Files.createDirectory(sourceDir.resolve("dir2"));
+        // source/dir1/symlink -> ../dir2
+        Files.createSymbolicLink(dir1.resolve("symlink"), dir1.relativize(dir2));
+        final Path targetDir = tempDirPath.resolve("target");
+
+        // When
+        final PathCounters pathCounters = PathUtils.copyDirectory(sourceDir, targetDir, NOFOLLOW_LINKS);
+
+        // Then
+        assertEquals(0L, pathCounters.getByteCounter().get());
+        assertEquals(3L, pathCounters.getDirectoryCounter().get());
+        // Verify that symlink with NOFOLLOW_LINKS counts as file
+        assertEquals(1L, pathCounters.getFileCounter().get());
+        final Path copyOfDir2 = targetDir.resolve("dir2");
+        final Path copyOfRelativeSymlinkToDir2 = targetDir.resolve("dir1").resolve("symlink");
+        assertTrue(Files.isSymbolicLink(copyOfRelativeSymlinkToDir2));
+        assertTrue(Files.isDirectory(copyOfRelativeSymlinkToDir2));
+        // Verify that target/dir1/symlink resolves to /tmp/target/dir2
+        assertEquals(copyOfDir2.toRealPath(), copyOfRelativeSymlinkToDir2.toRealPath());
+    }
+
+    /**
+     * Illustrates how copy with {@link LinkOption#NOFOLLOW_LINKS} preserves absolute symlinks to directories.
+     * This simulates to the behavior of Linux {@code cp -r}.
+     * Given the source directory structure:
+     * <pre>{@code
+     * user@host:/tmp$ tree source/ external/
+     * source/
+     * └── dir
+     *     └── symlink -> /tmp/external
+     * external/
+     * }</pre>
+     * When doing {@code user@host:/tmp$ cp -r source target}, then the resulting target directory structure is:
+     * <pre>{@code
+     * user@host:/tmp$ tree target/
+     * target/
+     * └── dir
+     *     └── symlink -> /tmp/external
+     * }</pre>
+     */
+    @Test
+    void testCopyDirectoryWithNoFollowLinksPreservesAbsoluteSymbolicLinkToDir() throws Exception {
+        // Given
+        final Path sourceDir = Files.createDirectory(tempDirPath.resolve("source"));
+        final Path externalDir = Files.createDirectory(tempDirPath.resolve("external"));
+        final Path dir = Files.createDirectory(sourceDir.resolve("dir"));
+        // source/dir/symlink -> /tmp/external
+        Files.createSymbolicLink(dir.resolve("symlink"), externalDir.toAbsolutePath());
+        final Path targetDir = tempDirPath.resolve("target");
+
+        // When
+        final PathCounters pathCounters = PathUtils.copyDirectory(sourceDir, targetDir, NOFOLLOW_LINKS);
+
+        // Then
+        assertEquals(0L, pathCounters.getByteCounter().get());
+        assertEquals(2L, pathCounters.getDirectoryCounter().get());
+        // Verify that symlink with NOFOLLOW_LINKS counts as file
+        assertEquals(1L, pathCounters.getFileCounter().get());
+        final Path copyOfAbsoluteSymlinkToDir = targetDir.resolve("dir").resolve("symlink");
+        assertTrue(Files.isSymbolicLink(copyOfAbsoluteSymlinkToDir));
+        assertTrue(Files.isDirectory(copyOfAbsoluteSymlinkToDir));
+        // Verify that target/dir/symlink resolves to /tmp/external
+        assertEquals(externalDir.toRealPath(), copyOfAbsoluteSymlinkToDir.toRealPath());
+    }
+
+    /**
+     * Illustrates how copy with {@link LinkOption#NOFOLLOW_LINKS} preserves relative symlinks to files.
+     * This simulates to the behavior of Linux {@code cp -r}.
+     * Given the source directory structure:
+     * <pre>{@code
+     * user@host:/tmp$ tree source/
+     * source/
+     * ├── dir
+     * │   └── symlink -> ../file
+     * └── file
+     * }</pre>
+     * When doing {@code user@host:/tmp$ cp -r source target}, then the resulting target directory structure is:
+     * <pre>{@code
+     * user@host:/tmp$ tree target/
+     * target/
+     * ├── dir
+     * │   └── symlink -> ../file
+     * └── file
+     * }</pre>
+     */
+    @Test
+    void testCopyDirectoryWithNoFollowLinksPreservesRelativeSymbolicLinkToFile() throws Exception {
+        // Given
+        final Path sourceDir = Files.createDirectory(tempDirPath.resolve("source"));
+        final Path dir = Files.createDirectory(sourceDir.resolve("dir"));
+        final Path file = Files.write(sourceDir.resolve("file"), BYTE_ARRAY_FIXTURE);
+        // source/dir/symlink -> ../file
+        Files.createSymbolicLink(dir.resolve("symlink"), dir.relativize(file));
+        final Path targetDir = tempDirPath.resolve("target");
+
+        // When
+        final PathCounters pathCounters = PathUtils.copyDirectory(sourceDir, targetDir, NOFOLLOW_LINKS);
+
+        // Then
+        assertEquals(11L, pathCounters.getByteCounter().get());
+        assertEquals(2L, pathCounters.getDirectoryCounter().get());
+        // Verify that file + symlink with NOFOLLOW_LINKS counts as 2 files
+        assertEquals(2L, pathCounters.getFileCounter().get());
+        final Path copyOfFile = targetDir.resolve("file");
+        final Path copyOfRelativeSymlinkToFile = targetDir.resolve("dir").resolve("symlink");
+        assertTrue(Files.isSymbolicLink(copyOfRelativeSymlinkToFile));
+        assertTrue(Files.isRegularFile(copyOfRelativeSymlinkToFile));
+        // Verify that /tmp/target/dir/symlink resolves to /tmp/target/file
+        assertEquals(copyOfFile.toRealPath(), copyOfRelativeSymlinkToFile.toRealPath());
+    }
+
+    /**
+     * Illustrates how copy with {@link LinkOption#NOFOLLOW_LINKS} preserves relative symlinks to files.
+     * This simulates to the behavior of Linux {@code cp -r}.
+     * Given the source directory structure:
+     * <pre>{@code
+     * user@host:/tmp$ tree source/
+     * source/
+     * ├── dir
+     * │   └── symlink -> ../file
+     * └── file
+     * }</pre>
+     * When doing {@code user@host:/tmp$ cp -r source target}, then the resulting target directory structure is:
+     * <pre>{@code
+     * user@host:/tmp$ tree target/
+     * target/
+     * ├── dir
+     * │   └── symlink -> ../file
+     * └── file
+     * }</pre>
+     */
+    @Test
+    void testCopyDirectoryWithNoFollowLinksPreservesAbsoluteSymbolicLinkToFile() throws Exception {
+        // Given
+        final Path externalDir = Files.createDirectory(tempDirPath.resolve("external"));
+        final Path file = Files.write(externalDir.resolve("file"), BYTE_ARRAY_FIXTURE);
+        final Path sourceDir = Files.createDirectory(tempDirPath.resolve("source"));
+        final Path dir = Files.createDirectory(sourceDir.resolve("dir"));
+        // source/dir/symlink -> /tmp/file
+        Files.createSymbolicLink(dir.resolve("symlink"), file.toAbsolutePath());
+        final Path targetDir = tempDirPath.resolve("target");
+
+        // When
+        final PathCounters pathCounters = PathUtils.copyDirectory(sourceDir, targetDir, NOFOLLOW_LINKS);
+
+        // Then
+        assertEquals(0L, pathCounters.getByteCounter().get());
+        assertEquals(2L, pathCounters.getDirectoryCounter().get());
+        assertEquals(1L, pathCounters.getFileCounter().get());
+        final Path copyOfAbsoluteSymlinkToFile = targetDir.resolve("dir").resolve("symlink");
+        assertTrue(Files.isSymbolicLink(copyOfAbsoluteSymlinkToFile));
+        assertTrue(Files.isRegularFile(copyOfAbsoluteSymlinkToFile));
+        // Verify that /tmp/target/dir/symlink resolves to /tmp/source/file
+        assertEquals(file.toRealPath(), copyOfAbsoluteSymlinkToFile.toRealPath());
+    }
+
+    @Test
+    void testCopyDirectoryThrowsOnCyclicSymbolicLink() throws Exception {
+        final Path sourceDir = Files.createDirectory(tempDirPath.resolve("source"));
+        final Path dir1 = Files.createDirectory(sourceDir.resolve("dir1"));
+        final Path dir2 = Files.createDirectory(dir1.resolve("dir2"));
+        Files.createSymbolicLink(dir2.resolve("cyclic-symlink"), dir2.relativize(dir1));
+        final Path targetDir = tempDirPath.resolve("target");
+
+        assertThrows(FileSystemLoopException.class, () -> PathUtils.copyDirectory(sourceDir, targetDir));
+
+        assertTrue(Files.exists(targetDir));
+        final Path copyOfDir2 = targetDir.resolve("dir1").resolve("dir2");
+        assertTrue(Files.exists(copyOfDir2));
+        assertTrue(Files.isDirectory(copyOfDir2));
+        assertFalse(Files.exists(copyOfDir2.resolve("cyclic-symlink")));
+    }
+
+    @Test
+    void testCopyDirectoryWithNoFollowLinksPreservesCyclicSymbolicLink() throws Exception {
+        final Path sourceDir = Files.createDirectory(tempDirPath.resolve("source"));
+        final Path dir1 = Files.createDirectory(sourceDir.resolve("dir1"));
+        final Path dir2 = Files.createDirectory(dir1.resolve("dir2"));
+        Files.createSymbolicLink(dir2.resolve("cyclic-symlink"), dir2.relativize(dir1));
+        final Path targetDir = tempDirPath.resolve("target");
+
+        PathUtils.copyDirectory(sourceDir, targetDir, NOFOLLOW_LINKS);
+
+        assertTrue(Files.exists(targetDir));
+        final Path copyOfDir1 = targetDir.resolve("dir1");
+        final Path copyOfDir2 = copyOfDir1.resolve("dir2");
+        assertTrue(Files.exists(copyOfDir2));
+        assertTrue(Files.isDirectory(copyOfDir2));
+        final Path copyOfCyclicSymlink = copyOfDir2.resolve("cyclic-symlink");
+        assertTrue(Files.exists(copyOfCyclicSymlink));
+        assertEquals(copyOfDir1.toRealPath(), copyOfCyclicSymlink.toRealPath());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(CopyOptionsArgumentsProvider.class)
+    void testCopyDirectoryIgnoresBrokenSymbolicLink(CopyOption... copyOptions) throws Exception {
+        final Path sourceDir = Files.createDirectory(tempDirPath.resolve("source"));
+		final Path dir = Files.createDirectory(sourceDir.resolve("dir"));
+		Files.createSymbolicLink(dir.resolve("broken-symlink"), dir.relativize(sourceDir.resolve("file")));
+        final Path targetDir = tempDirPath.resolve("target");
+
+        PathUtils.copyDirectory(sourceDir, targetDir, copyOptions);
+
+        assertTrue(Files.exists(targetDir));
+        final Path copyOfDir = targetDir.resolve("dir");
+        assertTrue(Files.exists(copyOfDir));
+        assertTrue(Files.isDirectory(copyOfDir));
+        assertFalse(Files.exists(copyOfDir.resolve("broken-symlink")));
+    }
+
+    private static class CopyOptionsArgumentsProvider implements ArgumentsProvider {
+
+        @Override
+        public Stream<? extends Arguments> provideArguments(ParameterDeclarations parameters, ExtensionContext context) {
+            return Stream.of(
+                    Arguments.of((Object) new CopyOption[0]),
+                    Arguments.of((Object) new CopyOption[] { NOFOLLOW_LINKS })
+            );
+        }
+    }
+
+    @Test
+    void testCopyDirectoryFollowsAbsoluteSymbolicLinkToDirectory() throws Exception {
+        // Given
+        final Path externalDir = Files.createDirectory(tempDirPath.resolve("external"));
+        final Path dir1 = Files.createDirectory(externalDir.resolve("dir1"));
+        final Path file2 = Files.write(dir1.resolve("file2"), BYTE_ARRAY_FIXTURE);
+        final Path sourceDir = Files.createDirectory(tempDirPath.resolve("source"));
+        final Path dir3 = Files.createDirectory(sourceDir.resolve("dir3"));
+        final Path file4 = Files.write(dir3.resolve("file4"), BYTE_ARRAY_FIXTURE);
+        Files.createSymbolicLink(sourceDir.resolve("symlink1"), dir1.toAbsolutePath());
+        Files.createSymbolicLink(sourceDir.resolve("symlink2"), sourceDir.relativize(file2));
+        Files.createSymbolicLink(sourceDir.resolve("symlink3"), sourceDir.relativize(dir3));
+        Files.createSymbolicLink(dir3.resolve("symlink4"), file4.toAbsolutePath());
+        final Path targetDir = tempDirPath.resolve("target");
+
+        // When
+        final PathCounters pathCounters = PathUtils.copyDirectory(sourceDir, targetDir);
+
+        // Then
+        // 6 * 11 bytes == 66:
+        // file2
+        // file4
+        // symlink2 -> file2
+        // symlink4 -> file4
+        // symlink1 -> dir1 containing file2
+        // symlink3 -> dir3 containing file4
+        assertEquals(66L, pathCounters.getByteCounter().get());
+        assertEquals(4L, pathCounters.getDirectoryCounter().get());
+        assertEquals(6L, pathCounters.getFileCounter().get());
+        assertTrue(Files.exists(targetDir.resolve("dir3").resolve("file4")));
+        assertTrue(Files.exists(targetDir.resolve("dir3").resolve("symlink4")));
+    }
 }


### PR DESCRIPTION
Defined the behavior of `PathUtils.copyDirectory` for symbolic links. It depends on the option `LinkOption.NOFOLLOW_LINKS`. Non-symbolic (hard) links are out of scope, given that the copy behavior for them was already well-defined: they're treated as regular files.
For the sake of conciseness, the following paragraphs use the term "link" for "symbolic link".

Without  `NOFOLLOW_LINKS` option:
- Links are followed, so that there are no links in the target directory.
- Cyclic links result in `FileSystemLoopException`.
- Broken links are ignored, they are not copied at all.

With `NOFOLLOW_LINKS` option:
- Links are copied as links, so that there are links in the target directory for every link in the source directory.
- Links that link to a file or directory inside the source directory are copied to relative links inside the target directory, linking to the copied file or directory.
- Links that link to a file or directory outside the source directory are copied to links inside the target directory, linking to the same file or directory as the link in the source directory.
- Cyclic links are preserved, mirrored to cyclic links in the target directory.
- Broken links are ignored, they are not copied at all.

All of this is also explained in the updated JavaDoc.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
