### PR TITLE
DeferredFileOutputStream now clears and deletes its temporary storage by default.

### DIFF
--- a/src/main/java/org/apache/commons/io/IORandomAccessFile.java
+++ b/src/main/java/org/apache/commons/io/IORandomAccessFile.java
@@ -19,6 +19,7 @@ package org.apache.commons.io;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.util.Objects;
 
@@ -51,7 +52,7 @@ public final class IORandomAccessFile extends RandomAccessFile {
     /**
      * Constructs a new instance by calling {@link RandomAccessFile#RandomAccessFile(String, String)}.
      *
-     * @param name the file object.
+     * @param name the system-dependent file name.
      * @param mode the access mode, as described in {@link RandomAccessFile#RandomAccessFile(String, String)}.
      * @throws FileNotFoundException Thrown by {@link RandomAccessFile#RandomAccessFile(String, String)}.
      * @see RandomAccessFile#RandomAccessFile(String, String)
@@ -60,6 +61,26 @@ public final class IORandomAccessFile extends RandomAccessFile {
         super(name, mode);
         this.file = name != null ? new File(name) : null;
         this.mode = mode;
+    }
+
+    /**
+     * Clears the contents of this existing file by filling it with NUL ({@code 0)} bytes.
+     *
+     * @return {@code this} instance.
+     * @throws FileNotFoundException See {@link #IORandomAccessFile(File, String)}.
+     * @throws IOException           Thrown if an I/O error occurs.
+     */
+    public IORandomAccessFile clear() throws IOException {
+        final long length = length();
+        final byte[] zeroBuffer = IOUtils.byteArray();
+        long bytesWritten = 0;
+        while (bytesWritten < length) {
+            final long remaining = length - bytesWritten;
+            final int toWrite = (int) Math.min(zeroBuffer.length, remaining);
+            write(zeroBuffer, 0, toWrite);
+            bytesWritten += toWrite;
+        }
+        return this;
     }
 
     /**
@@ -81,7 +102,7 @@ public final class IORandomAccessFile extends RandomAccessFile {
     }
 
     /**
-     * Returns the pathname string of this abstract pathname. This is just the string returned by the {@link File#toString()} method.
+     * Returns the path name string of this abstract pathname. This is just the string returned by the {@link File#toString()} method.
      *
      * @return The string form of the File's abstract pathname.
      * @see File#toString()
@@ -90,5 +111,4 @@ public final class IORandomAccessFile extends RandomAccessFile {
     public String toString() {
         return Objects.toString(file);
     }
-
 }

--- a/src/main/java/org/apache/commons/io/RandomAccessFileMode.java
+++ b/src/main/java/org/apache/commons/io/RandomAccessFileMode.java
@@ -163,8 +163,8 @@ public enum RandomAccessFileMode {
      * @throws IOException Thrown by the given function.
      * @since 2.18.0
      */
-    public void accept(final Path file, final IOConsumer<RandomAccessFile> consumer) throws IOException {
-        try (RandomAccessFile raf = create(file)) {
+    public void accept(final Path file, final IOConsumer<IORandomAccessFile> consumer) throws IOException {
+        try (IORandomAccessFile raf = new IORandomAccessFile(file.toFile(), mode)) {
             consumer.accept(raf);
         }
     }
@@ -282,7 +282,7 @@ public enum RandomAccessFileMode {
     /**
      * Constructs a random access file to read from, and optionally to write to, the file specified by the {@link File} argument.
      *
-     * @param name the file object.
+     * @param name the system-dependent file name.
      * @return a random access file.
      * @throws FileNotFoundException See {@link IORandomAccessFile#IORandomAccessFile(File, String)}.
      * @since 2.18.0

--- a/src/main/java/org/apache/commons/io/file/PathUtils.java
+++ b/src/main/java/org/apache/commons/io/file/PathUtils.java
@@ -18,6 +18,7 @@
 package org.apache.commons.io.file;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -75,6 +76,7 @@ import java.util.stream.StreamSupport;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.io.IORandomAccessFile;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.RandomAccessFileMode;
 import org.apache.commons.io.RandomAccessFiles;
@@ -308,6 +310,33 @@ public final class PathUtils {
      */
     public static PathCounters cleanDirectory(final Path directory, final DeleteOption... deleteOptions) throws IOException {
         return visitFileTree(new CleaningPathVisitor(Counters.longPathCounters(), deleteOptions), directory).getPathCounters();
+    }
+
+    /**
+     * Clears the contents at an existing Path by filling it with NUL ({@code 0)} bytes.
+     *
+     * @param path The target path to an existing file.
+     * @return The given path.
+     * @throws FileNotFoundException See {@link IORandomAccessFile#IORandomAccessFile(File, String)}.
+     * @throws IOException Thrown writing to the Path.
+     * @since 2.23.0
+     */
+    public static Path clear(final Path path) throws IOException {
+        RandomAccessFileMode.READ_WRITE.accept(path, IORandomAccessFile::clear);
+        return path;
+    }
+
+    /**
+     * Clears the contents at a Path by filling it with NUL ({@code 0)} bytes.
+     *
+     * @param path The target path, may not exist, may be null.
+     * @return The given path.
+     * @throws FileNotFoundException See {@link IORandomAccessFile#IORandomAccessFile(File, String)}.
+     * @throws IOException Thrown writing to the Path.
+     * @since 2.23.0
+     */
+    public static Path clearIfExists(final Path path) throws IOException {
+        return exists(path) ? clear(path) : path;
     }
 
     /**
@@ -696,6 +725,18 @@ public final class PathUtils {
             }
         }
         return pathCounts;
+    }
+
+    /**
+     * A null-safe version of {@link Files#deleteIfExists(Path)}.
+     *
+     * @param path The path to the file to delete, may be {@code null}.
+     * @return Same as {@link Files#deleteIfExists(Path)} if {@code path} is non-null, false otherwise.
+     * @throws IOException Same as {@link Files#deleteIfExists(Path)}.
+     * @since 2.23.0
+     */
+    public static boolean deleteIfExists(final Path path) throws IOException {
+        return path != null && Files.deleteIfExists(path);
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/output/DeferredFileOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/DeferredFileOutputStream.java
@@ -30,13 +30,13 @@ import org.apache.commons.io.file.PathUtils;
 
 /**
  * An output stream which will retain data in memory until a specified threshold is reached, and only then commit it to disk. If the stream is closed before the
- * threshold is reached, the data will not be written to disk at all.
+ * threshold is reached, the data will not be written to disk.
  * <p>
- * To build an instance, use {@link Builder}.
+ * To build an instance, use the {@link Builder builder}.
  * </p>
  * <p>
- * The caller is responsible for deleting the output file ({@link #getFile()}, {@link #getPath()}) created by a DeferredFileOutputStream when the caller only
- * configured a prefix.
+ * A temporary file created <em>only</em> when a prefix is configured (via {@link Builder#setPrefix(String)}) and is deleted automatically when {@link #close()}
+ * is called.
  * </p>
  * <p>
  * The caller is responsible for deleting the output file passed to a constructor or builder through {@link Builder#setOutputFile(File)} or
@@ -82,6 +82,7 @@ public class DeferredFileOutputStream extends ThresholdingOutputStream {
         private String prefix;
         private String suffix;
         private Path directory;
+        private boolean deleteTempFileOnClose = true;
 
         /**
          * Constructs a new builder of {@link DeferredFileOutputStream}.
@@ -111,6 +112,24 @@ public class DeferredFileOutputStream extends ThresholdingOutputStream {
         @Override
         public DeferredFileOutputStream get() {
             return new DeferredFileOutputStream(this);
+        }
+
+        /**
+         * Sets whether to delete the temporary file when {@link DeferredFileOutputStream#close()} is called.
+         * <p>
+         * This only applies when a temporary file is created internally via a prefix/suffix configuration (i.e.,
+         * {@link #setPrefix(String)} is used). It has no effect when an explicit output file is provided via
+         * {@link #setOutputFile(File)} or {@link #setOutputFile(Path)}.
+         * </p>
+         *
+         * @param deleteTempFileOnClose {@code true} to delete the temporary file on close (default), {@code false} to
+         *                              keep it (the caller is then responsible for deleting it).
+         * @return {@code this} instance.
+         * @since 2.23.0
+         */
+        public Builder setDeleteTempFileOnClose(final boolean deleteTempFileOnClose) {
+            this.deleteTempFileOnClose = deleteTempFileOnClose;
+            return this;
         }
 
         /**
@@ -255,9 +274,20 @@ public class DeferredFileOutputStream extends ThresholdingOutputStream {
     private boolean closed;
 
     /**
+     * True when the output file was created internally as a temporary file by {@link #thresholdReached()}.
+     * Such a file is deleted automatically when {@link #close()} is called (subject to {@link #deleteTempFileOnClose}).
+     */
+    private boolean tempFile;
+
+    /**
+     * Controls whether a temporary file created internally is deleted when {@link #close()} is called.
+     */
+    private final boolean deleteTempFileOnClose;
+
+    /**
      * Constructs an instance of this class which will trigger an event at the specified threshold, and save data either to a file beyond that point.
      *
-     * @param builder         The construction data source.
+     * @param builder The construction data source.
      */
     private DeferredFileOutputStream(final Builder builder) {
         super(builder.threshold);
@@ -265,6 +295,7 @@ public class DeferredFileOutputStream extends ThresholdingOutputStream {
         this.prefix = builder.prefix;
         this.suffix = builder.suffix;
         this.directory = toPath(builder.directory, PathUtils::getTempDirectory);
+        this.deleteTempFileOnClose = builder.deleteTempFileOnClose;
         this.memoryOutputStream = new ByteArrayOutputStream(checkBufferSize(builder.getBufferSize()));
         this.currentOutputStream = memoryOutputStream;
     }
@@ -300,6 +331,7 @@ public class DeferredFileOutputStream extends ThresholdingOutputStream {
         this.prefix = prefix;
         this.suffix = suffix;
         this.directory = toPath(directory, PathUtils::getTempDirectory);
+        this.deleteTempFileOnClose = true;
         this.memoryOutputStream = new ByteArrayOutputStream(checkBufferSize(initialBufferSize));
         this.currentOutputStream = memoryOutputStream;
     }
@@ -351,14 +383,22 @@ public class DeferredFileOutputStream extends ThresholdingOutputStream {
     }
 
     /**
-     * Closes underlying output stream, and mark this as closed
+     * Closes underlying output stream, and marks this as closed. If the output was directed to a temporary file created
+     * internally via a prefix/suffix configuration, and {@link Builder#setDeleteTempFileOnClose(boolean)} is
+     * {@code true} (the default), that file is deleted.
      *
      * @throws IOException if an error occurs.
      */
     @Override
     public void close() throws IOException {
-        super.close();
-        closed = true;
+        try {
+            super.close();
+        } finally {
+            closed = true;
+            if (tempFile && deleteTempFileOnClose && outputPath != null) {
+                PathUtils.deleteIfExists(PathUtils.clearIfExists(outputPath));
+            }
+        }
     }
 
     /**
@@ -436,6 +476,7 @@ public class DeferredFileOutputStream extends ThresholdingOutputStream {
     protected void thresholdReached() throws IOException {
         if (prefix != null) {
             outputPath = Files.createTempFile(directory, prefix, suffix);
+            tempFile = true;
         }
         PathUtils.createParentDirectories(outputPath, null, PathUtils.EMPTY_FILE_ATTRIBUTE_ARRAY);
         final OutputStream fos = Files.newOutputStream(outputPath);

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -2988,7 +2988,7 @@ class FileUtilsTest extends AbstractTempDirTest {
             // Different result value depending on the Java version and operating system, but should not throw an exception or loop infinitely.
             FileUtils.sizeOfDirectory(file);
         } finally {
-            Files.deleteIfExists(linkPath);
+            PathUtils.deleteIfExists(linkPath);
         }
     }
 
@@ -3030,7 +3030,7 @@ class FileUtilsTest extends AbstractTempDirTest {
             assertDelete(true, nonEmptyFile);
             assertDelete(false, file);
         } finally {
-            Files.deleteIfExists(linkPath);
+            PathUtils.deleteIfExists(linkPath);
         }
     }
 

--- a/src/test/java/org/apache/commons/io/FilenameUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FilenameUtilsTest.java
@@ -50,7 +50,7 @@ class FilenameUtilsTest {
     private static final boolean WINDOWS = File.separatorChar == '\\';
 
     @TempDir
-    public Path temporaryFolder;
+    Path temporaryFolder;
 
     private Path testFile1;
     private Path testFile2;
@@ -59,42 +59,33 @@ class FilenameUtilsTest {
     private int testFile2Size;
 
     @BeforeEach
-    public void setUp() throws Exception {
+    void setUp() throws Exception {
         testFile1 = Files.createTempFile(temporaryFolder, "test", "1");
         testFile2 = Files.createTempFile(temporaryFolder, "test", "2");
-
         testFile1Size = (int) Files.size(testFile1);
         testFile2Size = (int) Files.size(testFile2);
         if (!Files.exists(testFile1.getParent())) {
-            throw new IOException("Cannot create file " + testFile1
-                    + " as the parent directory does not exist");
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
         }
-        try (BufferedOutputStream output3 =
-                new BufferedOutputStream(Files.newOutputStream(testFile1))) {
+        try (BufferedOutputStream output3 = new BufferedOutputStream(Files.newOutputStream(testFile1))) {
             TestUtils.generateTestData(output3, testFile1Size);
         }
         if (!Files.exists(testFile2.getParent())) {
-            throw new IOException("Cannot create file " + testFile2
-                    + " as the parent directory does not exist");
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
         }
-        try (BufferedOutputStream output2 =
-                new BufferedOutputStream(Files.newOutputStream(testFile2))) {
+        try (BufferedOutputStream output2 = new BufferedOutputStream(Files.newOutputStream(testFile2))) {
             TestUtils.generateTestData(output2, testFile2Size);
         }
         if (!Files.exists(testFile1.getParent())) {
-            throw new IOException("Cannot create file " + testFile1
-                    + " as the parent directory does not exist");
+            throw new IOException("Cannot create file " + testFile1 + " as the parent directory does not exist");
         }
-        try (BufferedOutputStream output1 =
-                new BufferedOutputStream(Files.newOutputStream(testFile1))) {
+        try (BufferedOutputStream output1 = new BufferedOutputStream(Files.newOutputStream(testFile1))) {
             TestUtils.generateTestData(output1, testFile1Size);
         }
         if (!Files.exists(testFile2.getParent())) {
-            throw new IOException("Cannot create file " + testFile2
-                    + " as the parent directory does not exist");
+            throw new IOException("Cannot create file " + testFile2 + " as the parent directory does not exist");
         }
-        try (BufferedOutputStream output =
-                new BufferedOutputStream(Files.newOutputStream(testFile2))) {
+        try (BufferedOutputStream output = new BufferedOutputStream(Files.newOutputStream(testFile2))) {
             TestUtils.generateTestData(output, testFile2Size);
         }
     }

--- a/src/test/java/org/apache/commons/io/IORandomAccessFileTest.java
+++ b/src/test/java/org/apache/commons/io/IORandomAccessFileTest.java
@@ -17,10 +17,13 @@
 
 package org.apache.commons.io;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 import org.apache.commons.io.build.AbstractOriginTest;
 import org.junit.jupiter.api.Test;
@@ -38,6 +41,32 @@ class IORandomAccessFileTest {
         final File file = new File(FILE_NAME_RW);
         FileUtils.touch(file);
         return file;
+    }
+
+    /**
+     * Tests {@link IORandomAccessFile#clear()} by writing known non-zero bytes to the file, calling {@code clear()},
+     * and verifying that every byte in the file is {@code 0}.
+     *
+     * @throws IOException Thrown on a test failure.
+     */
+    @Test
+    void testClear() throws IOException {
+        final File file = newFileFixture();
+        final byte[] originalData = { 1, 2, 3, 4, 5, 6, 7, 8 };
+        // Write non-zero data into the file first
+        Files.write(file.toPath(), originalData);
+        try (IORandomAccessFile raf = new IORandomAccessFile(file, "rw")) {
+            assertEquals(originalData.length, raf.length());
+            // clear() should overwrite every byte with 0 and return 'this'
+            @SuppressWarnings("resource")
+            final IORandomAccessFile echoRaf = raf.clear();
+            assertSame(raf, echoRaf);
+            // Seek back to the start and read the contents
+            raf.seek(0);
+            final byte[] result = new byte[originalData.length];
+            raf.readFully(result);
+            assertArrayEquals(new byte[originalData.length], result, "All bytes should be 0 after clear()");
+        }
     }
 
     @ParameterizedTest

--- a/src/test/java/org/apache/commons/io/RandomAccessFilesTest.java
+++ b/src/test/java/org/apache/commons/io/RandomAccessFilesTest.java
@@ -29,6 +29,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.apache.commons.io.file.PathUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
@@ -126,9 +127,9 @@ class RandomAccessFilesTest {
             }
         } finally {
             // Delete ASAP
-            Files.deleteIfExists(bigFile1);
-            Files.deleteIfExists(bigFile2);
-            Files.deleteIfExists(bigFile3);
+            PathUtils.deleteIfExists(bigFile1);
+            PathUtils.deleteIfExists(bigFile2);
+            PathUtils.deleteIfExists(bigFile3);
         }
     }
 

--- a/src/test/java/org/apache/commons/io/channels/FileChannelsTest.java
+++ b/src/test/java/org/apache/commons/io/channels/FileChannelsTest.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.file.AbstractTempDirTest;
+import org.apache.commons.io.file.PathUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -231,9 +232,9 @@ class FileChannelsTest extends AbstractTempDirTest {
             }
         } finally {
             // Delete ASAP
-            Files.deleteIfExists(bigFile1);
-            Files.deleteIfExists(bigFile2);
-            Files.deleteIfExists(bigFile3);
+            PathUtils.deleteIfExists(bigFile1);
+            PathUtils.deleteIfExists(bigFile2);
+            PathUtils.deleteIfExists(bigFile3);
         }
     }
 
@@ -294,9 +295,9 @@ class FileChannelsTest extends AbstractTempDirTest {
             }
         } finally {
             // Delete ASAP
-            Files.deleteIfExists(bigFile1);
-            Files.deleteIfExists(bigFile2);
-            Files.deleteIfExists(bigFile3);
+            PathUtils.deleteIfExists(bigFile1);
+            PathUtils.deleteIfExists(bigFile2);
+            PathUtils.deleteIfExists(bigFile3);
         }
     }
 

