### PR TITLE
Add FileCleaningTracker.exitWhenFinishedTest()

### DIFF
--- a/src/main/java/org/apache/commons/io/FileCleaningTracker.java
+++ b/src/main/java/org/apache/commons/io/FileCleaningTracker.java
@@ -221,6 +221,17 @@ public class FileCleaningTracker {
     }
 
     /**
+     * Tests whether {@link #exitWhenFinished()} has been called, and therefore whether the file cleaner thread will terminate when there are no more objects
+     * being tracked for deletion.
+     *
+     * @return {@code true} if {@link #exitWhenFinished()} has been called, {@code false} otherwise.
+     * @since 2.23.0
+     */
+    public synchronized boolean exitWhenFinishedTest() {
+        return exitWhenFinished;
+    }
+
+    /**
      * Gets a copy of the file paths that failed to delete.
      *
      * @return A copy of the file paths that failed to delete.

--- a/src/test/java/org/apache/commons/io/FileCleaningTrackerTest.java
+++ b/src/test/java/org/apache/commons/io/FileCleaningTrackerTest.java
@@ -116,6 +116,42 @@ class FileCleaningTrackerTest extends AbstractTempDirTest {
     }
 
     @Test
+    void testExitWhenFinishedTestMatchesField() {
+        // Before calling exitWhenFinished()
+        assertEquals(fileCleaningTracker.exitWhenFinished, fileCleaningTracker.exitWhenFinishedTest(),
+                "exitWhenFinishedTest() must reflect the exitWhenFinished field (before)");
+        fileCleaningTracker.exitWhenFinished();
+        // After calling exitWhenFinished()
+        assertEquals(fileCleaningTracker.exitWhenFinished, fileCleaningTracker.exitWhenFinishedTest(),
+                "exitWhenFinishedTest() must reflect the exitWhenFinished field (after)");
+    }
+
+    @Test
+    void testExitWhenFinishedTestReturnsFalseInitially() {
+        assertFalse(fileCleaningTracker.exitWhenFinishedTest(), "exitWhenFinishedTest() should return false before exitWhenFinished() is called");
+    }
+
+    @Test
+    void testExitWhenFinishedTestReturnsTrueAfterExitWhenFinished() {
+        fileCleaningTracker.exitWhenFinished();
+        assertTrue(fileCleaningTracker.exitWhenFinishedTest(), "exitWhenFinishedTest() should return true after exitWhenFinished() is called");
+    }
+
+    @Test
+    void testExitWhenFinishedTestWithActiveReaper() throws Exception {
+        final String path = testFile.getPath();
+        // Start the reaper by tracking a file
+        final RandomAccessFile raf = createRandomAccessFile();
+        fileCleaningTracker.track(path, raf);
+        assertFalse(fileCleaningTracker.exitWhenFinishedTest(), "exitWhenFinishedTest() should return false while reaper is still active");
+        assertTrue(fileCleaningTracker.reaper.isAlive(), "Reaper should be alive");
+        fileCleaningTracker.exitWhenFinished();
+        assertTrue(fileCleaningTracker.exitWhenFinishedTest(),
+                "exitWhenFinishedTest() should return true after exitWhenFinished() is called with active reaper");
+        raf.close();
+    }
+
+    @Test
     void testFileCleanerDirectory_ForceStrategy_FileSource() throws Exception {
         if (!testFile.getParentFile().exists()) {
             throw new IOException("Cannot create file " + testFile + " as the parent directory does not exist");


### PR DESCRIPTION
Add `FileCleaningTracker.exitWhenFinishedTest()`.

Used in tests, for example, Commons FileUpload.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create the first cut of the unit tests; Claude Sonet 4.6 Medium.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
