### PR TITLE
[IO-438] Clarify IOUtils.closeQuietly() Javadocs

### DIFF
--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -800,6 +800,20 @@ public class IOUtils {
      * }
      * </pre>
      * <p>
+     * Closing all streams:
+     * </p>
+     *
+     * <pre>
+     * try {
+     *     IOUtils.copy(inputStream, outputStream);
+     *     outputStream.close(); // close errors are handled
+     *     outputStream = null;
+     * } finally {
+     *     IOUtils.closeQuietly(inputStream);
+     *     IOUtils.closeQuietly(outputStream); // only if normal close was skipped
+     * }
+     * </pre>
+     * <p>
      * Also consider using a try-with-resources statement where appropriate.
      * </p>
      *
@@ -837,6 +851,19 @@ public class IOUtils {
      *     // error handling
      * } finally {
      *     <strong>IOUtils.closeQuietly(closeable); // In case normal close was skipped due to Exception</strong>
+     * }
+     * </pre>
+     * <p>
+     * Closing all streams:
+     * </p>
+     *
+     * <pre>
+     * try {
+     *     IOUtils.copy(inputStream, outputStream);
+     *     outputStream.close(); // close errors are handled
+     *     outputStream = null;
+     * } finally {
+     *     IOUtils.closeQuietly(inputStream, outputStream); // only closes outputStream if normal close was skipped
      * }
      * </pre>
      * <p>

--- a/src/main/java/org/apache/commons/io/IOUtils.java
+++ b/src/main/java/org/apache/commons/io/IOUtils.java
@@ -778,7 +778,11 @@ public class IOUtils {
     /**
      * Closes a {@link Closeable} unconditionally.
      * <p>
-     * Equivalent to {@link Closeable#close()}, except any exceptions will be ignored. This is typically used in finally blocks.
+     * Equivalent to {@link Closeable#close()}, except any exceptions will be ignored. This is typically used in cleanup code when reporting a close failure is not
+     * necessary or useful.
+     * <p>
+     * Do not use this method to close output streams or writers when close failures must be reported. Closing an output stream or writer may flush buffered data,
+     * and ignoring a close failure can hide that data was not fully written.
      * <p>
      * Example code:
      * </p>
@@ -793,18 +797,6 @@ public class IOUtils {
      *     // error handling
      * } finally {
      *     IOUtils.closeQuietly(closeable);
-     * }
-     * </pre>
-     * <p>
-     * Closing all streams:
-     * </p>
-     *
-     * <pre>
-     * try {
-     *     return IOUtils.copy(inputStream, outputStream);
-     * } finally {
-     *     IOUtils.closeQuietly(inputStream);
-     *     IOUtils.closeQuietly(outputStream);
      * }
      * </pre>
      * <p>
@@ -845,17 +837,6 @@ public class IOUtils {
      *     // error handling
      * } finally {
      *     <strong>IOUtils.closeQuietly(closeable); // In case normal close was skipped due to Exception</strong>
-     * }
-     * </pre>
-     * <p>
-     * Closing all streams:
-     * </p>
-     *
-     * <pre>
-     * try {
-     *     return IOUtils.copy(inputStream, outputStream);
-     * } finally {
-     *     IOUtils.closeQuietly(inputStream, outputStream);
      * }
      * </pre>
      * <p>


### PR DESCRIPTION
IOUtils.closeQuietly() ignores exceptions thrown during close, which is useful for cleanup paths but can be unsafe when closing output streams or writers after successful writes.

This PR clarifies the Javadocs to warn that output close failures may indicate buffered data was not fully written. It also removes examples that used closeQuietly() after IOUtils.copy(), since those examples could encourage ignoring output close errors.

No runtime behavior changed.

Resolves [IO-438](https://issues.apache.org/jira/browse/IO-438).

Checklist:
- [x] Read the contribution guidelines for this project.
- [x] Read the ASF Generative Tooling Guidance.
- [x] Ran `mvn -Drat.skip=true -DskipTests javadoc:javadoc`