--- a/src/test/java/org/apache/commons/io/channels/FilterFileChannelTest.java
+++ b/src/test/java/org/apache/commons/io/channels/FilterFileChannelTest.java
@@ -38,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
+import org.apache.commons.io.file.PathUtils;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -144,7 +145,7 @@ class FilterFileChannelTest {
                 assertEquals(1024, mapped.capacity());
             }
         } finally {
-            Files.deleteIfExists(tmp);
+            PathUtils.deleteIfExists(tmp);
         }
     }
 

--- a/src/test/java/org/apache/commons/io/file/DeletingPathVisitorTest.java
+++ b/src/test/java/org/apache/commons/io/file/DeletingPathVisitorTest.java
@@ -54,7 +54,7 @@ class DeletingPathVisitorTest extends AbstractTempDirTest {
     void testDeleteEmptyDirectory(final DeletingPathVisitor visitor) throws IOException {
         applyDeleteEmptyDirectory(visitor);
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -65,7 +65,7 @@ class DeletingPathVisitorTest extends AbstractTempDirTest {
     void testDeleteEmptyDirectoryNullCtorArg(final PathCounters pathCounters) throws IOException {
         applyDeleteEmptyDirectory(new DeletingPathVisitor(pathCounters, (String[]) null));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -77,7 +77,7 @@ class DeletingPathVisitorTest extends AbstractTempDirTest {
         PathUtils.copyDirectory(Paths.get("src/test/resources/org/apache/commons/io/dirs-1-file-size-0"), tempDirPath);
         assertCounts(1, 1, 0, PathUtils.visitFileTree(visitor, tempDirPath));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -89,7 +89,7 @@ class DeletingPathVisitorTest extends AbstractTempDirTest {
         PathUtils.copyDirectory(Paths.get("src/test/resources/org/apache/commons/io/dirs-1-file-size-1"), tempDirPath);
         assertCounts(1, 1, 1, PathUtils.visitFileTree(visitor, tempDirPath));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -116,7 +116,7 @@ class DeletingPathVisitorTest extends AbstractTempDirTest {
         PathUtils.copyDirectory(Paths.get("src/test/resources/org/apache/commons/io/dirs-2-file-size-2"), tempDirPath);
         assertCounts(3, 2, 2, PathUtils.visitFileTree(visitor, tempDirPath));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/file/FilesUncheckTest.java
+++ b/src/test/java/org/apache/commons/io/file/FilesUncheckTest.java
@@ -107,9 +107,9 @@ class FilesUncheckTest {
     @BeforeEach
     @AfterEach
     public void deleteFixtures() throws IOException {
-        Files.deleteIfExists(NEW_FILE_PATH);
-        Files.deleteIfExists(NEW_DIR_PATH);
-        Files.deleteIfExists(NEW_FILE_PATH_LINK);
+        PathUtils.deleteIfExists(NEW_FILE_PATH);
+        PathUtils.deleteIfExists(NEW_DIR_PATH);
+        PathUtils.deleteIfExists(NEW_FILE_PATH_LINK);
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/file/PathUtilsDeleteDirectoryTest.java
+++ b/src/test/java/org/apache/commons/io/file/PathUtilsDeleteDirectoryTest.java
@@ -43,7 +43,7 @@ class PathUtilsDeleteDirectoryTest extends AbstractTempDirTest {
         assertThrows(expectedType, () -> PathUtils.deleteDirectory(absent, StandardDeleteOption.OVERRIDE_READ_ONLY));
         assertThrows(expectedType, () -> PathUtils.deleteDirectory(absent, PathUtils.EMPTY_DELETE_OPTION_ARRAY));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -54,7 +54,7 @@ class PathUtilsDeleteDirectoryTest extends AbstractTempDirTest {
         PathUtils.copyDirectory(Paths.get("src/test/resources/org/apache/commons/io/dirs-1-file-size-0"), tempDirPath);
         assertCounts(1, 1, 0, PathUtils.deleteDirectory(tempDirPath));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -65,7 +65,7 @@ class PathUtilsDeleteDirectoryTest extends AbstractTempDirTest {
         PathUtils.copyDirectory(Paths.get("src/test/resources/org/apache/commons/io/dirs-1-file-size-0"), tempDirPath);
         assertCounts(1, 1, 0, PathUtils.deleteDirectory(tempDirPath, options));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     @Test
@@ -86,7 +86,7 @@ class PathUtilsDeleteDirectoryTest extends AbstractTempDirTest {
         PathUtils.copyDirectory(Paths.get("src/test/resources/org/apache/commons/io/dirs-1-file-size-1"), tempDirPath);
         assertCounts(1, 1, 1, PathUtils.deleteDirectory(tempDirPath));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -97,7 +97,7 @@ class PathUtilsDeleteDirectoryTest extends AbstractTempDirTest {
         PathUtils.copyDirectory(Paths.get("src/test/resources/org/apache/commons/io/dirs-2-file-size-2"), tempDirPath);
         assertCounts(3, 2, 2, PathUtils.deleteDirectory(tempDirPath));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -107,6 +107,6 @@ class PathUtilsDeleteDirectoryTest extends AbstractTempDirTest {
     void testDeleteEmptyDirectory() throws IOException {
         assertCounts(1, 0, 0, PathUtils.deleteDirectory(tempDirPath));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 }

--- a/src/test/java/org/apache/commons/io/file/PathUtilsDeleteFileTest.java
+++ b/src/test/java/org/apache/commons/io/file/PathUtilsDeleteFileTest.java
@@ -60,7 +60,7 @@ class PathUtilsDeleteFileTest extends AbstractTempDirTest {
         PathUtils.copyFileToDirectory(Paths.get("src/test/resources/org/apache/commons/io/dirs-1-file-size-0/" + fileName), tempDirPath);
         assertCounts(0, 1, 0, PathUtils.deleteFile(tempDirPath.resolve(fileName)));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -72,7 +72,7 @@ class PathUtilsDeleteFileTest extends AbstractTempDirTest {
         PathUtils.copyFileToDirectory(Paths.get("src/test/resources/org/apache/commons/io/dirs-1-file-size-1/" + fileName), tempDirPath);
         assertCounts(0, 1, 1, PathUtils.deleteFile(tempDirPath.resolve(fileName)));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -82,7 +82,7 @@ class PathUtilsDeleteFileTest extends AbstractTempDirTest {
     void testDeleteFileDoesNotExist() throws IOException {
         testDeleteFileEmpty(PathUtils.deleteFile(tempDirPath.resolve("file-does-not-exist.bin")));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     private void testDeleteFileEmpty(final PathCounters pathCounts) {
@@ -96,7 +96,7 @@ class PathUtilsDeleteFileTest extends AbstractTempDirTest {
     void testDeleteFileEmptyDirectory() throws IOException {
         assertThrows(NoSuchFileException.class, () -> testDeleteFileEmpty(PathUtils.deleteFile(tempDirPath)));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -115,7 +115,7 @@ class PathUtilsDeleteFileTest extends AbstractTempDirTest {
         }
         assertCounts(0, 1, 1, PathUtils.deleteFile(resolved, StandardDeleteOption.OVERRIDE_READ_ONLY));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -135,6 +135,6 @@ class PathUtilsDeleteFileTest extends AbstractTempDirTest {
         PathUtils.setReadOnly(resolved, false);
         PathUtils.deleteFile(resolved);
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 }

--- a/src/test/java/org/apache/commons/io/file/PathUtilsDeleteTest.java
+++ b/src/test/java/org/apache/commons/io/file/PathUtilsDeleteTest.java
@@ -20,7 +20,6 @@ package org.apache.commons.io.file;
 import static org.apache.commons.io.file.CounterAssertions.assertCounts;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import org.apache.commons.io.FileUtils;
@@ -40,7 +39,7 @@ class PathUtilsDeleteTest extends AbstractTempDirTest {
             tempDirPath.toFile());
         assertCounts(0, 1, 0, PathUtils.delete(tempDirPath.resolve(fileName)));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     private void testDeleteDirectory1FileSize0(final DeleteOption... options) throws IOException {
@@ -50,7 +49,7 @@ class PathUtilsDeleteTest extends AbstractTempDirTest {
             tempDirPath.toFile());
         assertCounts(0, 1, 0, PathUtils.delete(tempDirPath.resolve(fileName), options));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -87,7 +86,7 @@ class PathUtilsDeleteTest extends AbstractTempDirTest {
             tempDirPath.toFile());
         assertCounts(0, 1, 1, PathUtils.delete(tempDirPath.resolve(fileName)));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     private void testDeleteDirectory1FileSize1(final DeleteOption... options) throws IOException {
@@ -98,7 +97,7 @@ class PathUtilsDeleteTest extends AbstractTempDirTest {
             tempDirPath.toFile());
         assertCounts(0, 1, 1, PathUtils.delete(tempDirPath.resolve(fileName), options));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -134,7 +133,7 @@ class PathUtilsDeleteTest extends AbstractTempDirTest {
     void testDeleteEmptyDirectory() throws IOException {
         testDeleteEmptyDirectory(PathUtils.delete(tempDirPath));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     /**
@@ -143,7 +142,7 @@ class PathUtilsDeleteTest extends AbstractTempDirTest {
     private void testDeleteEmptyDirectory(final DeleteOption... options) throws IOException {
         testDeleteEmptyDirectory(PathUtils.delete(tempDirPath, options));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 
     private void testDeleteEmptyDirectory(final PathCounters pathCounts) {
@@ -183,6 +182,6 @@ class PathUtilsDeleteTest extends AbstractTempDirTest {
     void testDeleteFileDoesNotExist() throws IOException {
         assertCounts(0, 0, 0, PathUtils.deleteFile(tempDirPath.resolve("file-does-not-exist.bin")));
         // This will throw if not empty.
-        Files.deleteIfExists(tempDirPath);
+        PathUtils.deleteIfExists(tempDirPath);
     }
 }

--- a/src/test/java/org/apache/commons/io/file/PathUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/file/PathUtilsTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeFalse;
@@ -78,6 +79,70 @@ class PathUtilsTest extends AbstractTempDirTest {
 
     private void setLastModifiedMillis(final Path file, final long millis) throws IOException {
         Files.setLastModifiedTime(file, FileTime.fromMillis(millis));
+    }
+
+    /**
+     * Tests {@link PathUtils#clear(Path)} by writing known non-zero bytes to a temporary file, calling {@code clear()}, and verifying that every byte in the
+     * file is {@code 0} and that the file length is unchanged. Also verifies the returned {@link Path} is the same instance.
+     *
+     * @throws IOException Thrown on a test failure.
+     */
+    @Test
+    void testClear() throws IOException {
+        final Path file = tempDirPath.resolve("testClear.bin");
+        final byte[] originalData = { 1, 2, 3, 4, 5, 6, 7, 8 };
+        Files.write(file, originalData);
+        assertEquals(originalData.length, Files.size(file)); // Sanity check
+        // clear() should zero all bytes and return the same Path
+        final Path echoRaf = PathUtils.clear(file);
+        assertSame(file, echoRaf);
+        final byte[] result = Files.readAllBytes(file);
+        assertEquals(originalData.length, result.length, "File length must be unchanged after clear()");
+        assertArrayEquals(new byte[originalData.length], result, "All bytes should be 0 after clear()");
+    }
+
+    /**
+     * Tests {@link PathUtils#clearIfExists(Path)} when the path exists: verifies that all bytes are zeroed, the file length is unchanged, and the returned
+     * {@link Path} is the same instance.
+     *
+     * @throws IOException Thrown on a test failure.
+     */
+    @Test
+    void testClearIfExistsExistingFile() throws IOException {
+        final Path file = tempDirPath.resolve("testClearIfExists.bin");
+        final byte[] originalData = { 1, 2, 3, 4, 5, 6, 7, 8 };
+        Files.write(file, originalData);
+        assertEquals(originalData.length, Files.size(file)); // Sanity check
+        // clearIfExists() should zero all bytes and return the same Path
+        final Path returned = PathUtils.clearIfExists(file);
+        assertSame(file, returned, "clearIfExists() should return the given path when it exists");
+        final byte[] result = Files.readAllBytes(file);
+        assertEquals(originalData.length, result.length, "File length must be unchanged after clearIfExists()");
+        assertArrayEquals(new byte[originalData.length], result, "All bytes should be 0 after clearIfExists()");
+    }
+
+    /**
+     * Tests {@link PathUtils#clearIfExists(Path)} when the path does not exist: verifies the method is a no-op and returns the given (non-existing) path.
+     *
+     * @throws IOException Thrown on a test failure.
+     */
+    @Test
+    void testClearIfExistsNonExistentFile() throws IOException {
+        final Path nonExistent = tempDirPath.resolve("does-not-exist.bin");
+        assertFalse(Files.exists(nonExistent)); // Sanity check
+        final Path returned = PathUtils.clearIfExists(nonExistent);
+        assertSame(nonExistent, returned, "clearIfExists() should return the given path when it does not exist");
+        assertFalse(Files.exists(nonExistent), "clearIfExists() must not create the file when it does not exist");
+    }
+
+    /**
+     * Tests {@link PathUtils#clearIfExists(Path)} with a {@code null} path: verifies the method returns {@code null} without throwing an exception.
+     *
+     * @throws IOException Thrown on a test failure.
+     */
+    @Test
+    void testClearIfExistsNull() throws IOException {
+        assertNull(PathUtils.clearIfExists(null));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/io/input/UnsynchronizedBufferedInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/UnsynchronizedBufferedInputStreamTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.file.PathUtils;
 import org.apache.commons.io.input.UnsynchronizedBufferedInputStream.Builder;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
@@ -82,7 +83,7 @@ class UnsynchronizedBufferedInputStreamTest {
     @AfterEach
     protected void tearDown() throws IOException {
         IOUtils.closeQuietly(is);
-        Files.deleteIfExists(fileName);
+        PathUtils.deleteIfExists(fileName);
     }
 
     /**

--- a/src/test/java/org/apache/commons/io/input/UnsynchronizedFilterInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/UnsynchronizedFilterInputStreamTest.java
@@ -28,6 +28,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.io.file.PathUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -70,7 +71,7 @@ class UnsynchronizedFilterInputStreamTest {
     @AfterEach
     protected void tearDown() throws IOException {
         IOUtils.closeQuietly(is);
-        Files.deleteIfExists(fileName);
+        PathUtils.deleteIfExists(fileName);
     }
 
     /**

--- a/src/test/java/org/apache/commons/io/output/DeferredFileOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/DeferredFileOutputStreamTest.java
@@ -29,11 +29,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.stream.IntStream;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.file.AbstractTempDirTest;
+import org.apache.commons.io.file.PathUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -63,6 +65,12 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
      * The test data as a byte array, derived from the string.
      */
     private final byte[] testBytes = testString.getBytes();
+
+    void assertContentsEquals(DeferredFileOutputStream out) throws IOException {
+        try (InputStream is = out.toInputStream()) {
+            assertArrayEquals(testBytes, IOUtils.toByteArray(is));
+        }
+    }
 
     /**
      * Tests the case where the amount of data exceeds the threshold, and is therefore written to disk. The actual data
@@ -103,19 +111,19 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
         final File testFile = Files.createTempFile(tempDirPath, "testAboveThreshold", "dat").toFile();
         final int threshold = testBytes.length - 5;
         try (DeferredFileOutputStream out = DeferredFileOutputStream.builder()
+                // @formatter:off
                 .setThreshold(threshold)
                 .setBufferSize(initialBufferSize)
                 .setOutputFile(testFile)
                 .get()) {
+            // @formatter:on
             assertThresholdingInitialState(out, threshold, 0);
             assertDeferredInitialState(out);
             out.write(testBytes, 0, testBytes.length);
             out.close();
             assertFalse(out.isInMemory());
             assertEquals(testFile.length(), out.getByteCount());
-            try (InputStream is = out.toInputStream()) {
-                assertArrayEquals(testBytes, IOUtils.toByteArray(is));
-            }
+            assertContentsEquals(out);
             verifyResultFile(testFile);
         }
     }
@@ -180,36 +188,58 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
     @ParameterizedTest(name = "initialBufferSize = {0}")
     @MethodSource("data")
     void testBelowThresholdGetInputStream(final int initialBufferSize) throws IOException {
-        // @formatter:off
         final int threshold = testBytes.length + 42;
         try (DeferredFileOutputStream out = DeferredFileOutputStream.builder()
+                // @formatter:off
                 .setThreshold(threshold)
                 .setBufferSize(initialBufferSize)
                 .get()) {
-        // @formatter:on
+                // @formatter:on
             assertThresholdingInitialState(out, threshold, 0);
             assertDeferredInitialState(out);
             out.write(testBytes, 0, testBytes.length);
             out.close();
             assertTrue(out.isInMemory());
             assertEquals(testBytes.length, out.getByteCount());
-            try (InputStream is = out.toInputStream()) {
-                assertArrayEquals(testBytes, IOUtils.toByteArray(is));
-            }
+            assertContentsEquals(out);
+        }
+    }
+
+    /**
+     * Tests that writing beyond the threshold throws a {@link NoSuchFileException} when the directory supplied to
+     * {@link DeferredFileOutputStream.Builder#setDirectory(Path)} does not exist.
+     *
+     * @throws IOException Thrown on a test failure.
+     */
+    @Test
+    void testSetDirectoryNonExistent() throws IOException {
+        final Path nonExistentDir = tempDirPath.resolve("does-not-exist");
+        final int threshold = testBytes.length - 5;
+        try (DeferredFileOutputStream out = DeferredFileOutputStream.builder()
+                // @formatter:off
+                .setThreshold(threshold)
+                .setPrefix("commons-io-test")
+                .setSuffix(".out")
+                .setDirectory(nonExistentDir)
+                .get()) {
+                // @formatter:on
+            assertThrows(NoSuchFileException.class, () -> out.write(testBytes, 0, testBytes.length));
         }
     }
 
     /**
      * Tests specifying a temporary file and the threshold is reached.
+     * Verifies the temporary file is deleted automatically when the stream is closed.
      */
     @ParameterizedTest(name = "initialBufferSize = {0}")
     @MethodSource("data")
     void testTempFileAboveThreshold(final int initialBufferSize) throws IOException {
         final String prefix = "commons-io-test";
         final String suffix = ".out";
-        // @formatter:off
         final int threshold = testBytes.length - 5;
+        Path capturedPath = null;
         try (DeferredFileOutputStream out = DeferredFileOutputStream.builder()
+                // @formatter:off
                 .setThreshold(threshold)
                 .setBufferSize(initialBufferSize)
                 .setPrefix(prefix)
@@ -217,13 +247,12 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
                 .setDirectory(tempDirFile)
                 .setDirectory(tempDirPath.toFile())
                 .get()) {
-        // @formatter:on
+                // @formatter:on
             assertThresholdingInitialState(out, threshold, 0);
             assertDeferredInitialState(out);
             assertNull(out.getFile(), "Check File is null-A");
             assertNull(out.getPath(), "Check Path is null-A");
             out.write(testBytes, 0, testBytes.length);
-            out.close();
             assertFalse(out.isInMemory());
             assertEquals(testBytes.length, out.getByteCount());
             assertNull(out.getData());
@@ -233,11 +262,14 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
             assertTrue(out.getFile().getName().endsWith(suffix), "Check suffix");
             assertEquals(tempDirPath, out.getPath().getParent(), "Check dir");
             verifyResultFile(out.getFile());
-        }
+            capturedPath = out.getPath();
+        } // close() called here; temp file should be deleted
+        assertFalse(Files.exists(capturedPath), "Temp file should be deleted after close()");
     }
 
     /**
-     * Tests specifying a temporary file and the threshold is reached.
+     * Tests specifying a temporary file with prefix only and the threshold is reached.
+     * Verifies the temporary file is deleted automatically when the stream is closed.
      *
      * @throws IOException Thrown on a test failure.
      */
@@ -247,35 +279,33 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
         final String prefix = "commons-io-test";
         final String suffix = null;
         final int threshold = testBytes.length - 5;
+        Path capturedPath = null;
         try (DeferredFileOutputStream out = DeferredFileOutputStream.builder()
-            // @formatter:off
+                // @formatter:off
                 .setThreshold(threshold)
                 .setBufferSize(initialBufferSize)
                 .setPrefix(prefix)
                 .setSuffix(suffix)
+                .setDirectory((File) null)
                 .setDirectory((Path) null)
                 .get()) {
-            // @formatter:on
-            try {
-                assertThresholdingInitialState(out, threshold, 0);
-                assertDeferredInitialState(out);
-                assertNull(out.getFile(), "Check File is null-A");
-                assertNull(out.getPath(), "Check Path is null-A");
-                out.write(testBytes, 0, testBytes.length);
-                out.close();
-                assertFalse(out.isInMemory());
-                assertNull(out.getData());
-                assertEquals(testBytes.length, out.getByteCount());
-                assertNotNull(out.getFile(), "Check file not null");
-                assertTrue(out.getFile().exists(), "Check file exists");
-                assertTrue(out.getFile().getName().startsWith(prefix), "Check prefix");
-                assertTrue(out.getFile().getName().endsWith(".tmp"), "Check suffix"); // ".tmp" is default
-                verifyResultFile(out.getFile());
-            } finally {
-                // Delete the temporary file.
-                out.getFile().delete();
-            }
-        }
+                // @formatter:on
+            assertThresholdingInitialState(out, threshold, 0);
+            assertDeferredInitialState(out);
+            assertNull(out.getFile(), "Check File is null-A");
+            assertNull(out.getPath(), "Check Path is null-A");
+            out.write(testBytes, 0, testBytes.length);
+            assertFalse(out.isInMemory());
+            assertNull(out.getData());
+            assertEquals(testBytes.length, out.getByteCount());
+            assertNotNull(out.getFile(), "Check file not null");
+            assertTrue(out.getFile().exists(), "Check file exists");
+            assertTrue(out.getFile().getName().startsWith(prefix), "Check prefix");
+            assertTrue(out.getFile().getName().endsWith(".tmp"), "Check suffix"); // ".tmp" is default
+            verifyResultFile(out.getFile());
+            capturedPath = out.getPath();
+        } // close() called here; temp file should be deleted automatically
+        assertFalse(Files.exists(capturedPath), "Temp file should be deleted after close()");
     }
 
     /**
@@ -303,6 +333,68 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
     }
 
     /**
+     * Tests that the temporary file created by {@link Files#createTempFile} in
+     * {@link DeferredFileOutputStream#thresholdReached()} IS automatically deleted when the
+     * {@link DeferredFileOutputStream} is closed.
+     *
+     * @throws IOException Thrown on a test failure.
+     */
+    @Test
+    void testTempFileDeletedAfterClose() throws IOException {
+        final String prefix = "commons-io-test";
+        final String suffix = ".out";
+        final int threshold = testBytes.length - 5;
+        Path capturedPath = null;
+        try (DeferredFileOutputStream out = DeferredFileOutputStream.builder()
+                // @formatter:off
+                .setThreshold(threshold)
+                .setPrefix(prefix)
+                .setSuffix(suffix)
+                .setDirectory(tempDirPath)
+                .get()) {
+                // @formatter:on
+            assertNull(out.getPath(), "Temp file should not exist before threshold is reached");
+            // Write enough data to exceed the threshold, triggering thresholdReached() and Files.createTempFile()
+            out.write(testBytes, 0, testBytes.length);
+            assertFalse(out.isInMemory(), "Data should have been written to disk after threshold exceeded");
+            // Capture the temp file path before closing
+            capturedPath = out.getPath();
+            assertNotNull(capturedPath, "Temp file path should be set after threshold is reached");
+            assertTrue(Files.exists(capturedPath), "Temp file should exist after threshold is reached");
+        } // close() called here; temp file should be deleted automatically
+        assertFalse(Files.exists(capturedPath), "Temp file created by Files.createTempFile() in thresholdReached() must be deleted on close()");
+    }
+
+    /**
+     * Tests that the temporary file IS deleted on close when {@link DeferredFileOutputStream.Builder#setDeleteTempFileOnClose(boolean)} is explicitly set to
+     * {@code true}.
+     *
+     * @throws IOException Thrown on a test failure.
+     */
+    @Test
+    void testTempFileDeletedAfterCloseWhenFlagTrue() throws IOException {
+        final String prefix = "commons-io-test";
+        final String suffix = ".out";
+        final int threshold = testBytes.length - 5;
+        Path capturedPath = null;
+        try (DeferredFileOutputStream out = DeferredFileOutputStream.builder()
+                // @formatter:off
+                .setThreshold(threshold)
+                .setPrefix(prefix)
+                .setSuffix(suffix)
+                .setDirectory(tempDirPath)
+                .setDeleteTempFileOnClose(true)
+                .get()) {
+                // @formatter:on
+            out.write(testBytes, 0, testBytes.length);
+            assertFalse(out.isInMemory(), "Data should have been written to disk after threshold exceeded");
+            capturedPath = out.getPath();
+            assertTrue(Files.exists(capturedPath), "Temp file should exist before close()");
+        } // close() called here; temp file should be deleted because deleteTempFileOnClose=true
+        assertFalse(Files.exists(capturedPath), "Temp file must be deleted on close() when setDeleteTempFileOnClose(true)");
+    }
+
+    /**
      * Tests specifying a temporary file and the threshold is reached.
      *
      * @throws IOException Thrown on a test failure.
@@ -312,6 +404,41 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
         final String prefix = null;
         final String suffix = ".out";
         assertThrows(NullPointerException.class, () -> new DeferredFileOutputStream(testBytes.length - 5, prefix, suffix, tempDirFile));
+    }
+
+    /**
+     * Tests that the temporary file is NOT deleted on close when {@link DeferredFileOutputStream.Builder#setDeleteTempFileOnClose(boolean)} is set to
+     * {@code false}. The caller is then responsible for deleting it.
+     *
+     * @throws IOException Thrown on a test failure.
+     */
+    @Test
+    void testTempFileNotDeletedAfterCloseWhenFlagFalse() throws IOException {
+        final String prefix = "commons-io-test";
+        final String suffix = ".out";
+        final int threshold = testBytes.length - 5;
+        Path capturedPath = null;
+        try {
+            try (DeferredFileOutputStream out = DeferredFileOutputStream.builder()
+                    // @formatter:off
+                    .setThreshold(threshold)
+                    .setPrefix(prefix)
+                    .setSuffix(suffix)
+                    .setDirectory(tempDirPath)
+                    .setDeleteTempFileOnClose(false)
+                    .get()) {
+                    // @formatter:on
+                out.write(testBytes, 0, testBytes.length);
+                assertFalse(out.isInMemory(), "Data should have been written to disk after threshold exceeded");
+                capturedPath = out.getPath();
+                assertNotNull(capturedPath, "Temp file path should be set after threshold is reached");
+                assertTrue(Files.exists(capturedPath), "Temp file should exist before close()");
+            } // close() called here; temp file must NOT be deleted because deleteTempFileOnClose=false
+            assertTrue(Files.exists(capturedPath), "Temp file must NOT be deleted on close() when setDeleteTempFileOnClose(false)");
+        } finally {
+            // Caller is responsible for cleanup when deleteTempFileOnClose=false
+            PathUtils.deleteIfExists(capturedPath);
+        }
     }
 
     /**
@@ -453,10 +580,8 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
     private void verifyResultFile(final File testFile) throws IOException {
         try (InputStream fis = Files.newInputStream(testFile.toPath())) {
             assertEquals(testBytes.length, fis.available());
-
             final byte[] resultBytes = new byte[testBytes.length];
             assertEquals(testBytes.length, fis.read(resultBytes));
-
             assertArrayEquals(resultBytes, testBytes);
             assertEquals(-1, fis.read(resultBytes));
         }


### PR DESCRIPTION
`DeferredFileOutputStream` now clears and deletes its temporary storage by default.

To get the old behavior back, call
`DeferredFileOutputStream.Builder.setDeleteTempFileOnClose(false)`

- Add `DeferredFileOutputStream.Builder.setDeleteTempFileOnClose(boolean)`
- Add `PathUtils.clear[IfExists](Path)`
- Add `PathUtils.deleteIfExists(Path)`
- Update generic type of `RandomAccessFileMode.accept(Path, IOConsumer)` from `IOConsumer<RandomAccessFile>` to `IOConsumer<IORandomAccessFile>`
- Harden tests for NPEs on failures, happy path unchanged.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create the initial cut of the DeleteTempFileOnClose feature and the initial cut of all new unit tests.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
