### PR TITLE
ByteBufferCleaner to check Unsafe access in Java 23+

### DIFF
--- a/src/main/java/org/apache/commons/io/input/BufferedFileChannelInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BufferedFileChannelInputStream.java
@@ -26,6 +26,7 @@ import java.nio.file.StandardOpenOption;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.build.AbstractStreamBuilder;
+import org.apache.commons.io.input.MemoryMappedFileInputStream.Builder;
 
 /**
  * {@link InputStream} implementation which uses direct buffer to read a file to avoid extra copy of data between Java and native memory which happens when
@@ -74,11 +75,24 @@ public final class BufferedFileChannelInputStream extends InputStream {
 
         private FileChannel fileChannel;
 
+        private boolean clean = true;
+
         /**
          * Constructs a new builder of {@link BufferedFileChannelInputStream}.
          */
         public Builder() {
             // empty
+        }
+
+        /**
+         * Whether to attempt to clean ByteBuffer on close. Default is true.
+         *
+         * @param clean whether to attempt to clean ByteBuffer on close
+         * @return {@code this} instance.
+         */
+        public Builder setClean(final boolean clean) {
+            this.clean = clean;
+            return this;
         }
 
         /**
@@ -137,7 +151,9 @@ public final class BufferedFileChannelInputStream extends InputStream {
 
     private final ByteBuffer byteBuffer;
 
-    private boolean clean;
+    private final boolean clean;
+
+    private boolean cleaned;
 
     private final FileChannel fileChannel;
 
@@ -146,6 +162,7 @@ public final class BufferedFileChannelInputStream extends InputStream {
         this.fileChannel = builder.fileChannel != null ? builder.fileChannel : FileChannel.open(builder.getPath(), StandardOpenOption.READ);
         this.byteBuffer = ByteBuffer.allocateDirect(builder.getBufferSize());
         this.byteBuffer.flip();
+        this.clean = builder.clean;
     }
 
     /**
@@ -220,9 +237,9 @@ public final class BufferedFileChannelInputStream extends InputStream {
      * @param buffer The buffer to clean.
      */
     private void clean(final ByteBuffer buffer) {
-        if (!clean && ByteBufferCleaner.isSupported()) {
+        if (!cleaned && clean) {
             ByteBufferCleaner.clean(buffer);
-            clean = true;
+            cleaned = true;
         }
     }
 
@@ -235,8 +252,8 @@ public final class BufferedFileChannelInputStream extends InputStream {
         }
     }
 
