### PR TITLE
[IO-892] Add maximum traversal depth to FileAlterationObserver.

### DIFF
--- a/src/main/java/org/apache/commons/io/monitor/FileAlterationObserver.java
+++ b/src/main/java/org/apache/commons/io/monitor/FileAlterationObserver.java
@@ -21,9 +21,16 @@ import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.file.FileVisitOption;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -137,9 +144,14 @@ public class FileAlterationObserver implements Serializable {
 
         private FileEntry rootEntry;
 
-        private FileFilter fileFilter;
+        private FileFilter fileFilter = TrueFileFilter.INSTANCE;
 
-        private IOCase ioCase;
+        private IOCase ioCase = IOCase.SYSTEM;
+
+        /**
+         * Defaults to max int for compatibility.
+         */
+        private int maxDepth = Integer.MAX_VALUE;
 
         private Builder() {
             // empty
@@ -167,7 +179,7 @@ public class FileAlterationObserver implements Serializable {
          * @return This instance.
          */
         public Builder setFileFilter(final FileFilter fileFilter) {
-            this.fileFilter = fileFilter;
+            this.fileFilter = fileFilter != null ? fileFilter : TrueFileFilter.INSTANCE;
             return asThis();
         }
 
@@ -178,7 +190,28 @@ public class FileAlterationObserver implements Serializable {
          * @return This instance.
          */
         public Builder setIOCase(final IOCase ioCase) {
-            this.ioCase = ioCase;
+            this.ioCase = ioCase != null ? ioCase : IOCase.SYSTEM;
+            return asThis();
+        }
+
+        /**
+         * Sets the maximum depth of entries to monitor below the root directory. The root directory has depth 0.
+         * <p>
+         * The {@code maxDepth} parameter is the maximum number of levels of directories to visit. A value of {@code 0} means that only the starting file is
+         * visited, unless denied by the security manager. A value of {@link Integer#MAX_VALUE MAX_VALUE} may be used to indicate that all levels should be
+         * visited, and is the default value.
+         * </p>
+         *
+         * @param maxDepth the maximum depth, must not be negative.
+         * @return This instance.
+         * @throws IllegalArgumentException if {@code maxDepth} is negative.
+         * @since 2.23.0
+         */
+        public Builder setMaxDepth(final int maxDepth) {
+            if (maxDepth < 0) {
+                throw new IllegalArgumentException("maxDepth must not be negative");
+            }
+            this.maxDepth = maxDepth;
             return asThis();
         }
 
@@ -233,12 +266,20 @@ public class FileAlterationObserver implements Serializable {
     private final transient FileFilter fileFilter;
 
     /**
+     * See {@link Files#walkFileTree(Path, java.util.Set, int, java.nio.file.FileVisitor)}.
+     */
+    private final int maxDepth;
+
+    /**
      * Compares file names.
      */
     private final Comparator<File> comparator;
 
     private FileAlterationObserver(final Builder builder) {
-        this(builder.rootEntry != null ? builder.rootEntry : new FileEntry(builder.checkOriginFile()), builder.fileFilter, toComparator(builder.ioCase));
+        this.rootEntry = builder.rootEntry != null ? builder.rootEntry : new FileEntry(builder.checkOriginFile());
+        this.fileFilter = builder.fileFilter;
+        this.comparator = toComparator(builder.ioCase);
+        this.maxDepth = builder.maxDepth;
     }
 
     /**
@@ -290,6 +331,7 @@ public class FileAlterationObserver implements Serializable {
         this.rootEntry = rootEntry;
         this.fileFilter = fileFilter != null ? fileFilter : TrueFileFilter.INSTANCE;
         this.comparator = Objects.requireNonNull(comparator, "comparator");
+        this.maxDepth = Integer.MAX_VALUE;
     }
 
     /**
@@ -516,6 +558,15 @@ public class FileAlterationObserver implements Serializable {
     }
 
     /**
+     * Gets the maximum depth of entries to monitor below the root directory. The root directory has depth 0.
+     *
+     * @return the maximum depth.
+     */
+    int getMaxDepth() {
+        return maxDepth;
+    }
+
+    /**
      * Initializes the observer.
      *
      * @throws Exception Thrown if an error occurs.
@@ -544,7 +595,47 @@ public class FileAlterationObserver implements Serializable {
      * @return The directory contents or a zero length array if the empty or the file is not a directory.
      */
     private File[] listFiles(final File directory) {
-        return directory.isDirectory() ? sort(directory.listFiles(fileFilter)) : FileUtils.EMPTY_FILE_ARRAY;
+        if (!directory.isDirectory()) {
+            return FileUtils.EMPTY_FILE_ARRAY;
+        }
+        final Path start = directory.toPath();
+        final List<File> files = new ArrayList<>();
+        try {
+            Files.walkFileTree(start, EnumSet.noneOf(FileVisitOption.class), maxDepth, new SimpleFileVisitor<Path>() {
+
+                private void filter(final List<File> files, final Path dir) {
+                    final File f = dir.toFile();
+                    if (fileFilter.accept(f)) {
+                        files.add(f);
+                    }
+                }
+
+                @Override
+                public FileVisitResult preVisitDirectory(final Path dir, final BasicFileAttributes attrs) throws IOException {
+                    if (!dir.equals(start)) {
+                        filter(files, dir);
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(final Path file, final BasicFileAttributes attrs) throws IOException {
+                    filter(files, file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFileFailed(final Path file, final IOException exc) throws IOException {
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (final IOException e) {
+            // ignore
+        }
+        // Walking visits the root directory, but we don't want to include it in the list of files.
+        files.remove(directory);
+        return sort(files.toArray(FileUtils.EMPTY_FILE_ARRAY));
     }
 
     /**

--- a/src/test/java/org/apache/commons/io/monitor/FileAlterationObserverTest.java
+++ b/src/test/java/org/apache/commons/io/monitor/FileAlterationObserverTest.java
@@ -18,11 +18,13 @@ package org.apache.commons.io.monitor;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Iterator;
 
 import org.apache.commons.io.FileUtils;
@@ -32,12 +34,37 @@ import org.apache.commons.io.comparator.NameFileComparator;
 import org.apache.commons.io.filefilter.CanReadFileFilter;
 import org.apache.commons.io.filefilter.FileFilterUtils;
 import org.apache.commons.io.monitor.FileAlterationObserver.Builder;
+import org.apache.commons.lang3.SerializationUtils;
 import org.junit.jupiter.api.Test;
 
 /**
  * {@link FileAlterationObserver} Test Case.
  */
 class FileAlterationObserverTest extends AbstractMonitorTest {
+
+    private static final class CountingFile extends File {
+
+        private static final long serialVersionUID = 1L;
+
+        private final File[] children;
+
+        private int listFilesCount;
+
+        private CountingFile(final File file, final File... children) {
+            super(file.getPath());
+            this.children = children;
+        }
+
+        int getListFilesCount() {
+            return listFilesCount;
+        }
+
+        @Override
+        public File[] listFiles(final FileFilter filter) {
+            listFilesCount++;
+            return Arrays.stream(children).filter(filter::accept).toArray(File[]::new);
+        }
+    }
 
     private static final String PATH_STRING_FIXTURE = "/foo";
 
@@ -117,6 +144,24 @@ class FileAlterationObserverTest extends AbstractMonitorTest {
         assertEquals(file, observer.getDirectory());
         assertEquals(CanReadFileFilter.CAN_READ, observer.getFileFilter());
         assertEquals(NameFileComparator.NAME_INSENSITIVE_COMPARATOR, observer.getComparator());
+    }
+
+    @Test
+    void testBuilder_MaxDepth() {
+        final FileAlterationObserver observer = FileAlterationObserver.builder().setFile(PATH_STRING_FIXTURE).setMaxDepth(2).getUnchecked();
+        assertEquals(2, observer.getMaxDepth());
+    }
+
+    @Test
+    void testBuilder_MaxDepthDefault() {
+        final FileAlterationObserver observer = FileAlterationObserver.builder().setFile(PATH_STRING_FIXTURE).getUnchecked();
+        assertEquals(Integer.MAX_VALUE, observer.getMaxDepth());
+    }
+
+    @Test
+    void testBuilder_MaxDepthNegative() {
+        final Builder builder = FileAlterationObserver.builder();
+        assertThrows(IllegalArgumentException.class, () -> builder.setMaxDepth(-1));
     }
 
     @Test
@@ -446,6 +491,83 @@ class FileAlterationObserverTest extends AbstractMonitorTest {
         checkAndNotify();
         checkCollectionSizes("F", 0, 1, 0, 0, 1, 0);
         assertTrue(listener.getChangedFiles().contains(testDirAFile5), "F testDirAFile5");
+    }
+
+    @Test
+    void testMaxDepthDoesNotListChildrenAtBoundary() throws Exception {
+        final File deepFile = touch(new File(testDir, "boundary/deep.txt"));
+        final CountingFile boundaryDirectory = new CountingFile(deepFile.getParentFile(), deepFile);
+        final CountingFile rootDirectory = new CountingFile(testDir, boundaryDirectory);
+        final FileAlterationObserver depthLimitedObserver = FileAlterationObserver.builder().setFile(rootDirectory).setMaxDepth(1).get();
+        depthLimitedObserver.initialize();
+        depthLimitedObserver.checkAndNotify();
+        depthLimitedObserver.checkAndNotify();
+        depthLimitedObserver.checkAndNotify();
+        assertEquals(0, boundaryDirectory.getListFilesCount());
+    }
+
+    @Test
+    void testMaxDepthIgnoresEventsBelowBoundary() throws Exception {
+        final File boundaryDirectory = new File(testDir, "boundary");
+        assertTrue(boundaryDirectory.mkdir());
+        final CollectionFileListener depthLimitedListener = new CollectionFileListener(true);
+        final FileAlterationObserver depthLimitedObserver = FileAlterationObserver.builder().setFile(testDir).setMaxDepth(0).get();
+        depthLimitedObserver.addListener(depthLimitedListener);
+        depthLimitedObserver.initialize();
+        final File deepFile = touch(new File(boundaryDirectory, "deep.txt"));
+        depthLimitedObserver.checkAndNotify();
+        assertTrue(deepFile.exists());
+        assertTrue(depthLimitedListener.getCreatedFiles().isEmpty());
+        touch(deepFile);
+        depthLimitedObserver.checkAndNotify();
+        assertTrue(depthLimitedListener.getChangedFiles().isEmpty());
+        assertTrue(deepFile.delete());
+        depthLimitedObserver.checkAndNotify();
+        assertTrue(depthLimitedListener.getDeletedFiles().isEmpty());
+    }
+
+    @Test
+    void testMaxDepthMonitorsBoundaryDirectory() throws Exception {
+        final CollectionFileListener depthLimitedListener = new CollectionFileListener(true);
+        final FileAlterationObserver depthLimitedObserver = FileAlterationObserver.builder().setFile(testDir).setMaxDepth(1).get();
+        depthLimitedObserver.addListener(depthLimitedListener);
+        depthLimitedObserver.initialize();
+        final File boundaryDirectory = new File(testDir, "boundary");
+        assertTrue(boundaryDirectory.mkdir());
+        depthLimitedObserver.checkAndNotify();
+        assertTrue(depthLimitedListener.getCreatedDirectories().contains(boundaryDirectory));
+        FileUtils.deleteDirectory(boundaryDirectory);
+        depthLimitedObserver.checkAndNotify();
+        assertTrue(depthLimitedListener.getDeletedDirectories().contains(boundaryDirectory));
+    }
+
+    @Test
+    void testMaxDepthSerialization() throws IOException {
+        final FileAlterationObserver expected = FileAlterationObserver.builder().setFile(PATH_STRING_FIXTURE).setMaxDepth(2).get();
+        final FileAlterationObserver actual = SerializationUtils.roundtrip(expected);
+        assertEquals(expected.getMaxDepth(), actual.getMaxDepth());
+    }
+
+    @Test
+    void testMaxDepthZeroDoesNotListRootChildren() throws Exception {
+        final File child = touch(new File(testDir, "child.txt"));
+        final CountingFile rootDirectory = new CountingFile(testDir, child);
+        final FileAlterationObserver depthLimitedObserver = FileAlterationObserver.builder().setFile(rootDirectory).setMaxDepth(0).get();
+        depthLimitedObserver.initialize();
+        depthLimitedObserver.checkAndNotify();
+        assertEquals(0, rootDirectory.getListFilesCount());
+    }
+
+    @Test
+    void testMaxDepthZeroWithCustomRootEntry() throws Exception {
+        final File child = touch(new File(testDir, "child.txt"));
+        final CountingFile rootDirectory = new CountingFile(testDir, child);
+        final FileEntry parentEntry = new FileEntry(testDir.getParentFile());
+        final FileEntry rootEntry = new FileEntry(parentEntry, rootDirectory);
+        final FileAlterationObserver depthLimitedObserver = FileAlterationObserver.builder().setRootEntry(rootEntry).setMaxDepth(0).get();
+        depthLimitedObserver.initialize();
+        depthLimitedObserver.checkAndNotify();
+        assertEquals(0, rootDirectory.getListFilesCount());
     }
 
     /**


### PR DESCRIPTION
This implementation reuses [Files.walkFileTree()](https://docs.oracle.com/en/java/javase/25/docs/api/java.base/java/nio/file/Files.html#walkFileTree(java.nio.file.Path,java.util.Set,int,java.nio.file.FileVisitor)) and its `maxDepth` feature instead of managing depth ourselves.

This is proposed as an alternative to #870.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create a part of this pull request: Meta Muse Glimmer.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
