### PR TITLE
[IO-855] Clarify PeekableInputStream.peek() behavior in Javadoc

### DIFF
--- a/src/main/java/org/apache/commons/io/input/buffer/PeekableInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/buffer/PeekableInputStream.java
@@ -50,11 +50,13 @@ public class PeekableInputStream extends CircularBufferInputStream {
     }
 
     /**
-     * Returns whether the next bytes in the buffer are as given by {@code sourceBuffer}. This is equivalent to
-     * {@link #peek(byte[], int, int)} with {@code offset} == 0, and {@code length} == {@code sourceBuffer.length}
+     * Returns whether the next bytes in the buffer exactly match {@code sourceBuffer}. This is equivalent to
+     * {@link #peek(byte[], int, int)} with {@code offset} == 0, and {@code length} == {@code sourceBuffer.length}.
+     * This method does not perform a prefix or starts-with check; for example, peeking {@code "Some"} against a stream
+     * containing {@code "Some text buffer"} returns {@code false}. This method does not consume bytes from the stream.
      *
      * @param sourceBuffer the buffer to compare against.
-     * @return true if the next bytes are as given.
+     * @return true if the next bytes exactly match {@code sourceBuffer}.
      * @throws IOException Refilling the buffer failed.
      */
     public boolean peek(final byte[] sourceBuffer) throws IOException {
@@ -63,13 +65,13 @@ public class PeekableInputStream extends CircularBufferInputStream {
     }
 
     /**
-     * Returns whether the next bytes in the buffer are as given by {@code sourceBuffer}, {code offset}, and
-     * {@code length}.
+     * Returns whether the next bytes in the buffer exactly match {@code length} bytes from {@code sourceBuffer}, starting at
+     * {@code offset}. This method does not consume bytes from the stream.
      *
      * @param sourceBuffer the buffer to compare against.
-     * @param offset the start offset.
+     * @param offset the start offset in {@code sourceBuffer}.
      * @param length the length to compare.
-     * @return true if the next bytes in the buffer are as given.
+     * @return true if the next bytes exactly match the requested range from {@code sourceBuffer}.
      * @throws IOException if there is a problem calling fillBuffer().
      */
     public boolean peek(final byte[] sourceBuffer, final int offset, final int length) throws IOException {

--- a/src/test/java/org/apache/commons/io/input/buffer/PeekableInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/buffer/PeekableInputStreamTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.io.input.buffer;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -24,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 
 import org.junit.jupiter.api.Test;
@@ -99,5 +101,30 @@ class PeekableInputStreamTest {
             }
         }
         assertTrue(true, "Test finished OK");
+    }
+
+    @Test
+    void testPeekExactMatch() throws IOException {
+        final byte[] input = "Some text buffer".getBytes(StandardCharsets.UTF_8);
+        try (PeekableInputStream inputStream = new PeekableInputStream(new ByteArrayInputStream(input))) {
+            assertTrue(inputStream.peek(input));
+        }
+    }
+
+    @Test
+    void testPeekPrefixDoesNotMatchLongerInput() throws IOException {
+        try (PeekableInputStream inputStream = new PeekableInputStream(
+                new ByteArrayInputStream("Some text buffer".getBytes(StandardCharsets.UTF_8)))) {
+            assertFalse(inputStream.peek("Some".getBytes(StandardCharsets.UTF_8)));
+        }
+    }
+
+    @Test
+    void testPeekDoesNotConsumeBytes() throws IOException {
+        final byte[] input = "Some".getBytes(StandardCharsets.UTF_8);
+        try (PeekableInputStream inputStream = new PeekableInputStream(new ByteArrayInputStream(input))) {
+            assertTrue(inputStream.peek(input));
+            assertEquals('S', inputStream.read());
+        }
     }
 }


### PR DESCRIPTION
PeekableInputStream.peek() currently performs an exact match against the provided byte array, but the Javadoc could be read as a prefix / starts-with check.
This PR clarifies the Javadoc to state that peek() requires an exact match and does not consume bytes from the stream.
It also adds tests covering:
- exact match returns true
- prefix-only match returns false
- peek() does not consume bytes
Resolves [IO-855](https://issues.apache.org/jira/browse/IO-855)

Checklist:
- [x] Read the contribution guidelines for this project.
- [x] Read the ASF Generative Tooling Guidance.
- [x] Ran `mvn -Drat.skip=true -Dtest=PeekableInputStreamTest test`
- [x] Added unit tests matching the documented behavior.