### PR TITLE
DeferredFileOutputStream better NPE message and new file permission tests

### DIFF
--- a/src/main/java/org/apache/commons/io/output/DeferredFileOutputStream.java
+++ b/src/main/java/org/apache/commons/io/output/DeferredFileOutputStream.java
@@ -479,14 +479,14 @@ public class DeferredFileOutputStream extends ThresholdingOutputStream {
             tempFile = true;
         }
         PathUtils.createParentDirectories(outputPath, null, PathUtils.EMPTY_FILE_ATTRIBUTE_ARRAY);
-        final OutputStream fos = Files.newOutputStream(outputPath);
+        final OutputStream os = Files.newOutputStream(Objects.requireNonNull(outputPath, "Either output file or prefix must be specified."));
         try {
-            memoryOutputStream.writeTo(fos);
+            memoryOutputStream.writeTo(os);
         } catch (final IOException e) {
-            fos.close();
+            os.close();
             throw e;
         }
-        currentOutputStream = fos;
+        currentOutputStream = os;
         memoryOutputStream = null;
     }
 

--- a/src/test/java/org/apache/commons/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsTest.java
@@ -83,6 +83,7 @@ import java.util.zip.Checksum;
 
 import org.apache.commons.io.file.AbstractTempDirTest;
 import org.apache.commons.io.file.Counters.PathCounters;
+import org.apache.commons.io.file.NioFileSystem;
 import org.apache.commons.io.file.PathUtils;
 import org.apache.commons.io.file.TempDirectory;
 import org.apache.commons.io.file.TempFile;
@@ -96,7 +97,6 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIf;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
@@ -2843,12 +2843,11 @@ class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
-    @EnabledIf("isPosixFilePermissionsSupported")
     void testReadFileToByteArray_IOExceptionOnPosixFileSystem() throws Exception {
+        assumeTrue(NioFileSystem.isPosix(tempDirPath));
         final File file = TestUtils.newFile(tempDirFile, "cant-read.txt");
         TestUtils.createFile(file, 100);
         Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("---------"));
-
         assertThrows(IOException.class, () -> FileUtils.readFileToByteArray(file));
     }
 
@@ -2861,12 +2860,11 @@ class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
-    @EnabledIf("isPosixFilePermissionsSupported")
     void testReadFileToString_IOExceptionOnPosixFileSystem() throws Exception {
+        assumeTrue(NioFileSystem.isPosix(tempDirPath));
         final File file = TestUtils.newFile(tempDirFile, "cant-read.txt");
         TestUtils.createFile(file, 100);
         Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("---------"));
-
         assertThrows(IOException.class, () -> FileUtils.readFileToString(file));
     }
 
@@ -2890,8 +2888,8 @@ class FileUtilsTest extends AbstractTempDirTest {
     }
 
     @Test
-    @EnabledIf("isPosixFilePermissionsSupported")
     void testReadLines_IOExceptionOnPosixFileSystem() throws Exception {
+        assumeTrue(NioFileSystem.isPosix(tempDirPath));
         final File file = TestUtils.newFile(tempDirFile, "cant-read.txt");
         TestUtils.createFile(file, 100);
         Files.setPosixFilePermissions(file.toPath(), PosixFilePermissions.fromString("---------"));

--- a/src/test/java/org/apache/commons/io/file/AbstractTempDirTest.java
+++ b/src/test/java/org/apache/commons/io/file/AbstractTempDirTest.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -97,8 +96,4 @@ public abstract class AbstractTempDirTest {
         tempDirFile = tempDirPath.toFile();
     }
 
-    @SuppressWarnings("resource") // no FileSystem allocation
-    protected final boolean isPosixFilePermissionsSupported() {
-        return FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
-    }
 }

