### PR TITLE
Avoid allocating the extension substring in FilenameUtils.isExtension

### DIFF
--- a/src/main/java/org/apache/commons/io/FilenameUtils.java
+++ b/src/main/java/org/apache/commons/io/FilenameUtils.java
@@ -26,7 +26,6 @@ import java.util.Deque;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 
 /**
  * General file name and file path manipulation utilities. The methods in this class operate on strings that represent relative or absolute paths. Nothing in
@@ -1009,10 +1008,31 @@ public class FilenameUtils {
             return false;
         }
         requireNonNullChars(fileName);
+        final int index = indexOfExtension(fileName);
         if (isEmpty(extension)) {
-            return indexOfExtension(fileName) == NOT_FOUND;
+            return index == NOT_FOUND;
         }
-        return getExtension(fileName).equals(extension);
+        // Compare the extension region in place rather than allocating getExtension(fileName).
+        return index != NOT_FOUND && extensionEquals(fileName, index, extension);
+    }
+
+    /**
+     * Tests whether the extension of {@code fileName} equals {@code extension}, without allocating the extension
+     * substring. This is equivalent to {@code getExtension(fileName).equals(extension)}: {@code index} is the extension
+     * separator position from {@link #indexOfExtension(String)} ({@link #NOT_FOUND} meaning the empty extension), and a
+     * {@code null} extension never matches.
+     *
+     * @param fileName  the file name, not null.
+     * @param index     the extension separator position, or {@link #NOT_FOUND} for the empty extension.
+     * @param extension the extension to compare against; null never matches.
+     * @return true if the extension equals the given extension.
+     */
+    private static boolean extensionEquals(final String fileName, final int index, final String extension) {
+        if (extension == null) {
+            return false;
+        }
+        final int extLen = index == NOT_FOUND ? 0 : fileName.length() - index - 1;
+        return extLen == extension.length() && (extLen == 0 || fileName.regionMatches(index + 1, extension, 0, extLen));
     }
 
     /**
@@ -1032,11 +1052,18 @@ public class FilenameUtils {
             return false;
         }
         requireNonNullChars(fileName);
+        final int index = indexOfExtension(fileName);
         if (extensions == null || extensions.length == 0) {
-            return indexOfExtension(fileName) == NOT_FOUND;
+            return index == NOT_FOUND;
         }
-        final String fileExt = getExtension(fileName);
-        return Stream.of(extensions).anyMatch(fileExt::equals);
+        // Compare the extension region against each candidate in place, avoiding both the getExtension
+        // substring and the Stream pipeline.
+        for (final String extension : extensions) {
+            if (extensionEquals(fileName, index, extension)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary

`FilenameUtils.isExtension(String, String)` returned `getExtension(fileName).equals(extension)`, and the `String...` overload did `Stream.of(extensions).anyMatch(getExtension(fileName)::equals)`. Both allocate the extension **substring** (and the varargs form an extra `Stream` pipeline) only to compare it — on a file-filtering path that returns a `boolean`.

This compares the extension region of `fileName` in place via `String.regionMatches`, through a small private helper that mirrors `getExtension(fileName).equals(extension)` exactly: `NOT_FOUND` is treated as the empty extension and a `null` extension never matches, so all documented cases — no-extension files, empty and null extensions, and empty entries in the varargs form — are unchanged. The `String...` overload also drops the `Stream` for a plain loop.

## Measurement

ThreadMXBean allocation driver, 200k warmed ops, `"/home/user/docs/report.final.pdf"`:

| call | before | after |
|------|--------|-------|
| `isExtension(s, "pdf")` | 48 B/op | 0 B/op |
| `isExtension(s, "doc", "pdf")` | 175 B/op | 0 B/op |

## Testing

`FilenameUtilsTest` passes unchanged (41 tests), including the existing null / empty-extension / varargs edge cases (`isExtension("file", "")`, `isExtension("file", "rtf", "")`, the null-char injection test, etc.).
