### PR TITLE
fix: confusing semantics for ValidatingObjectInputStream

### DIFF
--- a/src/main/java/org/apache/commons/io/serialization/ValidatingObjectInputStream.java
+++ b/src/main/java/org/apache/commons/io/serialization/ValidatingObjectInputStream.java
@@ -510,7 +510,11 @@ public class ValidatingObjectInputStream extends ObjectInputStream {
     @Override
     protected Class<?> resolveClass(final ObjectStreamClass osc) throws IOException, ClassNotFoundException {
         checkClassName(osc.getName());
-        return super.resolveClass(osc);
+        final Class<?> result = super.resolveClass(osc);
+        for (final Class<?> interfaceName : result.getInterfaces()) {
+            checkClassName(interfaceName.getName());
+        }
+        return result;
     }
 
     /**

--- a/src/test/java/org/apache/commons/io/serialization/ValidatingObjectInputStreamInterfaceTest.java
+++ b/src/test/java/org/apache/commons/io/serialization/ValidatingObjectInputStreamInterfaceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.commons.io.serialization;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.io.IOException;
+import java.io.InvalidClassException;
+import java.io.Serializable;
+
+import org.apache.commons.lang3.SerializationUtils;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link ValidatingObjectInputStream}.
+ */
+class ValidatingObjectInputStreamInterfaceTest {
+
+    public interface IFoo extends Serializable {
+
+        void foo();
+    }
+
+    public static class MockObject implements IFoo {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void foo() {
+            // empty
+        }
+    }
+    
+    abstract static class AbtractFoo implements IFoo {
+
+        private static final long serialVersionUID = 1L;
+        
+    }
+    
+    static class FooImpl extends AbtractFoo {
+
+        private static final long serialVersionUID = 1L;
+
+        @Override
+        public void foo() {
+            // empty
+        }
+        
+    }
+
+    @Test
+    void testAcceptAll() throws IOException, ClassNotFoundException {
+        final MockObject object = new MockObject();
+        final byte[] serialized = SerializationUtils.serialize(object);
+        final Class<IFoo> ifaceClass = IFoo.class;
+        // @formatter:off
+        try (ValidatingObjectInputStream vois = ValidatingObjectInputStream.builder()
+                .setByteArray(serialized)
+                .accept("*")
+                .get()) {
+            // @formatter:on
+            assertInstanceOf(ifaceClass, vois.readObject());
+        }
+    }
+
+    @Test
+    void testAcceptAbstractClass() throws IOException, ClassNotFoundException {
+        final FooImpl object = new FooImpl();
+        final byte[] serialized = SerializationUtils.serialize(object);
+        final Class<IFoo> ifaceClass = IFoo.class;
+        // @formatter:off
+        try (ValidatingObjectInputStream vois = ValidatingObjectInputStream.builder()
+                .setByteArray(serialized)
+                .accept(IFoo.class)
+                .accept(AbtractFoo.class)
+                .accept(FooImpl.class)
+                .get()) {
+            // @formatter:on
+            assertInstanceOf(ifaceClass, vois.readObject());
+        }
+    }
+
+    @Test
+    void testAcceptInterface() throws IOException, ClassNotFoundException {
+        final MockObject object = new MockObject();
+        final byte[] serialized = SerializationUtils.serialize(object);
+        final Class<IFoo> ifaceClass = IFoo.class;
+        // @formatter:off
+        try (ValidatingObjectInputStream vois = ValidatingObjectInputStream.builder()
+                .setByteArray(serialized)
+                .accept(ifaceClass) // not a feature
+                .get()) {
+            // @formatter:on
+            // not a feature
+            // assertInstanceOf(ifaceClass, vois.readObject());
+            assertThrows(InvalidClassException.class, vois::readObject);
+        }
+    }
+
+    @Test
+    void testRejectInterface() throws IOException, ClassNotFoundException {
+        final MockObject object = new MockObject();
+        final byte[] serialized = SerializationUtils.serialize(object);
+        final Class<IFoo> ifaceClass = IFoo.class;
+        // @formatter:off
+        try (ValidatingObjectInputStream vois = ValidatingObjectInputStream.builder()
+                .setByteArray(serialized)
+                .accept("*")
+                .reject(ifaceClass)
+                .get()) {
+            // @formatter:on
+            assertThrows(InvalidClassException.class, vois::readObject);
+        }
+    }
+}


### PR DESCRIPTION
Before Commons IO 2.21.0:
* Rejecting an interface had no effect
* Rejecting a class would reject objects of all subclasses as well
* Accepting an interface had no effect
* Accepting a class would accept objects only if all superclasses were accepted as well

After Commons IO 2.21.0:
* Rejecting an interface had no effect on regular objects, but would reject proxy classes implementing that interface
* Rejecting a class would reject objects of all subclasses as well
* Accepting an interface had no effect on regular objects, but would accept proxy classes implementing that interface
* Accepting a class would accept objects only if all superclasses were accepted as well

That seems rather inconsistent.

The logic change in this PR makes things slightly more consistent, but is a backwards-incompatible change (since it means applications using an allowist but not including the interfaces in it would stop accepting previously-accepted objects).

It seems generally odd that allowlisting a class will not actually accept it without additionally accepting its superclasses (and implemented interfaces).

Perhaps ValidatingObjectInputStream should either not take into account interfaces/superclasses at all, or do so in a more sophisticated fashion.

Before making decisions we should also investigate how JVM11's ObjectInputFilterConfig behaves. That may inform what would make sense for us, and it would be good to document the differences.

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [ ] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
