### PR TITLE
Fix FileWriterWithEncoding.Builder ignoring any Charset but the default

### DIFF
--- a/src/main/java/org/apache/commons/io/output/FileWriterWithEncoding.java
+++ b/src/main/java/org/apache/commons/io/output/FileWriterWithEncoding.java
@@ -73,7 +73,7 @@ public class FileWriterWithEncoding extends ProxyWriter {
      * FileWriterWithEncoding w = FileWriterWithEncoding.builder()
      *   .setPath(path)
      *   .setAppend(false)
-     *   .setCharsetEncoder(StandardCharsets.UTF_8)
+     *   .setCharset(StandardCharsets.UTF_8)
      *   .get();}
      * </pre>
      *
@@ -125,9 +125,6 @@ public class FileWriterWithEncoding extends ProxyWriter {
         }
 
         private Object getEncoder() {
-            if (charsetEncoder != null && getCharset() != null && !charsetEncoder.charset().equals(getCharset())) {
-                throw new IllegalStateException(String.format("Mismatched Charset(%s) and CharsetEncoder(%s)", getCharset(), charsetEncoder.charset()));
-            }
             return charsetEncoder != null ? charsetEncoder : getCharset();
         }
 
@@ -142,6 +139,13 @@ public class FileWriterWithEncoding extends ProxyWriter {
             return this;
         }
 
+        @Override
+        public Builder setCharset(final Charset charset) {
+            super.setCharset(charset);
+            charsetEncoder = getCharset().newEncoder();
+            return this;
+        }
+
         /**
          * Sets charsetEncoder to use for encoding.
          *
@@ -150,6 +154,9 @@ public class FileWriterWithEncoding extends ProxyWriter {
          */
         public Builder setCharsetEncoder(final CharsetEncoder charsetEncoder) {
             this.charsetEncoder = charsetEncoder;
+            if (charsetEncoder != null) {
+                super.setCharset(charsetEncoder.charset());
+            }
             return this;
         }
 

--- a/src/test/java/org/apache/commons/io/output/FileWriterWithEncodingTest.java
+++ b/src/test/java/org/apache/commons/io/output/FileWriterWithEncodingTest.java
@@ -17,6 +17,7 @@
 package org.apache.commons.io.output;
 
 import static org.apache.commons.io.test.TestUtils.checkFile;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -32,6 +33,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Arrays;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -41,6 +43,8 @@ import org.junit.jupiter.api.io.TempDir;
  * Tests {@link FileWriterWithEncoding}.
  */
 class FileWriterWithEncodingTest {
+
+    private static final String NON_ASCII = "caf\u00e9";
 
     @TempDir
     public File temporaryFolder;
@@ -201,6 +205,26 @@ class FileWriterWithEncodingTest {
             }
             assertTrue(file1.exists());
             assertTrue(file2.exists());
+        }
+    }
+
+    @Test
+    void testBuilder_nonDefaultCharset() throws Exception {
+        for (final Charset charset : Arrays.asList(StandardCharsets.UTF_16, StandardCharsets.ISO_8859_1)) {
+            try (Writer writer = FileWriterWithEncoding.builder().setFile(file2).setCharset(charset).get()) {
+                writer.write(NON_ASCII);
+            }
+            assertArrayEquals(NON_ASCII.getBytes(charset), Files.readAllBytes(file2.toPath()));
+        }
+    }
+
+    @Test
+    void testBuilder_nonDefaultCharsetEncoder() throws Exception {
+        for (final Charset charset : Arrays.asList(StandardCharsets.UTF_16, StandardCharsets.ISO_8859_1)) {
+            try (Writer writer = FileWriterWithEncoding.builder().setFile(file2).setCharsetEncoder(charset.newEncoder()).get()) {
+                writer.write(NON_ASCII);
+            }
+            assertArrayEquals(NON_ASCII.getBytes(charset), Files.readAllBytes(file2.toPath()));
         }
     }
 


### PR DESCRIPTION
`FileWriterWithEncoding.Builder` seeds its encoder from the default Charset, and `getEncoder()` throws `IllegalStateException` when Charset and encoder disagree. So `setCharset(UTF_16)` throws at `get()`, and `setCharsetEncoder(UTF_16.newEncoder())` throws too, because the other half is still the default: the builder could not write any encoding but the platform default. The class Javadoc's Charset example also passes a `Charset` to `setCharsetEncoder`, which does not compile.

The builder now keeps the pair consistent as `ReaderInputStream.Builder` does: `setCharset` refreshes the encoder, `setCharsetEncoder` sets the Charset, and the mismatch guard, with nothing left to catch, is removed. The example calls `setCharset`.

Tests: `testBuilder_nonDefaultCharset` and `testBuilder_nonDefaultCharsetEncoder`, red on master and green with the change. Default Maven goal green.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude (Anthropic) found the defect and drafted the fix and tests; I reviewed them, reproduced the failure on a fresh clone of master, and ran the default Maven goal.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
