### PR TITLE
Fix deleteQuietly handling for symlinked directories

### DIFF
--- a/src/main/java/org/apache/commons/io/FileUtils.java
+++ b/src/main/java/org/apache/commons/io/FileUtils.java
@@ -1302,7 +1302,7 @@ public class FileUtils {
             return false;
         }
         try {
-            if (file.isDirectory()) {
+            if (file.isDirectory() && !isSymlink(file)) {
                 cleanDirectory(file);
             }
         } catch (final Exception ignored) {

--- a/src/test/java/org/apache/commons/io/FileUtilsCleanSymlinksTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsCleanSymlinksTest.java
@@ -189,6 +189,30 @@ class FileUtilsCleanSymlinksTest {
     }
 
     @Test
+    void testDeleteQuietlyWithASymlinkDirDeletesOnlyLink() throws Exception {
+        if (SystemProperties.getOsName().startsWith("Win")) {
+            // Can't use "ln" for symlinks on the command line in Windows.
+            return;
+        }
+
+        final File randomDirectory = new File(top, "randomDir");
+        assertTrue(randomDirectory.mkdirs());
+
+        final File randomFile = new File(randomDirectory, "randomfile");
+        FileUtils.touch(randomFile);
+        assertEquals(1, randomDirectory.list().length);
+
+        final File symlinkDirectory = new File(top, "fakeDir");
+        assertTrue(setupSymlink(randomDirectory, symlinkDirectory));
+
+        assertTrue(FileUtils.deleteQuietly(symlinkDirectory));
+        assertFalse(symlinkDirectory.exists());
+        assertTrue(randomDirectory.exists());
+        assertTrue(randomFile.exists());
+        assertEquals(1, randomDirectory.list().length, "Contents of symbolic link should not have been removed");
+    }
+
+    @Test
     void testIdentifiesBrokenSymlinkFile() throws Exception {
         if (SystemProperties.getOsName().startsWith("Win")) {
             // Can't use "ln" for symlinks on the command line in Windows.

--- a/src/test/java/org/apache/commons/io/FileUtilsCleanSymlinksTest.java
+++ b/src/test/java/org/apache/commons/io/FileUtilsCleanSymlinksTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -206,7 +208,7 @@ class FileUtilsCleanSymlinksTest {
         assertTrue(setupSymlink(randomDirectory, symlinkDirectory));
 
         assertTrue(FileUtils.deleteQuietly(symlinkDirectory));
-        assertFalse(symlinkDirectory.exists());
+        assertFalse(Files.exists(symlinkDirectory.toPath(), LinkOption.NOFOLLOW_LINKS));
         assertTrue(randomDirectory.exists());
         assertTrue(randomFile.exists());
         assertEquals(1, randomDirectory.list().length, "Contents of symbolic link should not have been removed");


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

## Summary

This PR updates `FileUtils.deleteQuietly(File)` so that it does not clean the target contents when the input is a symbolic link to a directory.

Previously, `deleteQuietly()` checked `file.isDirectory()` and then called `cleanDirectory(file)` before deleting the file. On platforms where a symbolic link to a directory is treated as a directory, this could remove the contents of the symlink target before deleting the symlink itself.

`deleteDirectory()` already avoids this behavior by checking `!isSymlink(directory)` before cleaning directory contents. This PR applies the same safety check to `deleteQuietly()` for consistency.

## Change

Before:

```java
if (file.isDirectory()) {
    cleanDirectory(file);
}
```

After:

```java
if (file.isDirectory() && !isSymlink(file)) {
    cleanDirectory(file);
}
```

## Tests

Added a regression test that verifies all of the following:

- the symbolic-link directory entry itself is removed;
- the target directory still exists;
- the file inside the target directory is preserved.

The link assertion uses `Files.exists(path, LinkOption.NOFOLLOW_LINKS)` so it checks the link entry rather than following the link to its target.

Validation completed with Eclipse Temurin JDK 25:

```text
mvn -Dtest=FileUtilsCleanSymlinksTest test
mvn
```

The default Maven build passed with 6,616 tests run, 0 failures, and 0 errors. Checkstyle, SpotBugs, PMD, license, coverage, and Javadoc checks also passed.

## AI tooling disclosure

OpenAI Codex was used to help analyze the candidate issue, refine the regression-test assertion, investigate the CI failure, and draft the pull request explanation. The resulting code and test behavior were manually reviewed and validated with the commands listed above.