### PR TITLE
[IO-867] Fix ThresholdingOutputStream.isThresholdExceeded and event retry

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -47,6 +47,7 @@ The <action> type attribute can be add,update,fix,remove.
   <body>
     <release version="2.23.0" date="YYYY-MM-DD" description="This is a feature and maintenance release. Java 8 or later is required.">
       <!-- FIX -->
+      <action issue="IO-867" type="fix" dev="ggregory" due-to="Sai Asish Y">ThresholdingOutputStream.isThresholdExceeded() now reflects the threshold-reached state, and a failed thresholdReached() no longer leaves the stream unable to fire the event again.</action>
       <!-- ADD -->
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add IOConsumer.accept(IOConsumer, T) (#846).</action>
       <!-- UPDATE -->

--- a/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/ThresholdingOutputStream.java
@@ -111,7 +111,12 @@ public class ThresholdingOutputStream extends OutputStream {
     protected void checkThreshold(final int count) throws IOException {
         if (!thresholdExceeded && written + count > threshold) {
             thresholdExceeded = true;
-            thresholdReached();
+            try {
+                thresholdReached();
+            } catch (final IOException | RuntimeException e) {
+                thresholdExceeded = false;
+                throw e;
+            }
         }
     }
 
@@ -192,7 +197,7 @@ public class ThresholdingOutputStream extends OutputStream {
      * @return {@code true} if the threshold has been reached; {@code false} otherwise.
      */
     public boolean isThresholdExceeded() {
-        return written > threshold;
+        return thresholdExceeded;
     }
 
     /**

--- a/src/test/java/org/apache/commons/io/output/ThresholdingOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/ThresholdingOutputStreamTest.java
@@ -209,6 +209,26 @@ class ThresholdingOutputStreamTest {
     }
 
     @Test
+    void testThresholdReachedRetriedAfterException() throws IOException {
+        final int threshold = 1;
+        final AtomicInteger counter = new AtomicInteger();
+        try (ThresholdingOutputStream out = new ThresholdingOutputStream(threshold, tos -> {
+            if (counter.incrementAndGet() == 1) {
+                throw new IOException("Threshold reached.");
+            }
+        }, os -> new ByteArrayOutputStream(4))) {
+            assertThresholdingInitialState(out, threshold, 0);
+            out.write('a');
+            assertFalse(out.isThresholdExceeded());
+            assertThrows(IOException.class, () -> out.write('a'));
+            assertFalse(out.isThresholdExceeded());
+            out.write('a');
+            assertEquals(2, counter.get());
+            assertTrue(out.isThresholdExceeded());
+        }
+    }
+
+    @Test
     void testThresholdIOConsumerUncheckedException() throws IOException {
         final int threshold = 1;
         try (ThresholdingOutputStream out = new ThresholdingOutputStream(threshold, os -> {


### PR DESCRIPTION
`isThresholdExceeded()` now returns the tracked `thresholdExceeded` flag instead of `written > threshold`, so it stays consistent with `checkThreshold()` and with `DeferredFileOutputStream.isInMemory()`. `checkThreshold()` also rolls back the flag if `thresholdReached()` throws, so a failed event no longer prevents the stream from re-firing it and no longer leaves `DeferredFileOutputStream` in an inconsistent in-memory/on-disk state.

Closes #IO-867 (https://issues.apache.org/jira/browse/IO-867).