-    boolean isClean() {
-        return clean;
+    boolean isCleaned() {
+        return cleaned;
     }
 
     @Override

--- a/src/main/java/org/apache/commons/io/input/BufferedFileChannelInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/BufferedFileChannelInputStream.java
@@ -13,6 +13,7 @@
  */
 package org.apache.commons.io.input;
 
+import static org.apache.commons.io.IOUtils.EMPTY_BYTE_ARRAY;
 import static org.apache.commons.io.IOUtils.EOF;
 
 import java.io.BufferedInputStream;
@@ -26,7 +27,6 @@ import java.nio.file.StandardOpenOption;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.build.AbstractStreamBuilder;
-import org.apache.commons.io.input.MemoryMappedFileInputStream.Builder;
 
 /**
  * {@link InputStream} implementation which uses direct buffer to read a file to avoid extra copy of data between Java and native memory which happens when
@@ -42,7 +42,7 @@ import org.apache.commons.io.input.MemoryMappedFileInputStream.Builder;
  * @see Builder
  * @since 2.9.0
  */
-public final class BufferedFileChannelInputStream extends InputStream {
+public final class BufferedFileChannelInputStream extends AbstractInputStream {
 
     // @formatter:off
     /**
@@ -139,6 +139,8 @@ public final class BufferedFileChannelInputStream extends InputStream {
 
     }
 
+    private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.wrap(EMPTY_BYTE_ARRAY).asReadOnlyBuffer();
+
     /**
      * Constructs a new {@link Builder}.
      *
@@ -149,11 +151,9 @@ public final class BufferedFileChannelInputStream extends InputStream {
         return new Builder();
     }
 
-    private final ByteBuffer byteBuffer;
+    private ByteBuffer byteBuffer;
 
     private final boolean clean;
-
-    private boolean cleaned;
 
     private final FileChannel fileChannel;
 
@@ -224,7 +224,7 @@ public final class BufferedFileChannelInputStream extends InputStream {
     }
 
     /**
-     * Attempts to clean up a ByteBuffer if it is direct or memory-mapped. This uses an *unsafe* Sun API that will cause errors if one attempts to read from the
+     * Attempts to clean up byteBuffer if it is direct or memory-mapped. This uses an *unsafe* Sun API that will cause errors if one attempts to read from the
      * disposed buffer. However, neither the bytes allocated to direct buffers nor file descriptors opened for memory-mapped buffers put pressure on the garbage
      * collector. Waiting for garbage collection may lead to the depletion of off-heap memory or huge numbers of open files. There's unfortunately no standard
      * API to manually dispose of these kinds of buffers.
@@ -234,26 +234,21 @@ public final class BufferedFileChannelInputStream extends InputStream {
      * accessible even with reflection. However {@code sun.misc.Unsafe} added an {@code invokeCleaner()} method in JDK 9+ and this is still accessible with
      * reflection.
      * </p>
-     * @param buffer The buffer to clean.
      */
-    private void clean(final ByteBuffer buffer) {
-        if (!cleaned && clean) {
-            ByteBufferCleaner.clean(buffer);
-            cleaned = true;
+    private void cleanBuffer() {
+        if (clean) {
+            ByteBufferCleaner.clean(byteBuffer);
         }
     }
 
     @Override
     public synchronized void close() throws IOException {
-        try {
+        if (!isClosed()) {
+            cleanBuffer();
+            byteBuffer = EMPTY_BUFFER;
             fileChannel.close();
-        } finally {
-            clean(byteBuffer);
+            super.close();
         }
-    }
-
-    boolean isCleaned() {
-        return cleaned;
     }
 
     @Override

--- a/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
+++ b/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
@@ -103,7 +103,7 @@ final class ByteBufferCleaner {
     }
 
     static Cleaner getCleaner() {
-        if (!unsafeMemoryAccessDeprecated()) {
+        if (unsafeMemoryAccessDeprecated()) {
             return null;
         }
         try {
@@ -122,10 +122,10 @@ final class ByteBufferCleaner {
         try {
             version = Integer.parseInt(System.getProperty("java.specification.version"));
         } catch (final RuntimeException e) {
-            return true;
+            return false;
         }
         // see https://openjdk.org/jeps/471
-        return version < 23;
+        return version >= 23;
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
+++ b/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
@@ -91,9 +91,11 @@ final class ByteBufferCleaner {
      */
     static void clean(final ByteBuffer buffer) {
         try {
-            if (INSTANCE != null && buffer.isDirect()) {
+            if (buffer.isDirect()) {
                 Buffers.clearWritable(buffer);
-                INSTANCE.clean(buffer);
+                if (INSTANCE != null) {
+                    INSTANCE.clean(buffer);
+                }
             }
         } catch (final Exception e) {
             throw new IllegalStateException("Failed to clean direct buffer.", e);

--- a/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
+++ b/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
@@ -21,6 +21,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.util.List;
 
 import org.apache.commons.io.Buffers;
 
@@ -100,7 +101,7 @@ final class ByteBufferCleaner {
     }
 
     static Cleaner getCleaner() {
-        if (!unsafeMemoryAccessAllowed()) {
+        if (!unsafeMemoryAccessDeprecated()) {
             return null;
         }
         try {
@@ -114,19 +115,15 @@ final class ByteBufferCleaner {
         }
     }
 
-    private static boolean unsafeMemoryAccessAllowed() {
+    private static boolean unsafeMemoryAccessDeprecated() {
         final int version;
         try {
-            version = Integer.parseInt(ManagementFactory.getRuntimeMXBean().getSpecVersion());
+            version = Integer.parseInt(System.getProperty("java.specification.version"));
         } catch (final RuntimeException e) {
             return true;
         }
-        if (version < 23) {
-            return true;
-        }
         // see https://openjdk.org/jeps/471
-        return ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
-                                .anyMatch(arg -> arg.equals("--sun-misc-unsafe-memory-access=allow"));
+        return version < 23;
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
+++ b/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.io.input;
 
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
@@ -89,7 +90,7 @@ final class ByteBufferCleaner {
      */
     static void clean(final ByteBuffer buffer) {
         try {
-            if (buffer.isDirect()) {
+            if (INSTANCE != null && buffer.isDirect()) {
                 Buffers.clearWritable(buffer);
                 INSTANCE.clean(buffer);
             }
@@ -98,7 +99,10 @@ final class ByteBufferCleaner {
         }
     }
 
-    private static Cleaner getCleaner() {
+    static Cleaner getCleaner() {
+        if (!unsafeMemoryAccessAllowed()) {
+            return null;
+        }
         try {
             return new Java8Cleaner();
         } catch (final Exception e) {
@@ -108,6 +112,21 @@ final class ByteBufferCleaner {
                 throw new IllegalStateException("Failed to initialize a Cleaner.", e);
             }
         }
+    }
+
+    private static boolean unsafeMemoryAccessAllowed() {
+        final int version;
+        try {
+            version = Integer.parseInt(ManagementFactory.getRuntimeMXBean().getSpecVersion());
+        } catch (final RuntimeException e) {
+            return true;
+        }
+        if (version < 23) {
+            return true;
+        }
+        // see https://openjdk.org/jeps/471
+        return ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+                                .anyMatch(arg -> arg.equals("--sun-misc-unsafe-memory-access=allow"));
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
+++ b/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
@@ -17,11 +17,9 @@
 
 package org.apache.commons.io.input;
 
-import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-import java.util.List;
 
 import org.apache.commons.io.Buffers;
 

--- a/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
+++ b/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
@@ -124,7 +124,8 @@ final class ByteBufferCleaner {
     private static boolean unsafeMemoryAccessDeprecated() {
         final int version;
         try {
-            version = Integer.parseInt(System.getProperty("java.specification.version"));
+            final String versionString = System.getProperty("java.specification.version");
+            version = "1.8".equals(versionString) ? 8 : Integer.parseInt(versionString);
         } catch (final RuntimeException e) {
             return false;
         }

--- a/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
+++ b/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
@@ -79,7 +79,7 @@ final class ByteBufferCleaner {
         }
     }
 
-    private static final Cleaner INSTANCE = getCleanerMaybe();
+    private static final Cleaner INSTANCE = getCleaner();
 
     /**
      * Releases memory held by the given {@link ByteBuffer}.
@@ -91,55 +91,45 @@ final class ByteBufferCleaner {
         try {
             if (buffer.isDirect()) {
                 Buffers.clearWritable(buffer);
-                if (INSTANCE != null) {
-                    INSTANCE.clean(buffer);
-                } else {
-                    getCleaner().clean(buffer);
-                }
+                INSTANCE.clean(buffer);
             }
         } catch (final Exception e) {
             throw new IllegalStateException("Failed to clean direct buffer.", e);
         }
     }
 
-    static Cleaner getCleanerMaybe() {
-        if (unsafeMemoryAccessDeprecated()) {
-            return null;
-        }
-        return getCleaner();
-    }
-
     static Cleaner getCleaner() {
+        if (!isSupported()) {
+            return ignored -> {
+                // empty no op
+            };
+        }
         try {
-            return new Java8Cleaner();
+            return new ByteBufferCleaner.Java8Cleaner();
         } catch (final Exception e) {
             try {
-                return new Java9Cleaner();
+                return new ByteBufferCleaner.Java9Cleaner();
             } catch (final Exception e1) {
                 throw new IllegalStateException("Failed to initialize a Cleaner.", e);
             }
         }
     }
 
-    private static boolean unsafeMemoryAccessDeprecated() {
+    /**
+     * Tests if were able to load a non-empty cleaner for the current JVM. Attempting to call {@code ByteBufferCleaner#clean(ByteBuffer)} when this method
+     * returns false may result in an exception.
+     *
+     * @return {@code true} if cleaning is supported, {@code false} otherwise.
+     */
+    static boolean isSupported() {
         final int version;
         try {
             final String versionString = System.getProperty("java.specification.version");
             version = "1.8".equals(versionString) ? 8 : Integer.parseInt(versionString);
         } catch (final RuntimeException e) {
-            return false;
+            return true;
         }
-        // see https://openjdk.org/jeps/471
-        return version >= 23;
-    }
-
-    /**
-     * Tests if were able to load a suitable cleaner for the current JVM. Attempting to call {@code ByteBufferCleaner#clean(ByteBuffer)} when this method
-     * returns false will result in an exception.
-     *
-     * @return {@code true} if cleaning is supported, {@code false} otherwise.
-     */
-    static boolean isSupported() {
-        return INSTANCE != null;
+        // see https://openjdk.org/jeps/471 Deprecate the Memory-Access Methods in sun.misc.Unsafe for Removal
+        return version < 23;
     }
 }

--- a/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
+++ b/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
@@ -98,7 +98,7 @@ final class ByteBufferCleaner {
         }
     }
 
-    static Cleaner getCleaner() {
+    private static Cleaner getCleaner() {
         if (!isSupported()) {
             return ignored -> {
                 // empty no op

--- a/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
+++ b/src/main/java/org/apache/commons/io/input/ByteBufferCleaner.java
@@ -79,7 +79,7 @@ final class ByteBufferCleaner {
         }
     }
 
-    private static final Cleaner INSTANCE = getCleaner();
+    private static final Cleaner INSTANCE = getCleanerMaybe();
 
     /**
      * Releases memory held by the given {@link ByteBuffer}.
@@ -93,6 +93,8 @@ final class ByteBufferCleaner {
                 Buffers.clearWritable(buffer);
                 if (INSTANCE != null) {
                     INSTANCE.clean(buffer);
+                } else {
+                    getCleaner().clean(buffer);
                 }
             }
         } catch (final Exception e) {
@@ -100,10 +102,14 @@ final class ByteBufferCleaner {
         }
     }
 
-    static Cleaner getCleaner() {
+    static Cleaner getCleanerMaybe() {
         if (unsafeMemoryAccessDeprecated()) {
             return null;
         }
+        return getCleaner();
+    }
+
+    static Cleaner getCleaner() {
         try {
             return new Java8Cleaner();
         } catch (final Exception e) {

--- a/src/main/java/org/apache/commons/io/input/MemoryMappedFileInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/MemoryMappedFileInputStream.java
@@ -92,12 +92,25 @@ public final class MemoryMappedFileInputStream extends AbstractInputStream {
     // @formatter:on
     public static class Builder extends AbstractStreamBuilder<MemoryMappedFileInputStream, Builder> {
 
+        private boolean clean = true;
+
         /**
          * Constructs a new builder of {@link MemoryMappedFileInputStream}.
          */
         public Builder() {
             setBufferSizeDefault(DEFAULT_BUFFER_SIZE);
             setBufferSize(DEFAULT_BUFFER_SIZE);
+        }
+
+        /**
+         * Whether to attempt to clean ByteBuffer on close. Default is true.
+         *
+         * @param clean whether to attempt to clean ByteBuffer on close
+         * @return {@code this} instance.
+         */
+        public Builder setClean(final boolean clean) {
+            this.clean = clean;
+            return this;
         }
 
         /**
@@ -147,6 +160,7 @@ public final class MemoryMappedFileInputStream extends AbstractInputStream {
 
     private final int bufferSize;
     private final FileChannel channel;
+    private final boolean clean;
     private ByteBuffer buffer = EMPTY_BUFFER;
 
     /**
@@ -163,6 +177,7 @@ public final class MemoryMappedFileInputStream extends AbstractInputStream {
     private MemoryMappedFileInputStream(final Builder builder) throws IOException {
         this.bufferSize = builder.getBufferSize();
         this.channel = FileChannel.open(builder.getPath(), StandardOpenOption.READ);
+        this.clean = builder.clean;
     }
 
     @Override
@@ -172,7 +187,7 @@ public final class MemoryMappedFileInputStream extends AbstractInputStream {
     }
 
     private void cleanBuffer() {
-        if (ByteBufferCleaner.isSupported()) {
+        if (clean) {
             ByteBufferCleaner.clean(buffer);
         }
     }

--- a/src/main/java/org/apache/commons/io/input/MemoryMappedFileInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/MemoryMappedFileInputStream.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.io.input;
 
+import static org.apache.commons.io.IOUtils.EMPTY_BYTE_ARRAY;
 import static org.apache.commons.io.IOUtils.EOF;
 
 import java.io.BufferedInputStream;
@@ -146,7 +147,7 @@ public final class MemoryMappedFileInputStream extends AbstractInputStream {
      */
     private static final int DEFAULT_BUFFER_SIZE = 256 * 1024;
 
-    private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.wrap(new byte[0]).asReadOnlyBuffer();
+    private static final ByteBuffer EMPTY_BUFFER = ByteBuffer.wrap(EMPTY_BYTE_ARRAY).asReadOnlyBuffer();
 
     /**
      * Constructs a new {@link Builder}.

--- a/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
@@ -17,15 +17,19 @@
 
 package org.apache.commons.io.input;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.management.ManagementFactory;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 
+import org.apache.commons.lang3.JavaVersion;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -74,12 +78,13 @@ class BufferedFileChannelInputStreamTest extends AbstractInputStreamTest {
      */
     @Test
     void testCleanCalledOnlyOnce() throws Exception {
+        final boolean expectedCleanOnClose = !SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_23);
         try (BufferedFileChannelInputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).get()) {
             assertFalse(stream.isClean());
             stream.close();
-            assertTrue(stream.isClean());
+            assertEquals(stream.isClean(), expectedCleanOnClose);
             stream.close();
-            assertTrue(stream.isClean());
+            assertEquals(stream.isClean(), expectedCleanOnClose);
         }
     }
 

--- a/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.lang.management.ManagementFactory;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 

--- a/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
@@ -17,13 +17,10 @@
 
 package org.apache.commons.io.input;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -81,37 +78,20 @@ class BufferedFileChannelInputStreamTest extends AbstractInputStreamTest {
      */
     @Test
     void testCleanCalledOnlyOnce() throws Exception {
-        final boolean expectedCleanOnClose = ByteBufferCleaner.getCleaner() != null;
-        final int expectedCleanCallCount = expectedCleanOnClose ? 1 : 0;
+        final boolean expectedCleanOnClose = ByteBufferCleaner.isSupported();
         try (MockedStatic<ByteBufferCleaner> mocked = Mockito.mockStatic(ByteBufferCleaner.class);
-             BufferedFileChannelInputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).get()) {
-            assertFalse(stream.isCleaned());
-            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), never());
-
+             InputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).setClean(true).get()) {
             stream.close();
-            assertEquals(stream.isCleaned(), expectedCleanOnClose);
-            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), times(expectedCleanCallCount));
-
-            stream.close();
-            assertEquals(stream.isCleaned(), expectedCleanOnClose);
-            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), times(expectedCleanCallCount));
+            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)));
         }
     }
 
     @Test
     void testCleanCalledNever() throws Exception {
-        final boolean expectedCleanOnClose = false;
+        // test
         try (MockedStatic<ByteBufferCleaner> mocked = Mockito.mockStatic(ByteBufferCleaner.class);
-             BufferedFileChannelInputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).setClean(false).get()) {
-            assertFalse(stream.isCleaned());
-            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), never());
-
+             InputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).setClean(false).get()) {
             stream.close();
-            assertEquals(stream.isCleaned(), expectedCleanOnClose);
-            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), never());
-
-            stream.close();
-            assertEquals(stream.isCleaned(), expectedCleanOnClose);
             mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), never());
         }
     }

--- a/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
@@ -21,14 +21,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * Tests functionality of {@link BufferedFileChannelInputStream}.
@@ -76,24 +82,37 @@ class BufferedFileChannelInputStreamTest extends AbstractInputStreamTest {
     @Test
     void testCleanCalledOnlyOnce() throws Exception {
         final boolean expectedCleanOnClose = ByteBufferCleaner.getCleaner() != null;
-        try (BufferedFileChannelInputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).get()) {
+        final int expectedCleanCallCount = expectedCleanOnClose ? 1 : 0;
+        try (MockedStatic<ByteBufferCleaner> mocked = Mockito.mockStatic(ByteBufferCleaner.class);
+             BufferedFileChannelInputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).get()) {
             assertFalse(stream.isCleaned());
+            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), never());
+
             stream.close();
             assertEquals(stream.isCleaned(), expectedCleanOnClose);
+            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), times(expectedCleanCallCount));
+
             stream.close();
             assertEquals(stream.isCleaned(), expectedCleanOnClose);
+            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), times(expectedCleanCallCount));
         }
     }
 
     @Test
     void testCleanCalledNever() throws Exception {
         final boolean expectedCleanOnClose = false;
-        try (BufferedFileChannelInputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).setClean(false).get()) {
+        try (MockedStatic<ByteBufferCleaner> mocked = Mockito.mockStatic(ByteBufferCleaner.class);
+             BufferedFileChannelInputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).setClean(false).get()) {
             assertFalse(stream.isCleaned());
+            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), never());
+
             stream.close();
             assertEquals(stream.isCleaned(), expectedCleanOnClose);