--- a/src/test/java/org/apache/commons/io/file/NioFileSystem.java
+++ b/src/test/java/org/apache/commons/io/file/NioFileSystem.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.commons.io.file;
+
+import java.nio.file.FileSystem;
+import java.nio.file.Path;
+import java.util.Set;
+
+/**
+ * Helps tests use {@link FileSystem}s.
+ */
+public final class NioFileSystem {
+    // macOS:
+    // jshell> FileSystems.getDefault().supportedFileAttributeViews()
+    // $1 ==> [owner, basic, posix, user, unix]
+
+    /**
+     * The {@value} name from {@link FileSystem#supportedFileAttributeViews()}.
+     */
+    public static final String BASIC = "basic";
+
+    /**
+     * The {@value} name from {@link FileSystem#supportedFileAttributeViews()}.
+     */
+    public static final String DOS = "dos";
+
+    /**
+     * The {@value} name from {@link FileSystem#supportedFileAttributeViews()}.
+     */
+    public static final String OWNER = "owner";
+
+    /**
+     * The {@value} name from {@link FileSystem#supportedFileAttributeViews()}.
+     */
+    public static final String POSIX = "posix";
+
+    /**
+     * The {@value} name from {@link FileSystem#supportedFileAttributeViews()}.
+     */
+    public static final String UNIX = "unix";
+
+    /**
+     * The {@value} name from {@link FileSystem#supportedFileAttributeViews()}.
+     */
+    public static final String USER = "user";
+
+    /**
+     * Tests whether the given view names contains the {@link #DOS} name.
+     *
+     * @param views The names to test.
+     * @return whether the given view names contains the {@link #DOS} name.
+     */
+    public static boolean isDos(final Set<String> views) {
+        return views.contains(DOS);
+    }
+
+    /**
+     * Tests whether the given FileSystem contains the {@link #POSIX} file attribute view name.
+     *
+     * @param fileSystem The FileSystem to test.
+     * @return whether the given FileSystem contains the {@link #POSIX} file attribute view name.
+     */
+    public static boolean isPosix(final FileSystem fileSystem) {
+        return supportsFileAttributeView(fileSystem, POSIX);
+    }
+
+    /**
+     * Tests whether the given Path contains the {@link #POSIX} file attribute view name.
+     *
+     * @param path The Path to test.
+     * @return whether the given FileSystem contains the {@link #POSIX} file attribute view name.
+     */
+    public static boolean isPosix(final Path path) {
+        return supportsFileAttributeView(path.getFileSystem(), POSIX);
+    }
+
+    /**
+     * Tests whether the given view names contains the {@link #POSIX} name.
+     *
+     * @param views The names to test.
+     * @return whether the given view names contains the {@link #POSIX} name.
+     */
+    public static boolean isPosix(final Set<String> views) {
+        return views.contains(POSIX);
+    }
+
+    /**
+     * Tests whether the given view names contains the {@link #UNIX} name.
+     *
+     * @param views The names to test.
+     * @return whether the given view names contains the {@link #UNIX} name.
+     */
+    public static boolean isUnix(final Set<String> views) {
+        return views.contains(UNIX);
+    }
+
+    /**
+     * Tests whether the given FileSystem contains the {@code view} file attribute view name.
+     *
+     * @param fileSystem The FileSystem to test.
+     * @param view The view name to test.
+     * @return whether the given FileSystem contains the {@code view} file attribute view name.
+     */
+    public static boolean supportsFileAttributeView(final FileSystem fileSystem, final String view) {
+        return fileSystem.supportedFileAttributeViews().contains(view);
+    }
+
+    /**
+     * No instances needed.
+     */
+    private NioFileSystem() {
+        // empty
+    }
+}

--- a/src/test/java/org/apache/commons/io/output/DeferredFileOutputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/output/DeferredFileOutputStreamTest.java
@@ -24,17 +24,22 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.file.AbstractTempDirTest;
+import org.apache.commons.io.file.NioFileSystem;
 import org.apache.commons.io.file.PathUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -203,6 +208,57 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
             assertEquals(testBytes.length, out.getByteCount());
             assertContentsEquals(out);
         }
