### PR TITLE
Clean BufferedFileChannelInputStream's direct ByteBuffer once

### DIFF
--- a/src/main/java/org/apache/commons/io/input/BufferedFileChannelInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BufferedFileChannelInputStream.java
@@ -137,6 +137,8 @@ public final class BufferedFileChannelInputStream extends InputStream {
 
     private final ByteBuffer byteBuffer;
 
+    private boolean clean;
+
     private final FileChannel fileChannel;
 
     @SuppressWarnings("resource")
@@ -209,26 +211,18 @@ public final class BufferedFileChannelInputStream extends InputStream {
      * disposed buffer. However, neither the bytes allocated to direct buffers nor file descriptors opened for memory-mapped buffers put pressure on the garbage
      * collector. Waiting for garbage collection may lead to the depletion of off-heap memory or huge numbers of open files. There's unfortunately no standard
      * API to manually dispose of these kinds of buffers.
-     *
-     * @param buffer the buffer to clean.
-     */
-    private void clean(final ByteBuffer buffer) {
-        if (buffer.isDirect()) {
-            cleanDirectBuffer(buffer);
-        }
-    }
-
-    /**
+     * <p>
      * In Java 8, the type of {@code sun.nio.ch.DirectBuffer.cleaner()} was {@code sun.misc.Cleaner}, and it was possible to access the method
      * {@code sun.misc.Cleaner.clean()} to invoke it. The type changed to {@code jdk.internal.ref.Cleaner} in later JDKs, and the {@code clean()} method is not
      * accessible even with reflection. However {@code sun.misc.Unsafe} added an {@code invokeCleaner()} method in JDK 9+ and this is still accessible with
      * reflection.
-     *
-     * @param buffer the buffer to clean. must be a DirectBuffer.
+     * </p>
+     * @param buffer the buffer to clean.
      */
-    private void cleanDirectBuffer(final ByteBuffer buffer) {
-        if (ByteBufferCleaner.isSupported()) {
+    private void clean(final ByteBuffer buffer) {
+        if (!clean && buffer.isDirect() && ByteBufferCleaner.isSupported()) {
             ByteBufferCleaner.clean(buffer);
+            clean = true;
         }
     }
 
@@ -239,6 +233,10 @@ public final class BufferedFileChannelInputStream extends InputStream {
         } finally {
             clean(byteBuffer);
         }
+    }
+
+    boolean isClean() {
+        return clean;
     }
 
     @Override
@@ -300,6 +298,7 @@ public final class BufferedFileChannelInputStream extends InputStream {
         byteBuffer.flip();
         return skippedFromBuffer + skipFromFileChannel(toSkipFromFileChannel);
     }
+
 
     private long skipFromFileChannel(final long n) throws IOException {
         final long currentFilePosition = fileChannel.position();

--- a/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
@@ -14,8 +14,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.apache.commons.io.input;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -65,6 +67,22 @@ class BufferedFileChannelInputStreamTest extends AbstractInputStreamTest {
         assertThrows(IllegalStateException.class, () -> BufferedFileChannelInputStream.builder().get());
     }
 
+    /**
+     * Tests that the {@code clean(ByteBuffer)} method only performs buffer cleaning once, even when {@link BufferedFileChannelInputStream#close()} is invoked
+     * multiple times. The private {@code clean} boolean field is inspected via reflection: it must be {@code false} before any close, {@code true} after the
+     * first close, and remain {@code true} after a second close, confirming that {@code ByteBufferCleaner.clean()} is never called more than once.
+     */
+    @Test
+    void testCleanCalledOnlyOnce() throws Exception {
+        try (BufferedFileChannelInputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).get()) {
+            assertFalse(stream.isClean());
+            stream.close();
+            assertTrue(stream.isClean());
+            stream.close();
+            assertTrue(stream.isClean());
+        }
+    }
+
     @Test
     void testReadAfterClose() throws Exception {
         for (final InputStream inputStream : inputStreams) {
@@ -72,5 +90,4 @@ class BufferedFileChannelInputStreamTest extends AbstractInputStreamTest {
             assertThrows(IOException.class, inputStream::read);
         }
     }
-
 }


### PR DESCRIPTION
Clean `BufferedFileChannelInputStream`'s direct `ByteBuffer` once.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create the first cut of the unit test.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
