### PR TITLE
[IO-780] Do not discard CharsetEncoder errors in ReaderInputStream

### DIFF
--- a/src/main/java/org/apache/commons/io/input/ReaderInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/ReaderInputStream.java
@@ -389,11 +389,15 @@ public class ReaderInputStream extends AbstractInputStream {
         }
         encoderOut.compact();
         lastCoderResult = charsetEncoder.encode(encoderIn, encoderOut, endOfInput);
-        if (endOfInput) {
-            lastCoderResult = charsetEncoder.flush(encoderOut);
-        }
+        // IO-780: Check encode() errors before flush() overwrites lastCoderResult.
         if (lastCoderResult.isError()) {
             lastCoderResult.throwException();
+        }
+        if (endOfInput) {
+            lastCoderResult = charsetEncoder.flush(encoderOut);
+            if (lastCoderResult.isError()) {
+                lastCoderResult.throwException();
+            }
         }
         encoderOut.flip();
     }

--- a/src/test/java/org/apache/commons/io/input/ReaderInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/ReaderInputStreamTest.java
@@ -149,21 +149,26 @@ class ReaderInputStreamTest {
         }
     }
 
+    /**
+     * Tests IO-780: a trailing unpaired surrogate is malformed input. {@code encode()} reports the
+     * error; {@code flush()} must not overwrite that result, otherwise {@code read()} returns EOF
+     * instead of throwing.
+     */
     @Test
     @Timeout(value = 500, unit = TimeUnit.MILLISECONDS)
     void testCodingError() throws IOException {
-        // Encoder which throws on malformed or unmappable input
+        // Encoder which throws on malformed or unmappable input (default CodingErrorAction.REPORT)
         CharsetEncoder encoder = StandardCharsets.UTF_8.newEncoder();
         try (ReaderInputStream in = new ReaderInputStream(new StringReader("\uD800"), encoder)) {
-            // Does not throws an exception because the input is an underflow and not an error
-            assertDoesNotThrow(() -> in.read());
-            // assertThrows(IllegalStateException.class, () -> in.read());
+            assertThrows(CharacterCodingException.class, in::read);
         }
         encoder = StandardCharsets.UTF_8.newEncoder();
         try (ReaderInputStream in = ReaderInputStream.builder().setReader(new StringReader("\uD800")).setCharsetEncoder(encoder).get()) {
-            // TODO WIP
-            assertDoesNotThrow(() -> in.read());
-            // assertThrows(IllegalStateException.class, () -> in.read());
+            assertThrows(CharacterCodingException.class, in::read);
+        }
+        encoder = StandardCharsets.UTF_8.newEncoder();
+        try (ReaderInputStream in = new ReaderInputStream(new StringReader("\uD800"), encoder)) {
+            assertThrows(CharacterCodingException.class, () -> in.read(new byte[8]));
         }
     }
 

--- a/src/test/java/org/apache/commons/io/input/ReaderInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/ReaderInputStreamTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.commons.io.input;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;


### PR DESCRIPTION
Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Assisted with drafting the patch and PR text; change and tests authored and verified locally as Md Tanvir Alam.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.

Fixes [IO-780](https://issues.apache.org/jira/browse/IO-780).

`ReaderInputStream.fillBuffer()` called `CharsetEncoder.flush()` whenever the reader had reached EOF, overwriting `lastCoderResult` from `encode()`. When `encode()` reported malformed input (for example a trailing unpaired surrogate with the default `CodingErrorAction.REPORT`), the error was discarded and `read()` returned `-1` instead of throwing.

This checks `lastCoderResult.isError()` after `encode()` and after `flush()`.

The existing `testCodingError()` WIP now asserts `CharacterCodingException` for both `read()` and `read(byte[])`, matching the JIRA reproducer.