### PR TITLE
IO-892: Add maximum traversal depth to FileAlterationObserver

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -62,6 +62,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="fix" dev="ggregory" due-to="Gary Gregory">DeferredFileOutputStream better NPE message and new file permission tests (#862).</action>
       <action type="fix" dev="ggregory" due-to="Gary Gregory">Add messages when throwing NullPointerException.</action>
       <!-- ADD -->
+      <action type="add" due-to="bart" issue="IO-892">Add FileAlterationObserver.Builder.setMaxDepth(int) to limit directory traversal depth.</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add IOConsumer.accept(IOConsumer, T) (#846).</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add UnsynchronizedBufferedReader.unwrap() (#850).</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add UnsynchronizedBufferedReader.getPosition() (#851).</action>

--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -62,7 +62,7 @@ The <action> type attribute can be add,update,fix,remove.
       <action type="fix" dev="ggregory" due-to="Gary Gregory">DeferredFileOutputStream better NPE message and new file permission tests (#862).</action>
       <action type="fix" dev="ggregory" due-to="Gary Gregory">Add messages when throwing NullPointerException.</action>
       <!-- ADD -->
-      <action type="add" due-to="bart" issue="IO-892">Add FileAlterationObserver.Builder.setMaxDepth(int) to limit directory traversal depth.</action>
+      <action type="add" dev="ggregory" due-to="bart" issue="IO-892">Add FileAlterationObserver.Builder.setMaxDepth(int) to limit directory traversal depth.</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add IOConsumer.accept(IOConsumer, T) (#846).</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add UnsynchronizedBufferedReader.unwrap() (#850).</action>
       <action type="add" dev="ggregory" due-to="Gary Gregory">Add UnsynchronizedBufferedReader.getPosition() (#851).</action>

--- a/src/main/java/org/apache/commons/io/monitor/FileAlterationObserver.java
+++ b/src/main/java/org/apache/commons/io/monitor/FileAlterationObserver.java
@@ -116,6 +116,12 @@ import org.apache.commons.io.filefilter.TrueFileFilter;
  * {@link FileEntry} can be used to capture additional properties that the basic implementation does not support. The {@link FileEntry#refresh(File)} method is
  * used to determine if a file or directory has changed since the last check and stores the current state of the {@link File}'s properties.
  * </p>
+ * <h2>Maximum Depth</h2>
+ * <p>
+ * Use {@link Builder#setMaxDepth(int)} to limit the depth of entries monitored below the root directory. The root directory has depth 0. Setting the maximum
+ * depth to 0 prevents listing any entries below the root. At greater depths, entries at the maximum depth are monitored, but their children are not listed and
+ * no events are generated for those children. The default is {@link Integer#MAX_VALUE}, which preserves full recursive monitoring.
+ * </p>
  * <h2>Deprecating Serialization</h2>
  * <p>
  * <em>Serialization is deprecated and will be removed in 3.0. Consider using a serialization proxy.</em>
@@ -139,6 +145,8 @@ public class FileAlterationObserver implements Serializable {
         private FileFilter fileFilter;
 
         private IOCase ioCase;
+
+        private int maxDepth = Integer.MAX_VALUE;
 
         private Builder() {
             // empty
@@ -178,6 +186,26 @@ public class FileAlterationObserver implements Serializable {
          */
         public Builder setIOCase(final IOCase ioCase) {
             this.ioCase = ioCase;
+            return asThis();
+        }
+
+        /**
+         * Sets the maximum depth of entries to monitor below the root directory. The root directory has depth 0.
+         * <p>
+         * Setting {@code maxDepth} to 0 prevents listing any entries below the root. At greater depths, entries at {@code maxDepth} are monitored, but their
+         * children are not listed and no events are generated for those children.
+         * </p>
+         *
+         * @param maxDepth the maximum depth, must not be negative.
+         * @return This instance.
+         * @throws IllegalArgumentException if {@code maxDepth} is negative.
+         * @since 2.23.0
+         */
+        public Builder setMaxDepth(final int maxDepth) {
+            if (maxDepth < 0) {
+                throw new IllegalArgumentException("maxDepth must not be negative");
+            }
+            this.maxDepth = maxDepth;
             return asThis();
         }
 
@@ -236,8 +264,14 @@ public class FileAlterationObserver implements Serializable {
      */
     private final Comparator<File> comparator;
 
+    /**
+     * The maximum depth of entries to monitor.
+     */
+    private final Integer maxDepth;
+
     private FileAlterationObserver(final Builder builder) {
-        this(builder.rootEntry != null ? builder.rootEntry : new FileEntry(builder.checkOriginFile()), builder.fileFilter, toComparator(builder.ioCase));
+        this(builder.rootEntry != null ? builder.rootEntry : new FileEntry(builder.checkOriginFile()), builder.fileFilter, toComparator(builder.ioCase),
+                builder.maxDepth);
     }
 
     /**
@@ -284,11 +318,24 @@ public class FileAlterationObserver implements Serializable {
      * @param comparator How to compare files.
      */
     private FileAlterationObserver(final FileEntry rootEntry, final FileFilter fileFilter, final Comparator<File> comparator) {
+        this(rootEntry, fileFilter, comparator, Integer.MAX_VALUE);
+    }
+
+    /**
+     * Constructs an observer for the specified directory, file filter, file comparator and maximum depth.
+     *
+     * @param rootEntry  The root directory to observe.
+     * @param fileFilter The file filter or null if none.
+     * @param comparator How to compare files.
+     * @param maxDepth   The maximum depth of entries to monitor.
+     */
+    private FileAlterationObserver(final FileEntry rootEntry, final FileFilter fileFilter, final Comparator<File> comparator, final int maxDepth) {
         Objects.requireNonNull(rootEntry, "rootEntry");
         Objects.requireNonNull(rootEntry.getFile(), "rootEntry.getFile()");
         this.rootEntry = rootEntry;
         this.fileFilter = fileFilter != null ? fileFilter : TrueFileFilter.INSTANCE;
         this.comparator = Objects.requireNonNull(comparator, "comparator");
+        this.maxDepth = maxDepth;
     }
 
     /**
@@ -367,7 +414,7 @@ public class FileAlterationObserver implements Serializable {
             }
             if (c < currentEntries.length && comparator.compare(previousEntry.getFile(), currentEntries[c]) == 0) {
                 fireOnChange(previousEntry, currentEntries[c]);
-                checkAndFire(previousEntry, previousEntry.getChildren(), listFiles(currentEntries[c]));
+                checkAndFire(previousEntry, previousEntry.getChildren(), listFiles(currentEntries[c], previousEntry));
                 actualEntries[c] = previousEntry;
                 c++;
             } else {
@@ -393,7 +440,7 @@ public class FileAlterationObserver implements Serializable {
         // fire directory/file events
         final File rootFile = rootEntry.getFile();
         if (rootFile.exists()) {
-            checkAndFire(rootEntry, rootEntry.getChildren(), listFiles(rootFile));
+            checkAndFire(rootEntry, rootEntry.getChildren(), listFiles(rootFile, rootEntry));
         } else if (rootEntry.isExists()) {
             checkAndFire(rootEntry, rootEntry.getChildren(), FileUtils.EMPTY_FILE_ARRAY);
         }
@@ -509,6 +556,17 @@ public class FileAlterationObserver implements Serializable {
     }
 
     /**
+     * Gets the maximum depth of entries to monitor. The root directory has depth 0.
+     *
+     * @return The maximum depth.
+     * @since 2.23.0
+     */
+    public int getMaxDepth() {
+        // A null value preserves unlimited recursion when deserializing streams written before this field was added.
+        return maxDepth != null ? maxDepth : Integer.MAX_VALUE;
+    }
+
+    /**
      * Initializes the observer.
      *
      * @throws Exception Thrown if an error occurs.
@@ -527,7 +585,19 @@ public class FileAlterationObserver implements Serializable {
      * @return The child file entries.
      */
     private FileEntry[] listFileEntries(final File file, final FileEntry entry) {
-        return Stream.of(listFiles(file)).map(f -> createFileEntry(entry, f)).toArray(FileEntry[]::new);
+        return Stream.of(listFiles(file, entry)).map(f -> createFileEntry(entry, f)).toArray(FileEntry[]::new);
+    }
+
+    /**
+     * Lists the contents of a directory when the parent entry is below the maximum depth.
+     *
+     * @param directory The directory to list.
+     * @param entry     The directory entry.
+     * @return The directory contents or a zero length array if the maximum depth is reached.
+     */
+    private File[] listFiles(final File directory, final FileEntry entry) {
+        final int depth = entry.getLevel() - rootEntry.getLevel();
+        return depth < getMaxDepth() ? listFiles(directory) : FileUtils.EMPTY_FILE_ARRAY;
     }
 
     /**

--- a/src/main/java/org/apache/commons/io/monitor/FileAlterationObserver.java
+++ b/src/main/java/org/apache/commons/io/monitor/FileAlterationObserver.java
@@ -267,7 +267,7 @@ public class FileAlterationObserver implements Serializable {
     /**
      * The maximum depth of entries to monitor.
      */
-    private final Integer maxDepth;
+    private final int maxDepth;
 
     private FileAlterationObserver(final Builder builder) {
         this(builder.rootEntry != null ? builder.rootEntry : new FileEntry(builder.checkOriginFile()), builder.fileFilter, toComparator(builder.ioCase),
@@ -562,8 +562,7 @@ public class FileAlterationObserver implements Serializable {
      * @since 2.23.0
      */
     public int getMaxDepth() {
-        // A null value preserves unlimited recursion when deserializing streams written before this field was added.
-        return maxDepth != null ? maxDepth : Integer.MAX_VALUE;
+        return maxDepth;
     }
 
     /**
@@ -589,7 +588,7 @@ public class FileAlterationObserver implements Serializable {
     }
 
     /**
-     * Lists the contents of a directory when the parent entry is below the maximum depth.
+     * Lists the contents of a directory when its entry is below the maximum depth.
      *
      * @param directory The directory to list.
      * @param entry     The directory entry.

--- a/src/test/java/org/apache/commons/io/monitor/FileAlterationObserverTest.java
+++ b/src/test/java/org/apache/commons/io/monitor/FileAlterationObserverTest.java
@@ -18,11 +18,13 @@ package org.apache.commons.io.monitor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
 
 import org.apache.commons.io.FileUtils;
@@ -32,12 +34,37 @@ import org.apache.commons.io.comparator.NameFileComparator;
 import org.apache.commons.io.filefilter.CanReadFileFilter;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.monitor.FileAlterationObserver.Builder;
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.jupiter.api.Test;
 
 /**
  * {@link FileAlterationObserver} Test Case.
  */
 class FileAlterationObserverTest extends AbstractMonitorTest {
+
+    private static final class CountingFile extends File {
+
+        private static final long serialVersionUID = 1L;
+
+        private final File[] children;
+
+        private int listFilesCount;
+
+        private CountingFile(final File file, final File... children) {
+            super(file.getPath());
+            this.children = children;
+        }
+
+        int getListFilesCount() {
+            return listFilesCount;
+        }
+
+        @Override
+        public File[] listFiles(final FileFilter filter) {
+            listFilesCount++;
+            return Arrays.stream(children).filter(filter::accept).toArray(File[]::new);
+        }
+    }
 
     private static final String PATH_STRING_FIXTURE = "/foo";
 
@@ -117,6 +144,24 @@ class FileAlterationObserverTest extends AbstractMonitorTest {
         assertEquals(file, observer.getDirectory());
         assertEquals(CanReadFileFilter.CAN_READ, observer.getFileFilter());
         assertEquals(NameFileComparator.NAME_INSENSITIVE_COMPARATOR, observer.getComparator());
+    }
+
+    @Test
+    void testBuilder_MaxDepth() {
+        final FileAlterationObserver observer = FileAlterationObserver.builder().setFile(PATH_STRING_FIXTURE).setMaxDepth(2).getUnchecked();
+        assertEquals(2, observer.getMaxDepth());
+    }
+
+    @Test
+    void testBuilder_MaxDepthDefault() {
+        final FileAlterationObserver observer = FileAlterationObserver.builder().setFile(PATH_STRING_FIXTURE).getUnchecked();
+        assertEquals(Integer.MAX_VALUE, observer.getMaxDepth());
+    }
+
+    @Test
+    void testBuilder_MaxDepthNegative() {
+        final Builder builder = FileAlterationObserver.builder();
+        assertThrows(IllegalArgumentException.class, () -> builder.setMaxDepth(-1));
     }
 
     @Test
@@ -266,6 +311,94 @@ class FileAlterationObserverTest extends AbstractMonitorTest {
 
         checkAndNotify();
         checkCollectionsEmpty("G");
+    }
+
+    @Test
+    void testMaxDepthDoesNotListChildrenAtBoundary() throws Exception {
+        final File deepFile = touch(new File(testDir, "boundary/deep.txt"));
+        final CountingFile boundaryDirectory = new CountingFile(deepFile.getParentFile(), deepFile);
+        final CountingFile rootDirectory = new CountingFile(testDir, boundaryDirectory);
+        final FileAlterationObserver depthLimitedObserver = FileAlterationObserver.builder().setFile(rootDirectory).setMaxDepth(1).getUnchecked();
+        depthLimitedObserver.initialize();
+
+        depthLimitedObserver.checkAndNotify();
+        depthLimitedObserver.checkAndNotify();
+        depthLimitedObserver.checkAndNotify();
+
+        assertEquals(0, boundaryDirectory.getListFilesCount());
+    }
+
+    @Test
+    void testMaxDepthIgnoresEventsBelowBoundary() throws Exception {
+        final File boundaryDirectory = new File(testDir, "boundary");
+        assertTrue(boundaryDirectory.mkdir());
+        final CollectionFileListener depthLimitedListener = new CollectionFileListener(true);
+        final FileAlterationObserver depthLimitedObserver = FileAlterationObserver.builder().setFile(testDir).setMaxDepth(1).getUnchecked();
+        depthLimitedObserver.addListener(depthLimitedListener);
+        depthLimitedObserver.initialize();
+
+        final File deepFile = touch(new File(boundaryDirectory, "deep.txt"));
+        depthLimitedObserver.checkAndNotify();
+        assertTrue(deepFile.exists());
+        assertTrue(depthLimitedListener.getCreatedFiles().isEmpty());
+
+        touch(deepFile);
+        depthLimitedObserver.checkAndNotify();
+        assertTrue(depthLimitedListener.getChangedFiles().isEmpty());
+
+        assertTrue(deepFile.delete());
+        depthLimitedObserver.checkAndNotify();
+        assertTrue(depthLimitedListener.getDeletedFiles().isEmpty());
+    }
+
+    @Test
+    void testMaxDepthMonitorsBoundaryDirectory() throws Exception {
+        final CollectionFileListener depthLimitedListener = new CollectionFileListener(true);
+        final FileAlterationObserver depthLimitedObserver = FileAlterationObserver.builder().setFile(testDir).setMaxDepth(1).getUnchecked();
+        depthLimitedObserver.addListener(depthLimitedListener);
+        depthLimitedObserver.initialize();
+
+        final File boundaryDirectory = new File(testDir, "boundary");
+        assertTrue(boundaryDirectory.mkdir());
+        depthLimitedObserver.checkAndNotify();
+        assertTrue(depthLimitedListener.getCreatedDirectories().contains(boundaryDirectory));
+
+        FileUtils.deleteDirectory(boundaryDirectory);
+        depthLimitedObserver.checkAndNotify();
+        assertTrue(depthLimitedListener.getDeletedDirectories().contains(boundaryDirectory));
+    }
+
+    @Test
+    void testMaxDepthSerialization() {
+        final FileAlterationObserver expected = FileAlterationObserver.builder().setFile(PATH_STRING_FIXTURE).setMaxDepth(2).getUnchecked();
+        final FileAlterationObserver actual = SerializationUtils.roundtrip(expected);
+        assertEquals(expected.getMaxDepth(), actual.getMaxDepth());
+    }
+
+    @Test
+    void testMaxDepthZeroDoesNotListRootChildren() throws Exception {
+        final File child = touch(new File(testDir, "child.txt"));
+        final CountingFile rootDirectory = new CountingFile(testDir, child);
+        final FileAlterationObserver depthLimitedObserver = FileAlterationObserver.builder().setFile(rootDirectory).setMaxDepth(0).getUnchecked();
+        depthLimitedObserver.initialize();
+
+        depthLimitedObserver.checkAndNotify();
+
+        assertEquals(0, rootDirectory.getListFilesCount());
+    }
+
+    @Test
+    void testMaxDepthZeroWithCustomRootEntry() throws Exception {
+        final File child = touch(new File(testDir, "child.txt"));
+        final CountingFile rootDirectory = new CountingFile(testDir, child);
+        final FileEntry parentEntry = new FileEntry(testDir.getParentFile());
+        final FileEntry rootEntry = new FileEntry(parentEntry, rootDirectory);
+        final FileAlterationObserver depthLimitedObserver = FileAlterationObserver.builder().setRootEntry(rootEntry).setMaxDepth(0).getUnchecked();
+        depthLimitedObserver.initialize();
+
+        depthLimitedObserver.checkAndNotify();
+
+        assertEquals(0, rootDirectory.getListFilesCount());
     }
 
     /**


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements. See the NOTICE file distributed with
 this work for additional information regarding copyright ownership.
 The ASF licenses this file to you under the Apache License, Version 2.0.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)!

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html).
- [x] I used AI to create part of this pull request. OpenAI Codex assisted with analysis, implementation, tests, local verification, and preparation of this description.
- [ ] Run a successful build using the default Maven goal with `mvn`.
- [x] Write unit tests that match behavioral changes.
- [x] Write a detailed pull request description.
- [x] Each commit has a meaningful subject line and body.

## Summary

This PR adds an optional maximum traversal depth to `FileAlterationObserver` through `Builder.setMaxDepth(int)`.

The observed root has depth 0. Setting `maxDepth` to 0 prevents listing entries below the root. At greater depths, entries at `maxDepth` are monitored, but their children are not listed and do not generate events.

The default remains `Integer.MAX_VALUE`, so existing builder usage and deprecated constructors preserve full recursive monitoring. The depth limit applies during both initialization and every `checkAndNotify()` cycle.

## Why this is not a FileFilter

A regular `FileFilter` cannot provide the same traversal behavior. `FileAlterationObserver` calls `directory.listFiles(fileFilter)`, so a depth-aware filter would still enumerate every child in a boundary directory. It also cannot express "monitor this directory but do not descend into it" with one boolean result.

This implementation checks the depth boundary before invoking `listFiles()`.

## Tests

Tests cover default compatibility, invalid values, boundary directory events, ignored events below the boundary, repeated check cycles, verification that `listFiles()` is not called below the boundary, custom root entries, and serialization round trips.

Local Windows/NTFS results for 100,000 files below a depth-1 boundary:

| Mode | Initialize | Steady check average |
| --- | ---: | ---: |
| Unlimited | 9069.894 ms | 8772.802 ms |
| `maxDepth=1` | 126.719 ms | 16.517 ms |

Verification completed successfully:

- `mvn -q "-Dtest=FileAlterationObserverTest,FileEntryTest,FileAlterationMonitorTest" test`
- `mvn -q -DskipTests checkstyle:check javadoc:javadoc package japicmp:cmp`
- `git diff --check origin/master...HEAD`

JIRA: https://issues.apache.org/jira/browse/IO-892
