### PR TITLE
Fix Tailer rotation retry after replacement open failure

### DIFF
--- a/src/main/java/org/apache/commons/io/input/Tailer.java
+++ b/src/main/java/org/apache/commons/io/input/Tailer.java
@@ -988,6 +988,7 @@ public class Tailer implements Runnable, AutoCloseable {
         try {
             FileTime last = FileTimes.EPOCH; // The last time the file was checked for changes
             long position = 0; // position within the file
+            boolean rotationPending = false;
             // Open the file
             while (getRun() && reader == null) {
                 try {
@@ -1008,21 +1009,28 @@ public class Tailer implements Runnable, AutoCloseable {
                 final boolean newer = tailable.isNewer(last); // IO-279, must be done first
                 // Check the file length to see if it was rotated
                 final long length = tailable.size();
-                if (length < position) {
+                if (rotationPending || length < position) {
                     // File was rotated
-                    listener.fileRotated();
+                    if (!rotationPending) {
+                        listener.fileRotated();
+                        rotationPending = true;
+                    }
                     // Reopen the reader after rotation ensuring that the old file is closed iff we re-open it
                     // successfully
-                    try (RandomAccessResourceBridge save = reader) {
-                        reader = tailable.getRandomAccess(RAF_READ_ONLY_MODE);
-                        // At this point, we're sure that the old file is rotated
-                        // Finish scanning the old file and then we'll start with the new one
-                        try {
-                            readLines(save);
-                        } catch (final IOException ioe) {
-                            listener.handle(ioe);
+                    try {
+                        final RandomAccessResourceBridge replacement = tailable.getRandomAccess(RAF_READ_ONLY_MODE);
+                        try (RandomAccessResourceBridge save = reader) {
+                            reader = replacement;
+                            // At this point, we're sure that the old file is rotated
+                            // Finish scanning the old file and then we'll start with the new one
+                            try {
+                                readLines(save);
+                            } catch (final IOException ioe) {
+                                listener.handle(ioe);
+                            }
+                            position = 0;
+                            rotationPending = false;
                         }
-                        position = 0;
                     } catch (final FileNotFoundException e) {
                         // in this case we continue to use the previous reader and position values
                         listener.fileNotFound();

--- a/src/test/java/org/apache/commons/io/input/TailerRotationTest.java
+++ b/src/test/java/org/apache/commons/io/input/TailerRotationTest.java
@@ -1,0 +1,237 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.io.input;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Regression coverage for temporarily missing replacement files during rotation.
+ */
+class TailerRotationTest {
+
+    private static final class Bridge implements Tailer.RandomAccessResourceBridge {
+
+        private int closeCalls;
+        private boolean closed;
+        private final byte[] content;
+        private long pointer;
+
+        Bridge(final String content) {
+            this.content = content.getBytes(StandardCharsets.UTF_8);
+        }
+
+        @Override
+        public void close() {
+            closed = true;
+            closeCalls++;
+        }
+
+        @Override
+        public long getPointer() {
+            return pointer;
+        }
+
+        @Override
+        public int read(final byte[] buffer) throws IOException {
+            if (closed) {
+                throw new IOException("read attempted on closed bridge");
+            }
+            if (pointer >= content.length) {
+                return -1;
+            }
+            final int count = (int) Math.min(buffer.length, content.length - pointer);
+            System.arraycopy(content, (int) pointer, buffer, 0, count);
+            pointer += count;
+            return count;
+        }
+
+        @Override
+        public void seek(final long position) throws IOException {
+            if (position < 0 || position > content.length) {
+                throw new IOException("invalid bridge position " + position);
+            }
+            pointer = position;
+        }
+    }
+
+    /**
+     * Simulates one rotation: the path is absent for one open attempt, then the
+     * replacement stays larger than the position read from the old inode.
+     */
+    private static final class SingleRotationTailable implements Tailer.Tailable {
+
+        private final int failedOpens;
+        private final Bridge newBridge = new Bridge("new\nmore\n");
+        private final Bridge oldBridge = new Bridge("old\nlate\n");
+        private final AtomicInteger openCalls = new AtomicInteger();
+        private final AtomicInteger sizeCalls = new AtomicInteger();
+
+        SingleRotationTailable(final int failedOpens) {
+            this.failedOpens = failedOpens;
+        }
+
+        @Override
+        public Tailer.RandomAccessResourceBridge getRandomAccess(final String mode) throws FileNotFoundException {
+            final int attempt = openCalls.incrementAndGet();
+            if (attempt == 1) {
+                return oldBridge;
+            }
+            if (attempt <= failedOpens + 1) {
+                throw new FileNotFoundException("replacement temporarily absent");
+            }
+            if (attempt == failedOpens + 2) {
+                return newBridge;
+            }
+            throw new AssertionError("open budget exceeded");
+        }
+
+        @Override
+        public boolean isNewer(final FileTime previous) {
+            return false;
+        }
+
+        @Override
+        public FileTime lastModifiedFileTime() {
+            return FileTime.fromMillis(0);
+        }
+
+        @Override
+        public long size() {
+            final int call = sizeCalls.incrementAndGet();
+            if (call == 1) {
+                return 4; // "old\n" was already consumed through the old reader.
+            }
+            if (call == 2) {
+                return 0; // Detect one rotation before the replacement grows.
+            }
+            if (call > 30) {
+                throw new AssertionError("loop budget exceeded");
+            }
+            return 9; // replacement is present and never shrinks again.
+        }
+    }
+
+    @Test
+    void closesOldReaderWhenStoppedDuringRotationRetry() {
+        final SingleRotationTailable tailable = new SingleRotationTailable(1);
+        final AtomicReference<Exception> listenerException = new AtomicReference<>();
+        final AtomicReference<Tailer> tailerReference = new AtomicReference<>();
+        final Tailer tailer = Tailer.builder()
+                .setStartThread(false)
+                .setTailFromEnd(true)
+                .setDelayDuration(Duration.ofMillis(1))
+                .setTailable(tailable)
+                .setTailerListener(new TailerListenerAdapter() {
+                    @Override
+                    public void fileNotFound() {
+                        assertFalse(tailable.oldBridge.closed);
+                        tailerReference.get().close();
+                    }
+
+                    @Override
+                    public void handle(final Exception exception) {
+                        listenerException.compareAndSet(null, exception);
+                    }
+
+                })
+                .get();
+        tailerReference.set(tailer);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), tailer::run);
+
+        assertEquals(2, tailable.openCalls.get());
+        assertNull(listenerException.get());
+        assertTrue(tailable.oldBridge.closed);
+        assertFalse(tailable.newBridge.closed);
+        assertEquals(1, tailable.oldBridge.closeCalls);
+        assertEquals(0, tailable.newBridge.closeCalls);
+        assertFalse(tailer.getRun());
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {0, 1, 2})
+    void resumesRotationWithoutAnotherPathShrink(final int failedOpens) {
+        final SingleRotationTailable tailable = new SingleRotationTailable(failedOpens);
+        final List<String> lines = new ArrayList<>();
+        final AtomicInteger missingFiles = new AtomicInteger();
+        final AtomicInteger rotations = new AtomicInteger();
+        final AtomicReference<Exception> listenerException = new AtomicReference<>();
+        final AtomicReference<Tailer> tailerReference = new AtomicReference<>();
+        final Tailer tailer = Tailer.builder()
+                .setStartThread(false)
+                .setTailFromEnd(true)
+                .setDelayDuration(Duration.ofMillis(1))
+                .setTailable(tailable)
+                .setTailerListener(new TailerListenerAdapter() {
+                    @Override
+                    public void fileNotFound() {
+                        missingFiles.incrementAndGet();
+                    }
+
+                    @Override
+                    public void fileRotated() {
+                        rotations.incrementAndGet();
+                    }
+
+                    @Override
+                    public void handle(final Exception exception) {
+                        listenerException.compareAndSet(null, exception);
+                    }
+
+                    @Override
+                    public void handle(final String line) {
+                        lines.add(line);
+                        if ("more".equals(line)) {
+                            tailerReference.get().close();
+                        }
+                    }
+                })
+                .get();
+        tailerReference.set(tailer);
+
+        assertTimeoutPreemptively(Duration.ofSeconds(2), tailer::run);
+
+        assertEquals(Arrays.asList("late", "new", "more"), lines);
+        assertEquals(failedOpens, missingFiles.get());
+        assertEquals(1, rotations.get());
+        assertEquals(failedOpens + 2, tailable.openCalls.get());
+        assertNull(listenerException.get());
+        assertTrue(tailable.oldBridge.closed);
+        assertTrue(tailable.newBridge.closed);
+        assertEquals(1, tailable.oldBridge.closeCalls);
+        assertEquals(1, tailable.newBridge.closeCalls);
+        assertFalse(tailer.getRun());
+    }
+}


### PR DESCRIPTION
Follows up on [the reported failed reopen during rotation](https://www.mail-archive.com/dev@commons.apache.org/msg78091.html).

If opening the replacement throws `FileNotFoundException`, the existing try-with-resources closes the old reader. Subsequent reads may then terminate the tailer. Keeping that reader open alone is insufficient when the replacement grows past the previous position before the next poll.

This patch opens the replacement before closing the old reader and retains `rotationPending` until reopening succeeds. Remaining old-file lines are read after the replacement opens. It does not fix the separate periodic `reOpen` failure path described in IO-399.

Validation on base `f720b24227eb6972d4281d330ddb64c1416f81a4`:

- Four deterministic rotation cases cover zero, one, and two failed opens, plus stopping during retry. Three fail on the unmodified base; all four pass with the patch.
- Targeted Tailer run: 32 tests, zero failures/errors, one existing Windows skip.
- Checkstyle, PMD, and SpotBugs checks pass.
- The full default build did not complete successfully on Windows. Three `PathUtilsCopyTest` symlink privilege errors reproduce on the unmodified base. This is not a claim that the full test suite passes.

Submitted following [the maintainer's suggestion to provide a PR with a failing test](https://www.mail-archive.com/dev@commons.apache.org/msg78092.html). A Jira association can be added as needed.