+            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), never());
+
             stream.close();
             assertEquals(stream.isCleaned(), expectedCleanOnClose);
+            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), never());
         }
     }
 

--- a/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/BufferedFileChannelInputStreamTest.java
@@ -27,8 +27,6 @@ import java.io.InputStream;
 import java.nio.channels.FileChannel;
 import java.nio.file.StandardOpenOption;
 
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -77,13 +75,25 @@ class BufferedFileChannelInputStreamTest extends AbstractInputStreamTest {
      */
     @Test
     void testCleanCalledOnlyOnce() throws Exception {
-        final boolean expectedCleanOnClose = !SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_23);
+        final boolean expectedCleanOnClose = ByteBufferCleaner.getCleaner() != null;
         try (BufferedFileChannelInputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).get()) {
-            assertFalse(stream.isClean());
+            assertFalse(stream.isCleaned());
             stream.close();
-            assertEquals(stream.isClean(), expectedCleanOnClose);
+            assertEquals(stream.isCleaned(), expectedCleanOnClose);
             stream.close();
-            assertEquals(stream.isClean(), expectedCleanOnClose);
+            assertEquals(stream.isCleaned(), expectedCleanOnClose);
+        }
+    }
+
+    @Test
+    void testCleanCalledNever() throws Exception {
+        final boolean expectedCleanOnClose = false;
+        try (BufferedFileChannelInputStream stream = BufferedFileChannelInputStream.builder().setPath(InputPath).setClean(false).get()) {
+            assertFalse(stream.isCleaned());
+            stream.close();
+            assertEquals(stream.isCleaned(), expectedCleanOnClose);
+            stream.close();
+            assertEquals(stream.isCleaned(), expectedCleanOnClose);
         }
     }
 