+    }
+
+    /**
+     * Tests that the temporary file is created with owner-only permissions on POSIX file systems.
+     */
+    @Test
+    void testPersistedFileIsOwnerOnlyOnPosix() throws IOException {
+      assumeTrue(NioFileSystem.isPosix(tempDirPath));
+      // Mirror production, where the supplier only resolves a not-yet-existing path.
+      final Path target = tempDirPath.resolve("posixPerms.bin");
+      final AtomicReference<Path> pathRef = new AtomicReference<>();
+      try (DeferredFileOutputStream dos = DeferredFileOutputStream.builder()
+              // @formatter:off
+              .setPath(target)
+              .setPrefix(getClass().getSimpleName())
+              .setDeleteTempFileOnClose(false)
+              .get()
+              // @formatter:on
+              ) {
+        dos.write(testBytes);
+        pathRef.set(dos.getPath());
+      }
+      final Path pathTemp = pathRef.get();
+      assertTrue(Files.exists(pathTemp));
+      assertTrue(Files.isRegularFile(pathTemp));
+      assertEquals("rw-------", PosixFilePermissions.toString(Files.getPosixFilePermissions(pathTemp)));
+    }
+
+    /**
+     * Tests that persisting over an already existing path truncates and overwrites it.
+     */
+    @Test
+    void testPersistedFileOverwritesExisting() throws IOException {
+      final Path target = tempDirPath.resolve("overwrite.bin");
+      Files.write(target, "stale-and-longer".getBytes(StandardCharsets.UTF_8));
+      final AtomicReference<Path> pathRef = new AtomicReference<>();
+      try (DeferredFileOutputStream dos = DeferredFileOutputStream.builder()
+              // @formatter:off
+              .setPath(target)
+              .setPrefix(getClass().getSimpleName())
+              .setDeleteTempFileOnClose(false)
+              .get()
+              // @formatter:on
+              ) {
+        dos.write(testBytes);
+        pathRef.set(dos.getPath());
+      }
+      final Path pathTemp = pathRef.get();
+      assertTrue(Files.exists(pathTemp));
+      assertTrue(Files.isRegularFile(pathTemp));
+      assertArrayEquals(testBytes, Files.readAllBytes(pathTemp));
     }
 
     /**
@@ -516,8 +572,7 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
             assertThrows(IOException.class, () -> dfos.writeTo(baos));
             dfos.close();
             dfos.writeTo(baos);
-            final byte[] copiedBytes = baos.toByteArray();
-            assertArrayEquals(testBytes, copiedBytes);
+            assertArrayEquals(testBytes, baos.toByteArray());
             verifyResultFile(testFile);
         }
     }
@@ -541,8 +596,7 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
             assertEquals(testBytes.length, dfos.getByteCount());
             dfos.close();
             dfos.writeTo(baos);
-            final byte[] copiedBytes = baos.toByteArray();
-            assertArrayEquals(testBytes, copiedBytes);
+            assertArrayEquals(testBytes, baos.toByteArray());
             verifyResultFile(testFile);
         }
     }
@@ -567,8 +621,7 @@ class DeferredFileOutputStreamTest extends AbstractTempDirTest {
             assertEquals(testBytes.length, dfos.getByteCount());
             dfos.close();
             dfos.writeTo(baos);
-            final byte[] copiedBytes = baos.toByteArray();
-            assertArrayEquals(testBytes, copiedBytes);
+            assertArrayEquals(testBytes, baos.toByteArray());
         }
     }
 


### PR DESCRIPTION
- Add tests to validate owner permission on POSIX.
- Refactor test to check a specific folder for POSIX instead of the default FS.
- DeferredFileOutputStream.thresholdReached(): Throws an NPE with a useful message.
- DeferredFileOutputStream.thresholdReached(): Better local variable name.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] ~~I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?~~
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
