### PR TITLE
Buffers.clear(...) only zeros the buffer's own window of the backing array

### DIFF
--- a/src/main/java/org/apache/commons/io/Buffers.java
+++ b/src/main/java/org/apache/commons/io/Buffers.java
@@ -86,7 +86,7 @@ public final class Buffers {
             return null;
         }
         if (clearBuffer(buffer).hasArray()) {
-            Arrays.fill(buffer.array(), (byte) 0);
+            Arrays.fill(buffer.array(), buffer.arrayOffset(), buffer.arrayOffset() + buffer.capacity(), (byte) 0);
         } else {
             final byte[] zeros = new byte[IOUtils.DEFAULT_BUFFER_SIZE];
             while (buffer.hasRemaining()) {
@@ -108,7 +108,7 @@ public final class Buffers {
             return null;
         }
         if (clearBuffer(buffer).hasArray()) {
-            Arrays.fill(buffer.array(), (char) 0);
+            Arrays.fill(buffer.array(), buffer.arrayOffset(), buffer.arrayOffset() + buffer.capacity(), (char) 0);
         } else {
             final char[] zeros = new char[IOUtils.DEFAULT_BUFFER_SIZE];
             while (buffer.hasRemaining()) {
@@ -130,7 +130,7 @@ public final class Buffers {
             return null;
         }
         if (clearBuffer(buffer).hasArray()) {
-            Arrays.fill(buffer.array(), 0);
+            Arrays.fill(buffer.array(), buffer.arrayOffset(), buffer.arrayOffset() + buffer.capacity(), 0);
         } else {
             final double[] zeros = new double[IOUtils.DEFAULT_BUFFER_SIZE];
             while (buffer.hasRemaining()) {
@@ -152,7 +152,7 @@ public final class Buffers {
             return null;
         }
         if (clearBuffer(buffer).hasArray()) {
-            Arrays.fill(buffer.array(), 0);
+            Arrays.fill(buffer.array(), buffer.arrayOffset(), buffer.arrayOffset() + buffer.capacity(), 0);
         } else {
             final float[] zeros = new float[IOUtils.DEFAULT_BUFFER_SIZE];
             while (buffer.hasRemaining()) {
@@ -174,7 +174,7 @@ public final class Buffers {
             return null;
         }
         if (clearBuffer(buffer).hasArray()) {
-            Arrays.fill(buffer.array(), 0);
+            Arrays.fill(buffer.array(), buffer.arrayOffset(), buffer.arrayOffset() + buffer.capacity(), 0);
         } else {
             final int[] zeros = new int[IOUtils.DEFAULT_BUFFER_SIZE];
             while (buffer.hasRemaining()) {
@@ -196,7 +196,7 @@ public final class Buffers {
             return null;
         }
         if (clearBuffer(buffer).hasArray()) {
-            Arrays.fill(buffer.array(), 0);
+            Arrays.fill(buffer.array(), buffer.arrayOffset(), buffer.arrayOffset() + buffer.capacity(), 0);
         } else {
             final long[] zeros = new long[IOUtils.DEFAULT_BUFFER_SIZE];
             while (buffer.hasRemaining()) {
@@ -218,7 +218,7 @@ public final class Buffers {
             return null;
         }
         if (clearBuffer(buffer).hasArray()) {
-            Arrays.fill(buffer.array(), (short) 0);
+            Arrays.fill(buffer.array(), buffer.arrayOffset(), buffer.arrayOffset() + buffer.capacity(), (short) 0);
         } else {
             final short[] zeros = new short[IOUtils.DEFAULT_BUFFER_SIZE];
             while (buffer.hasRemaining()) {

--- a/src/test/java/org/apache/commons/io/BuffersTest.java
+++ b/src/test/java/org/apache/commons/io/BuffersTest.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.io;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -29,6 +30,7 @@ import java.nio.FloatBuffer;
 import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.nio.ShortBuffer;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 
@@ -176,6 +178,26 @@ public class BuffersTest {
     }
 
     /**
+     * Tests {@link Buffers#clear(ByteBuffer)} on a slice: only the slice's own window of the backing array is zeroed.
+     */
+    @Test
+    void testClearByteBufferArrayBackedSlice() {
+        final byte[] backing = new byte[CAPACITY];
+        Arrays.fill(backing, (byte) 1);
+        final ByteBuffer parent = ByteBuffer.wrap(backing);
+        parent.position(2);
+        parent.limit(5);
+        final ByteBuffer slice = parent.slice();
+        assertEquals(2, slice.arrayOffset());
+        assertEquals(3, slice.capacity());
+        final ByteBuffer result = Buffers.clear(slice);
+        assertSame(slice, result);
+        assertEquals(0, result.position());
+        assertEquals(3, result.limit());
+        assertArrayEquals(new byte[] { 1, 1, 0, 0, 0, 1, 1, 1 }, backing);
+    }
+
+    /**
      * Tests {@link Buffers#clear(ByteBuffer)} with a direct buffer.
      */
     @Test
@@ -224,6 +246,26 @@ public class BuffersTest {
         for (int i = 0; i < CAPACITY; i++) {
             assertEquals(0, result.get(i));
         }
+    }
+
+    /**
+     * Tests {@link Buffers#clear(CharBuffer)} on a slice: only the slice's own window of the backing array is zeroed.
+     */
+    @Test
+    void testClearCharBufferArrayBackedSlice() {
+        final char[] backing = new char[CAPACITY];
+        Arrays.fill(backing, 'a');
+        final CharBuffer parent = CharBuffer.wrap(backing);
+        parent.position(2);
+        parent.limit(5);
+        final CharBuffer slice = parent.slice();
+        assertEquals(2, slice.arrayOffset());
+        assertEquals(3, slice.capacity());
+        final CharBuffer result = Buffers.clear(slice);
+        assertSame(slice, result);
+        assertEquals(0, result.position());
+        assertEquals(3, result.limit());
+        assertArrayEquals(new char[] { 'a', 'a', 0, 0, 0, 'a', 'a', 'a' }, backing);
     }
 
     /**
@@ -449,6 +491,26 @@ public class BuffersTest {
     }
 
     /**
+     * Tests {@link Buffers#clear(IntBuffer)} on a slice: only the slice's own window of the backing array is zeroed.
+     */
+    @Test
+    void testClearIntBufferArrayBackedSlice() {
+        final int[] backing = new int[CAPACITY];
+        Arrays.fill(backing, 1);
+        final IntBuffer parent = IntBuffer.wrap(backing);
+        parent.position(2);
+        parent.limit(5);
+        final IntBuffer slice = parent.slice();
+        assertEquals(2, slice.arrayOffset());
+        assertEquals(3, slice.capacity());
+        final IntBuffer result = Buffers.clear(slice);
+        assertSame(slice, result);
+        assertEquals(0, result.position());
+        assertEquals(3, result.limit());
+        assertArrayEquals(new int[] { 1, 1, 0, 0, 0, 1, 1, 1 }, backing);
+    }
+
+    /**
      * Tests {@link Buffers#clear(IntBuffer)} with a direct (view) buffer.
      */
     @Test
@@ -550,6 +612,26 @@ public class BuffersTest {
         for (int i = 0; i < CAPACITY; i++) {
             assertEquals((short) 0, result.get(i));
         }
+    }
+
+    /**
+     * Tests {@link Buffers#clear(ShortBuffer)} on a slice: only the slice's own window of the backing array is zeroed.
+     */
+    @Test
+    void testClearShortBufferArrayBackedSlice() {
+        final short[] backing = new short[CAPACITY];
+        Arrays.fill(backing, (short) 1);
+        final ShortBuffer parent = ShortBuffer.wrap(backing);
+        parent.position(2);
+        parent.limit(5);
+        final ShortBuffer slice = parent.slice();
+        assertEquals(2, slice.arrayOffset());
+        assertEquals(3, slice.capacity());
+        final ShortBuffer result = Buffers.clear(slice);
+        assertSame(slice, result);
+        assertEquals(0, result.position());
+        assertEquals(3, result.limit());
+        assertArrayEquals(new short[] { 1, 1, 0, 0, 0, 1, 1, 1 }, backing);
     }
 
     /**


### PR DESCRIPTION
## What

`Buffers.clear(XBuffer)` promises to clear *this* buffer. For array-backed buffers it does more than that: every overload calls

```java
Arrays.fill(buffer.array(), 0);
```

`array()` returns the whole backing array, so `arrayOffset()` and `capacity()` are ignored. A buffer returned by `slice()` shares its parent's array at a non-zero offset, so clearing a slice also zeros bytes that belong to the parent and are outside the slice.

The direct branch of the same method is correct, because it writes zeros through the buffer and therefore respects the window. So the two branches of one method disagree.

## Reproduction

JDK 17, `master` at eb60bd5, 10-element heap array filled with `7`, slice over `[4, 7)`:

```java
byte[] backing = new byte[10];
Arrays.fill(backing, (byte) 7);
ByteBuffer parent = ByteBuffer.wrap(backing);
parent.position(4);
parent.limit(7);
ByteBuffer slice = parent.slice();   // capacity 3, arrayOffset 4

Buffers.clear(slice);
```

| path | result |
| --- | --- |
| array-backed slice | `[0, 0, 0, 0, 0, 0, 0, 0, 0, 0]` |
| same test with `allocateDirect` | `[7, 7, 7, 7, 0, 0, 0, 7, 7, 7]` |

The direct result is what the Javadoc describes.

## Change

`clearBuffer()` has already set the position to zero and the limit to the capacity, so the region that belongs to this buffer is `[arrayOffset(), arrayOffset() + capacity())`. This switches the seven array-backed branches to the ranged `Arrays.fill()` overload. Buffers with `arrayOffset() == 0` are unaffected, which covers everything `allocate()` and `wrap()` produce, and the direct branches are untouched.

`Buffers` is new in 2.23.0 and is not released yet, and the only in-tree callers go through `clearDirect(...)`, so this does not change behavior anyone can be depending on today.

## Tests

Four regression tests in `BuffersTest` (byte, char, int, short, covering each cast variant of the fill). Verified they are load-bearing:

- with the change: `Tests run: 61, Failures: 0, Errors: 0, Skipped: 0`
- with `Buffers.java` reverted: `Tests run: 61, Failures: 4`

Full default goal (`mvn`, so rat, checkstyle, japicmp, spotbugs, pmd and javadoc included): `BUILD SUCCESS`, `Tests run: 6414, Failures: 0, Errors: 0, Skipped: 36`.

---

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
  - Tool: Claude Code (Anthropic), running as an autonomous contribution workflow.
  - Extent: all of it. The defect was found by diffing the `@since 2.23.0` Javadoc contracts against the implementations, and the probe, the patch, the tests and this description were written by the tool.
  - Verification: every number quoted above comes from a run on this machine, not from the model. The probe was executed before and after the patch, and the reverted-source run is how the four tests were confirmed to fail without the change.
  - Human oversight: none before submission. Please review it as unreviewed work. I will answer any question about the change on this thread.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
