### PR TITLE
Fix MemoryMappedFileInputStream.read() returning sign-extended values for bytes over 0x7F

### DIFF
--- a/src/main/java/org/apache/commons/io/input/MemoryMappedFileInputStream.java
+++ b/src/main/java/org/apache/commons/io/input/MemoryMappedFileInputStream.java
@@ -234,7 +234,7 @@ public final class MemoryMappedFileInputStream extends AbstractInputStream {
                 return EOF;
             }
         }
-        return Short.toUnsignedInt(buffer.get());
+        return buffer.get() & 0xFF;
     }
 
     @Override

--- a/src/test/java/org/apache/commons/io/input/MemoryMappedFileInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/MemoryMappedFileInputStreamTest.java
@@ -212,6 +212,18 @@ class MemoryMappedFileInputStreamTest {
     }
 
     @Test
+    void testReadSingleByteIsUnsigned() throws IOException {
+        final byte[] expectedData = { 0x00, 0x01, 0x7F, (byte) 0x80, (byte) 0xAB, (byte) 0xFE, (byte) 0xFF };
+        final Path file = Files.write(Files.createTempFile(tempDir, null, null), expectedData);
+        try (InputStream inputStream = newInputStream(file, 4)) {
+            for (final byte expected : expectedData) {
+                assertEquals(expected & 0xFF, inputStream.read());
+            }
+            assertEquals(IOUtils.EOF, inputStream.read());
+        }
+    }
+
+    @Test
     void testReadSingleByte() throws IOException {
         // setup
         final Path file = createTestFile(2);


### PR DESCRIPTION
`MemoryMappedFileInputStream.read()` returned `Short.toUnsignedInt(buffer.get())`, which widens the byte to a short with sign extension before masking, so every byte from 0x80 to 0xFF came back as 0xFF80 to 0xFFFF instead of 128 to 255. `InputStream.read()` promises 0 to 255, and a caller copying byte by byte writes the wrong values out. The existing `testReadSingleByte` casts each result back to `byte` before comparing, which hides the difference.

The change masks with `& 0xFF`, as the other single-byte `read()` implementations in this package do.

Test: `testReadSingleByteIsUnsigned`, red on master and green with the change. Default Maven goal green.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude (Anthropic) found the defect and drafted the fix and test; I reviewed them, reproduced the failure on a fresh clone of master, and ran the default Maven goal.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
