### PR TITLE
Fix CircularByteBuffer.peek() matching bytes past the buffered data

### DIFF
--- a/src/main/java/org/apache/commons/io/input/buffer/CircularByteBuffer.java
+++ b/src/main/java/org/apache/commons/io/input/buffer/CircularByteBuffer.java
@@ -190,7 +190,7 @@ public class CircularByteBuffer {
         if (length < 0 || length > buffer.length) {
             throw new IllegalArgumentException("Illegal length: " + length);
         }
-        if (length < currentNumberOfBytes) {
+        if (length != currentNumberOfBytes) {
             return false;
         }
         int localOffset = startOffset;

--- a/src/test/java/org/apache/commons/io/input/buffer/CircularByteBufferTest.java
+++ b/src/test/java/org/apache/commons/io/input/buffer/CircularByteBufferTest.java
@@ -162,4 +162,13 @@ class CircularByteBufferTest {
         // targetOffset >= targetBuffer.length
         assertThrows(IllegalArgumentException.class, () -> cbb.read(bytesOut, 0, bytesOut.length + 1));
     }
+
+    @Test
+    void testPeekLongerThanBuffered() {
+        final CircularByteBuffer cbb = new CircularByteBuffer(8);
+        cbb.add(new byte[] { 1, 2, 3, 4, 5, 6 }, 0, 6);
+        cbb.read(new byte[4], 0, 4);
+        assertTrue(cbb.peek(new byte[] { 5, 6 }, 0, 2));
+        assertFalse(cbb.peek(new byte[] { 5, 6, 0, 0 }, 0, 4));
+    }
 }

--- a/src/test/java/org/apache/commons/io/input/buffer/PeekableInputStreamTest.java
+++ b/src/test/java/org/apache/commons/io/input/buffer/PeekableInputStreamTest.java
@@ -93,6 +93,13 @@ class PeekableInputStreamTest {
     }
 
     @Test
+    void testPeekLongerThanInputDoesNotMatch() throws IOException {
+        try (PeekableInputStream inputStream = new PeekableInputStream(new ByteArrayInputStream(new byte[] { 1, 2 }))) {
+            assertFalse(inputStream.peek(new byte[] { 1, 2, 0, 0 }));
+        }
+    }
+
+    @Test
     void testRandomRead() throws Exception {
         final byte[] inputBuffer = newInputBuffer();
         final byte[] bufferCopy = new byte[inputBuffer.length];


### PR DESCRIPTION
`CircularByteBuffer.peek()` returned false early only when `length` was smaller than the number of buffered bytes. A larger `length` fell through to the comparison loop, which read past the valid bytes into whatever the backing array held there, so a fresh buffer holding `{1, 2}` reported an exact match for `{1, 2, 0, 0}`. Through `PeekableInputStream.peek()` a two-byte stream matched a four-byte pattern, and a scanner branching on that result took the branch for content the stream does not contain.

The guard now returns false unless `length` equals the buffered count, the exact-match rule IO-855 documented.

Tests: `testPeekLongerThanBuffered` and `testPeekLongerThanInputDoesNotMatch`, red on master and green with the change. Default Maven goal green.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude (Anthropic) found the defect and drafted the fix and tests; I reviewed them, reproduced the failure on a fresh clone of master, and ran the default Maven goal.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