--- a/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
+++ b/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.io.input;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -36,19 +37,22 @@ class ByteBufferCleanerTest {
 
     @Test
     void testCleanEmpty() {
-        final ByteBuffer buffer = ByteBuffer.allocateDirect(10);
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(8);
         // There is no way verify that the buffer has been cleaned up, we are just verifying that
         // clean() doesn't blow up
         ByteBufferCleaner.clean(buffer);
+        verifyCleared(buffer);
     }
 
     @Test
     void testCleanFull() {
-        final ByteBuffer buffer = ByteBuffer.allocateDirect(10);
-        buffer.put(RandomUtils.insecure().randomBytes(10), 0, 10);
+        final ByteBuffer buffer = ByteBuffer.allocateDirect(8);
+        buffer.putLong(Long.MAX_VALUE);
+        verifyUncleared(buffer);
         // There is no way verify that the buffer has been cleaned up, we are just verifying that
         // clean() doesn't blow up
         ByteBufferCleaner.clean(buffer);
+        verifyCleared(buffer);
     }
 
     @Test
@@ -73,5 +77,15 @@ class ByteBufferCleanerTest {
     void testUnsupportedByDefaultOnJava23() {
         assertNull(ByteBufferCleaner.getCleaner());
         assertFalse(ByteBufferCleaner.isSupported(), "ByteBufferCleaner does not work on this platform, please investigate and fix");
+    }
+
+    private void verifyUncleared(final ByteBuffer buffer) {
+        buffer.flip();
+        assertEquals(Long.MAX_VALUE, buffer.getLong());
+        buffer.flip();
+    }
+
+    private void verifyCleared(final ByteBuffer buffer) {
+        assertEquals(0, buffer.getLong());
     }
 }

--- a/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
+++ b/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.condition.JRE.JAVA_23;
 
 import java.nio.ByteBuffer;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 

--- a/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
+++ b/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
@@ -18,23 +18,16 @@ package org.apache.commons.io.input;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.condition.JRE.JAVA_23;
 
-import java.lang.management.ManagementFactory;
-import java.lang.management.RuntimeMXBean;
 import java.nio.ByteBuffer;
-import java.util.Arrays;
 
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
-import org.junit.jupiter.api.condition.JRE;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 /**
  * Tests {@code ByteBufferCleaner}.
@@ -80,17 +73,5 @@ class ByteBufferCleanerTest {
     void testUnsupportedByDefaultOnJava23() {
         assertNull(ByteBufferCleaner.getCleaner());
         assertFalse(ByteBufferCleaner.isSupported(), "ByteBufferCleaner does not work on this platform, please investigate and fix");
-    }
-
-    @Test
-    @EnabledForJreRange(min = JAVA_23)
-    void testSupportedIfUnsafeAllowedJava23() {
-        final RuntimeMXBean mockBean = Mockito.mock(RuntimeMXBean.class);
-        Mockito.when(mockBean.getSpecVersion()).thenReturn("23");
-        Mockito.when(mockBean.getInputArguments()).thenReturn(Arrays.asList("java", "--sun-misc-unsafe-memory-access=allow", "-version"));
-        try (final MockedStatic<ManagementFactory> managementFactory = Mockito.mockStatic(ManagementFactory.class)) {
-            managementFactory.when(ManagementFactory::getRuntimeMXBean).thenReturn(mockBean);
-            assertNotNull(ByteBufferCleaner.getCleaner());
-        }
     }
 }

--- a/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
+++ b/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
@@ -16,12 +16,25 @@
  */
 package org.apache.commons.io.input;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.condition.JRE.JAVA_23;
 
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 
 import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * Tests {@code ByteBufferCleaner}.
@@ -46,8 +59,38 @@ class ByteBufferCleanerTest {
     }
 
     @Test
+    void testCleanNonDirectBuffer() {
+        assertDoesNotThrow(() -> ByteBufferCleaner.clean(ByteBuffer.allocate(10)));
+    }
+
+    @Test
+    @EnabledForJreRange(max = JAVA_23)
+    void testCleanNullBuffer() {
+        assertThrows(IllegalStateException.class, () -> ByteBufferCleaner.clean(null));
+    }
+
+    @Test
+    @EnabledForJreRange(max = JAVA_23)
     void testSupported() {
         assertTrue(ByteBufferCleaner.isSupported(), "ByteBufferCleaner does not work on this platform, please investigate and fix");
     }
 
+    @Test
+    @EnabledForJreRange(min = JAVA_23)
+    void testUnsupportedByDefaultOnJava23() {
+        assertNull(ByteBufferCleaner.getCleaner());
+        assertFalse(ByteBufferCleaner.isSupported(), "ByteBufferCleaner does not work on this platform, please investigate and fix");
+    }
+
+    @Test
+    @EnabledForJreRange(min = JAVA_23)
+    void testSupportedIfUnsafeAllowedJava23() {
+        final RuntimeMXBean mockBean = Mockito.mock(RuntimeMXBean.class);
+        Mockito.when(mockBean.getSpecVersion()).thenReturn("23");
+        Mockito.when(mockBean.getInputArguments()).thenReturn(Arrays.asList("java", "--sun-misc-unsafe-memory-access=allow", "-version"));
+        try (final MockedStatic<ManagementFactory> managementFactory = Mockito.mockStatic(ManagementFactory.class)) {
+            managementFactory.when(ManagementFactory::getRuntimeMXBean).thenReturn(mockBean);
+            assertNotNull(ByteBufferCleaner.getCleaner());
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
+++ b/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
@@ -18,8 +18,7 @@ package org.apache.commons.io.input;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.condition.JRE.JAVA_23;
@@ -71,9 +70,8 @@ class ByteBufferCleanerTest {
 
     @Test
     @EnabledForJreRange(min = JAVA_23)
-    void testUnsupportedByDefaultOnJava23() {
-        assertNull(ByteBufferCleaner.getCleaner());
-        assertFalse(ByteBufferCleaner.isSupported(), "ByteBufferCleaner does not work on this platform, please investigate and fix");
+    void testSupportedByDefaultOnJava23() {
+        assertNotNull(ByteBufferCleaner.getCleaner(), "ByteBufferCleaner works on this platform by default, please investigate and fix");
     }
 
     private void verifyUncleared(final ByteBuffer buffer) {

--- a/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
+++ b/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
@@ -18,7 +18,7 @@ package org.apache.commons.io.input;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.condition.JRE.JAVA_23;
@@ -64,14 +64,14 @@ class ByteBufferCleanerTest {
 
     @Test
     @EnabledForJreRange(max = JAVA_23)
-    void testSupported() {
+    void testSupportedBeforeJava23() {
         assertTrue(ByteBufferCleaner.isSupported(), "ByteBufferCleaner does not work on this platform, please investigate and fix");
     }
 
     @Test
     @EnabledForJreRange(min = JAVA_23)
-    void testSupportedByDefaultOnJava23() {
-        assertNotNull(ByteBufferCleaner.getCleaner(), "ByteBufferCleaner works on this platform by default, please investigate and fix");
+    void testNotSupportedSinceJava23() {
+        assertFalse(ByteBufferCleaner.isSupported(), "ByteBufferCleaner works on this platform by default, please investigate and fix");
     }
 
     private void verifyUncleared(final ByteBuffer buffer) {

--- a/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
+++ b/src/test/java/org/apache/commons/io/input/ByteBufferCleanerTest.java
@@ -37,10 +37,9 @@ class ByteBufferCleanerTest {
     @Test
     void testCleanEmpty() {
         final ByteBuffer buffer = ByteBuffer.allocateDirect(8);
-        // There is no way verify that the buffer has been cleaned up, we are just verifying that
-        // clean() doesn't blow up
+        // There is no way verify that the buffer has been cleaned up by inspecting it because a cleaned buffer should
+        // not be used. We are just verifying that clean() doesn't blow up
         ByteBufferCleaner.clean(buffer);
-        verifyCleared(buffer);
     }
 
     @Test
@@ -48,10 +47,9 @@ class ByteBufferCleanerTest {
         final ByteBuffer buffer = ByteBuffer.allocateDirect(8);
         buffer.putLong(Long.MAX_VALUE);
         verifyUncleared(buffer);
-        // There is no way verify that the buffer has been cleaned up, we are just verifying that
-        // clean() doesn't blow up
+        // There is no way verify that the buffer has been cleaned up by inspecting it because a cleaned buffer should
+        // not be used. We are just verifying that clean() doesn't blow up
         ByteBufferCleaner.clean(buffer);
-        verifyCleared(buffer);
     }
 
     @Test
@@ -82,9 +80,5 @@ class ByteBufferCleanerTest {
         buffer.flip();
         assertEquals(Long.MAX_VALUE, buffer.getLong());
         buffer.flip();
-    }
-
-    private void verifyCleared(final ByteBuffer buffer) {
-        assertEquals(0, buffer.getLong());
     }
 }

--- a/src/test/java/org/apache/commons/io/input/MemoryMappedFileInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/MemoryMappedFileInputStreamTest.java
@@ -20,9 +20,12 @@ import static org.apache.commons.lang3.ArrayUtils.EMPTY_BYTE_ARRAY;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
@@ -35,6 +38,8 @@ import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 /**
  * Tests {@link MemoryMappedFileInputStream}.
@@ -323,4 +328,31 @@ class MemoryMappedFileInputStreamTest {
         }
     }
 
+    @Test
+    void testCleanCalled() throws Exception {
+        // setup
+        final Path file = createTestFile(100);
+        final byte[] expectedData = Files.readAllBytes(file);
+        // test
+        final boolean expectedCleanOnClose = true;
+        try (MockedStatic<ByteBufferCleaner> mocked = Mockito.mockStatic(ByteBufferCleaner.class);
+             InputStream stream = MemoryMappedFileInputStream.builder().setPath(file).setClean(true).get()) {
+            stream.close();
+            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)));
+        }
+    }
+
+    @Test
+    void testCleanCalledNever() throws Exception {
+        // setup
+        final Path file = createTestFile(100);
+        final byte[] expectedData = Files.readAllBytes(file);
+        // test
+        final boolean expectedCleanOnClose = false;
+        try (MockedStatic<ByteBufferCleaner> mocked = Mockito.mockStatic(ByteBufferCleaner.class);
+                InputStream stream = MemoryMappedFileInputStream.builder().setPath(file).setClean(false).get()) {
+            stream.close();
+            mocked.verify(() -> ByteBufferCleaner.clean(any(ByteBuffer.class)), never());
+        }
+    }
 }

--- a/src/test/java/org/apache/commons/io/input/MemoryMappedFileInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/MemoryMappedFileInputStreamTest.java
@@ -334,7 +334,6 @@ class MemoryMappedFileInputStreamTest {
         final Path file = createTestFile(100);
         final byte[] expectedData = Files.readAllBytes(file);
         // test
-        final boolean expectedCleanOnClose = true;
         try (MockedStatic<ByteBufferCleaner> mocked = Mockito.mockStatic(ByteBufferCleaner.class);
              InputStream stream = MemoryMappedFileInputStream.builder().setPath(file).setClean(true).get()) {
             stream.close();
@@ -348,7 +347,6 @@ class MemoryMappedFileInputStreamTest {
         final Path file = createTestFile(100);
         final byte[] expectedData = Files.readAllBytes(file);
         // test
-        final boolean expectedCleanOnClose = false;
         try (MockedStatic<ByteBufferCleaner> mocked = Mockito.mockStatic(ByteBufferCleaner.class);
                 InputStream stream = MemoryMappedFileInputStream.builder().setPath(file).setClean(false).get()) {
             stream.close();


### PR DESCRIPTION
In Java 23+, ByteBufferCleaner should check for access to deprecated memory-access methods in sun.misc.Unsafe

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Not used
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
